### PR TITLE
Add "Asset Server" to the config, and reroute MDB imports through this

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -301,3 +301,8 @@ APP_TITLE = env(
     "APP_TITLE",
     default="WeBook"
 )
+
+ASSET_SERVER_URL = env(
+    "APP_TITLE",
+    default="localhost/static"
+)

--- a/env.sample.mac_or_linux
+++ b/env.sample.mac_or_linux
@@ -5,3 +5,6 @@ DATABASE_URL=postgres://myuser:mypasswd@localhost:5432/everycheese
 #APP_TITLE=WeBook
 # --> Logo of the application
 #APP_LOGO=/static/images/wemade_logo.jpg
+# --> Asset server URL
+# NOTE: This is temporary until we can get a NPM proxy working, and will be deprecated thusly.
+#ASSET_SERVER_URL=localhost

--- a/env.sample.windows
+++ b/env.sample.windows
@@ -6,3 +6,6 @@ DATABASE_URL=sqlite:///everycheese.db
 #APP_TITLE=WeBook
 # --> Logo of the application
 #APP_LOGO=/static/images/wemade_logo.jpg
+# --> Asset server URL
+# NOTE: This is temporary until we can get a NPM proxy working, and will be deprecated thusly.
+#ASSET_SERVER_URL=localhost

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -17,7 +17,8 @@
 
     {% block css %}
     <!-- Third-party CSS libraries go here -->
-    <link href="{% static 'css/mdb.min.css' %}" rel="stylesheet">
+    <!-- <link href="{% static 'css/mdb.min.css' %}" rel="stylesheet"> -->
+    <link href="{{ ASSET_SERVER_URL }}mdb/css/mdb.min.css"
     <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
     <!-- This file stores project-specific CSS -->
     <link href="{% static 'css/project.css' %}" rel="stylesheet">
@@ -97,7 +98,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 
       <!-- Your stuff: Third-party javascript libraries go here -->
-      <script src="{% static 'js/mdb.min.js' %}"></script>
+      <!-- <script src="{% static 'js/mdb.min.js' %}"></script> -->
+
+      <script src="{{ ASSET_SERVER_URL }}mdb/js/mdb.min.js"></script>
+
       <script src="{% static 'js/bootbox.min.js' %}"></script>
       <script src="{% static 'js/bootbox.locales.min.js' %}"></script>
 

--- a/webook/utils/context_processors.py
+++ b/webook/utils/context_processors.py
@@ -3,4 +3,4 @@ from django.conf import settings
 
 def settings_context(_request):
     # Put global template variables here.
-    return {"DEBUG": settings.DEBUG, "APP_TITLE": settings.APP_TITLE, "APP_LOGO": settings.APP_LOGO }  # explicit
+    return {"DEBUG": settings.DEBUG, "APP_TITLE": settings.APP_TITLE, "APP_LOGO": settings.APP_LOGO, "ASSET_SERVER_URL": settings.ASSET_SERVER_URL }  # explicit


### PR DESCRIPTION
** Summary **
This PR introduces a new "Asset Server" setting, and redone MDB imports on base.html. This is a temporary workaround until we can get MDB into a NPM Proxy internally. As for now it simply gets these assets from another web server, avoiding placing the assets in the repository.
