### PR TITLE
Fix bug affecting positioning of "close" buttons in alerts (amongst others, I would imagine)

### DIFF
--- a/webook/static/css/project.css
+++ b/webook/static/css/project.css
@@ -23,3 +23,11 @@ div.modal-body > .bootbox-close-button {
   width: 100%;
   text-align: right;
 }
+
+/*
+  Needed to resolve the same issue as above (div.modal-body > .bootbox-close-button).
+  This ensures that in alerts with 'X' close buttons, that they will be positioned correctly to the right.
+ */
+.close {
+  float:right;
+}


### PR DESCRIPTION
**In short**
This PR introduces a fix for the issue raised in #17, concerning the placement of "close" buttons in alerts. 
This is achieved by floating all elements with the `close` class to the right. 

Closes #17 