### PR TITLE
Add "my profile" navbar dropdown

### DIFF
--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -18,7 +18,7 @@
     {% block css %}
     <!-- Third-party CSS libraries go here -->
     <link href="{% static 'css/mdb.min.css' %}" rel="stylesheet">
-
+    <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
     <!-- This file stores project-specific CSS -->
     <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock %}
@@ -35,36 +35,41 @@
         <a class="navbar-brand" href="{% url 'home' %}">WeBook</a>
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class="navbar-nav mr-auto">
+          <ul class="navbar-nav me-auto">
             <li class="nav-item active">
               <a class="nav-link" href="{% url 'home' %}">Home <span class="sr-only">(current)</span></a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{% url 'about' %}">About</a>
             </li>
-            {% if request.user.is_authenticated %}
-              <li class="nav-item">
-                {# URL provided by django-allauth/account/urls.py #}
-                <a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a>
-              </li>
-              <li class="nav-item">
-                {# URL provided by django-allauth/account/urls.py #}
-                <a class="nav-link" href="{% url 'account_logout' %}">{% trans "Sign Out" %}</a>
-              </li>
-            {% else %}
-              <li class="nav-item">
-                {# URL provided by django-allauth/account/urls.py #}
-                <a id="sign-up-link" class="nav-link" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a>
-              </li>
-              <li class="nav-item">
-                {# URL provided by django-allauth/account/urls.py #}
-                <a id="log-in-link" class="nav-link" href="{% url 'account_login' %}">{% trans "Sign In" %}</a>
-              </li>
-            {% endif %}
+          </ul>
+
+
+        {% if request.user.is_authenticated %}
+        <div class="btn-group shadow-0">
+          <button
+            type="button"
+            class="btn btn-link dropdown-toggle"
+            data-mdb-toggle="dropdown"
+            aria-expanded="false"
+          >
+            {% trans "Hi" %}, {{ request.user.username }}
+          </button>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="{% url 'users:detail' request.user.username  %}"><i class="la la-user"></i>&nbsp; {% trans "My Profile" %}</a></li>
+            <li>
+              <hr class="dropdown-divider" />
+            </li>
+            <li><a class="dropdown-item" href="{% url 'account_logout' %}"><i class="la la-times-circle"></i>&nbsp; {% trans "Sign Out" %}</a></li>
           </ul>
         </div>
-      </nav>
+        {% else %}
+          <a id="log-in-link" class="btn btn-success" href="{% url 'account_login' %}"><i class="la la-lock-open"></i> {% trans "Sign In" %}</a>
+          <a id="sign-up-link" class="btn btn-info ms-2" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a>
+        {% endif %}
 
+        </div>
+      </nav>
     </div>
 
     <div class="container">


### PR DESCRIPTION
**In short**
This PR adds a "My Profile" kind of dropdown. There are two options in this dropdown; "My Profile", and "Sign Out". If you are not signed in this dropdown will not appear, and you will instead be presented with two buttons; "Sign in" and "Sign up". 
It is not as aesthetically pleasing as it could be - but that will come later. We're just getting the lay of the land at this point. 

**When you are not signed in:**
![image](https://user-images.githubusercontent.com/62013916/138444227-47b615b5-e9a0-4977-9ff9-9d3da21a93e2.png)

**When you are signed in:**
![image](https://user-images.githubusercontent.com/62013916/138444342-384148e8-fd19-477e-9568-db3428c47296.png)
![image](https://user-images.githubusercontent.com/62013916/138444357-dc03989c-45ed-4b1f-abfc-47b1b411d37c.png)

I have also removed the old links in the navbar that served the same practical purpose.

_I have also added LineAwesome_

Closes #15 