### PR TITLE
Install fullcalendar

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -301,3 +301,8 @@ APP_TITLE = env(
     "APP_TITLE",
     default="WeBook"
 )
+
+FULLCALENDAR_LICENSE_KEY = env(
+    "FULLCALENDAR_LICENSE_KEY",
+    default=""
+)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -166,6 +166,7 @@ STATICFILES_DIRS = [str(APPS_DIR / "static")]
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    "npm.finders.NpmFinder",
 ]
 
 # MEDIA

--- a/env.sample.mac_or_linux
+++ b/env.sample.mac_or_linux
@@ -5,3 +5,7 @@ DATABASE_URL=postgres://myuser:mypasswd@localhost:5432/everycheese
 #APP_TITLE=WeBook
 # --> Logo of the application
 #APP_LOGO=/static/images/wemade_logo.jpg
+
+### Licenses
+# --> License key to FullCalendar.
+# FULLCALENDAR_LICENSE_KEY=YourLicenseKey

--- a/env.sample.windows
+++ b/env.sample.windows
@@ -6,3 +6,7 @@ DATABASE_URL=sqlite:///everycheese.db
 #APP_TITLE=WeBook
 # --> Logo of the application
 #APP_LOGO=/static/images/wemade_logo.jpg
+
+### Licenses
+# --> License key to FullCalendar.
+# FULLCALENDAR_LICENSE_KEY=YourLicenseKey

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "webook",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fullcalendar": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-5.10.1.tgz",
+      "integrity": "sha512-0jgDxiWRuC36MzAUK3+Equmu4R0+vAPEtttsXLX9GNNDUHEZ5HjcH+dUtWut4vlJtxGJgVZ+eZ76/7qhcu+RMA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "webook",
+  "version": "1.0.0",
+  "description": "Booking and planning arrangements",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wemadefree/WeBook.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/wemadefree/WeBook/issues"
+  },
+  "homepage": "https://github.com/wemadefree/WeBook#readme",
+  "dependencies": {
+    "fullcalendar": "^5.10.1"
+  }
+}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,3 +13,4 @@ django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
 django-allauth==0.42.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.9.2  # https://github.com/django-crispy-forms/django-crispy-forms
 django-autoslug==1.9.8  # https://github.com/justinmayer/django-autoslug/
+django-npm

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -19,6 +19,7 @@
     <!-- Third-party CSS libraries go here -->
     <link href="{% static 'css/mdb.min.css' %}" rel="stylesheet">
     <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
+    <link rel="stylesheet" href="{% static 'css/fullcalendar/main.min.css' %}">
     <!-- This file stores project-specific CSS -->
     <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock %}
@@ -101,6 +102,8 @@
       <script src="{% static 'js/bootbox.min.js' %}"></script>
       <script src="{% static 'js/bootbox.locales.min.js' %}"></script>
 
+      <script src="{% static 'js/fullcalendar/main.min.js' %}"></script>
+      <script src="{% static 'js/fullcalendar/locales-all.min.js' %}"></script>
       <!-- place project specific Javascript in this file -->
       <script src="{% static 'js/project.js' %}"></script>
     {% endblock javascript %}

--- a/webook/utils/context_processors.py
+++ b/webook/utils/context_processors.py
@@ -3,4 +3,5 @@ from django.conf import settings
 
 def settings_context(_request):
     # Put global template variables here.
-    return {"DEBUG": settings.DEBUG, "APP_TITLE": settings.APP_TITLE, "APP_LOGO": settings.APP_LOGO }  # explicit
+    return {"DEBUG": settings.DEBUG, "APP_TITLE": settings.APP_TITLE, "APP_LOGO": settings.APP_LOGO,
+            "FULLCALENDAR_LICENSE_KEY": settings.FULLCALENDAR_LICENSE_KEY }  # explicit


### PR DESCRIPTION
**Summary**
This PR installs FullCalendar.
As one might see this is my second go at doing this. Instead of adding the files manually (which FullCalendar discouraged), I have installed django-npm to handle these packages for us (as was encouraged). With the npm static files finder this works like an absolute charm, and I do believe this is an approach we should commit to - and it is especially relevant for issue #28 

To be more concrete I have set up basic config structure around the license key for FullCalendar. You add the license key to your .env, and you're ready to rock and roll. You also need to do npm install, and collectstatic to get the fullcalendar assets.