### PR TITLE
Write tests for arrangements models

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -275,7 +275,7 @@ class ConfirmationReceipt (TimeStampedModel):
 
     def __str__(self):
         """Return description of receipt"""
-        return f"{self.requested_by.get_name()} petitioned {self.sent_to} for a confirmation at STAMP."
+        return f"{self.requested_by} petitioned {self.sent_to} for a confirmation at STAMP."
 
 
 class Person(TimeStampedModel):

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -112,3 +112,20 @@ def test_confirmation_receipt__str__():
 
     assert confirmation_receipt.__str__() == "John Smith petitioned test@test.com for a confirmation at STAMP."
     assert str(confirmation_receipt) == "John Smith petitioned test@test.com for a confirmation at STAMP."
+
+
+def test_person__str__():
+    person = Person()
+    person.first_name = "John"
+    person.last_name = "Smith"
+
+    person_with_middle_name = Person()
+    person_with_middle_name.first_name = "John"
+    person_with_middle_name.middle_name = "Test"
+    person_with_middle_name.last_name = "Smith"
+
+    assert person.__str__() == "John Smith"
+    assert str(person) == "John Smith"
+
+    assert person_with_middle_name.__str__() == "John Test Smith"
+    assert str(person_with_middle_name) == "John Test Smith"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -146,7 +146,6 @@ def test_service_provider__str__():
     service_provider = ServiceProvider()
     service_provider.service_name = "Code Testing"
 
-
     service_type = ServiceType()
     service_type.name = "Quality Assurance"
     service_provider.service_type = service_type

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -51,3 +51,10 @@ def test_article__str__():
     article.name = "test"
     assert article.__str__() == "test"
     assert str(article) == "test"
+
+
+def test_organization_type__str__():
+    organization_type = OrganizationType()
+    organization_type.name = "test"
+    assert organization_type.__str__() == "test"
+    assert str(organization_type) == "test"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -109,6 +109,6 @@ def test_confirmation_receipt__str__():
 
     confirmation_receipt.sent_to = "test@test.com"
     confirmation_receipt.requested_by = requested_by
-    print(confirmation_receipt.__str__())
+
     assert confirmation_receipt.__str__() == "John Smith petitioned test@test.com for a confirmation at STAMP."
     assert str(confirmation_receipt) == "John Smith petitioned test@test.com for a confirmation at STAMP."

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -10,6 +10,7 @@ from webook.arrangement.models import (
     Article,
     Audience,
     BusinessHour,
+    Calendar,
     Location,
     OrganizationType,
     Room,
@@ -80,3 +81,10 @@ def test_business_hour__str__():
     business_hour.end_of_business_hours = time(14, 0) 
     assert business_hour.__str__() == "07:00:00 - 14:00:00"
     assert str(business_hour) == "07:00:00 - 14:00:00"
+
+
+def test_calendar__str__():
+    calendar = Calendar()
+    calendar.name = "test"
+    assert calendar.__str__() == "test"
+    assert str(calendar) == "test"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -12,6 +12,7 @@ from webook.arrangement.models import (
     BusinessHour,
     Calendar,
     Location,
+    Note,
     OrganizationType,
     Room,
     ServiceType,
@@ -88,3 +89,10 @@ def test_calendar__str__():
     calendar.name = "test"
     assert calendar.__str__() == "test"
     assert str(calendar) == "test"
+
+
+def test_note__str__():
+    note = Note()
+    note.content = "test"
+    assert note.__str__() == "test"
+    assert str(note) == "test"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -11,12 +11,14 @@ from webook.arrangement.models import (
     Audience,
     BusinessHour,
     Calendar,
+    ConfirmationReceipt,
     Location,
     Note,
     OrganizationType,
     Room,
     ServiceType,
     TimelineEvent,
+    Person
 )
 
 
@@ -96,3 +98,17 @@ def test_note__str__():
     note.content = "test"
     assert note.__str__() == "test"
     assert str(note) == "test"
+
+
+def test_confirmation_receipt__str__():
+    confirmation_receipt = ConfirmationReceipt()
+
+    requested_by = Person()
+    requested_by.first_name = "John"
+    requested_by.last_name = "Smith"
+
+    confirmation_receipt.sent_to = "test@test.com"
+    confirmation_receipt.requested_by = requested_by
+    print(confirmation_receipt.__str__())
+    assert confirmation_receipt.__str__() == "John Smith petitioned test@test.com for a confirmation at STAMP."
+    assert str(confirmation_receipt) == "John Smith petitioned test@test.com for a confirmation at STAMP."

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -65,3 +65,18 @@ def test_timeline_event__str__():
     timeline_event.content = "test"
     assert timeline_event.__str__() == "test"
     assert str(timeline_event) == "test"
+
+
+def test_service_type__str__():
+    service_type = ServiceType()
+    service_type.name = "test"
+    assert service_type.__str__() == "test"
+    assert str(service_type) == "test"
+
+
+def test_business_hour__str__():
+    business_hour = BusinessHour()
+    business_hour.start_of_business_hours = time(7, 0)
+    business_hour.end_of_business_hours = time(14, 0) 
+    assert business_hour.__str__() == "07:00:00 - 14:00:00"
+    assert str(business_hour) == "07:00:00 - 14:00:00"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -12,6 +12,7 @@ from webook.arrangement.models import (
     BusinessHour,
     Calendar,
     ConfirmationReceipt,
+    Event,
     Location,
     Note,
     OrganizationType,
@@ -156,3 +157,14 @@ def test_service_provider__str__():
 
     assert service_provider.__str__() == "Code Testing of type Quality Assurance provided by The Test Corporation"
     assert str(service_provider) == "Code Testing of type Quality Assurance provided by The Test Corporation"
+
+
+def test_event__str__():
+    event = Event()
+
+    event.title = "test"
+    event.start = time(7, 0)
+    event.end = time(14, 0)
+
+    assert event.__str__() == "test (07:00:00 - 14:00:00)"
+    assert str(event) == "test (07:00:00 - 14:00:00)"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -44,3 +44,10 @@ def test_room__str__():
     room.name = "test"
     assert room.__str__() == "test"
     assert str(room) == "test"
+
+
+def test_article__str__():
+    article = Article()
+    article.name = "test"
+    assert article.__str__() == "test"
+    assert str(article) == "test"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -16,6 +16,7 @@ from webook.arrangement.models import (
     Note,
     OrganizationType,
     Room,
+    ServiceProvider,
     ServiceType,
     TimelineEvent,
     Person,
@@ -139,3 +140,20 @@ def test_organization__str__():
 
     assert organization.__str__() == "The Test Corporation"
     assert str(organization) == "The Test Corporation"
+
+
+def test_service_provider__str__():
+    service_provider = ServiceProvider()
+    service_provider.service_name = "Code Testing"
+
+
+    service_type = ServiceType()
+    service_type.name = "Quality Assurance"
+    service_provider.service_type = service_type
+
+    organization = Organization()
+    organization.name = "The Test Corporation"
+    service_provider.organization = organization
+
+    assert service_provider.__str__() == "Code Testing of type Quality Assurance provided by The Test Corporation"
+    assert str(service_provider) == "Code Testing of type Quality Assurance provided by The Test Corporation"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -1,0 +1,73 @@
+import pytest
+
+from datetime import (
+    datetime,
+    time,
+)
+
+from webook.arrangement.models import (
+    Arrangement,
+    Article,
+    Audience,
+    BusinessHour,
+    Location,
+    OrganizationType,
+    Room,
+    ServiceType,
+    TimelineEvent,
+)
+
+def test_audience__str__():
+    audience = Audience()
+    audience.name = "test"
+    assert audience.__str__() == "test"
+    assert str(audience) == "test"
+
+def test_arrangement__str__():
+    arrangement = Arrangement()
+    arrangement.name = "test"
+    assert arrangement.__str__() == "test"
+    assert str(arrangement) == "test"
+
+def test_location__str__():
+    location = Location()
+    location.name = "test"
+    assert location.__str__() == "test"
+    assert str(location) == "test"
+
+def test_room__str__():
+    room = Room()
+    room.name = "test"
+    assert room.__str__() == "test"
+    assert str(room) == "test"
+
+def test_article__str__():
+    article = Article()
+    article.name = "test"
+    assert article.__str__() == "test"
+    assert str(article) == "test"
+
+def test_organization_type__str__():
+    organization_type = OrganizationType()
+    organization_type.name = "test"
+    assert organization_type.__str__() == "test"
+    assert str(organization_type) == "test"
+
+def test_timeline_event__str__():
+    timeline_event = TimelineEvent()
+    timeline_event.content = "test"
+    assert timeline_event.__str__() == "test"
+    assert str(timeline_event) == "test"
+
+def test_service_type__str__():
+    service_type = ServiceType()
+    service_type.name = "test"
+    assert service_type.__str__() == "test"
+    assert str(service_type) == "test"
+
+def test_business_hour__str__():
+    business_hour = BusinessHour()
+    business_hour.start_of_business_hours = time(7, 0)
+    business_hour.end_of_business_hours = time(14, 0) 
+    assert business_hour.__str__() == "07:00 - 14:00"
+    assert str(business_hour) == "07:00 - 14:00"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -18,7 +18,8 @@ from webook.arrangement.models import (
     Room,
     ServiceType,
     TimelineEvent,
-    Person
+    Person,
+    Organization,
 )
 
 
@@ -129,3 +130,12 @@ def test_person__str__():
 
     assert person_with_middle_name.__str__() == "John Test Smith"
     assert str(person_with_middle_name) == "John Test Smith"
+
+
+def test_organization__str__():
+    organization = Organization()
+
+    organization.name = "The Test Corporation"
+
+    assert organization.__str__() == "The Test Corporation"
+    assert str(organization) == "The Test Corporation"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -37,3 +37,10 @@ def test_location__str__():
     location.name = "test"
     assert location.__str__() == "test"
     assert str(location) == "test"
+
+
+def test_room__str__():
+    room = Room()
+    room.name = "test"
+    assert room.__str__() == "test"
+    assert str(room) == "test"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -58,3 +58,10 @@ def test_organization_type__str__():
     organization_type.name = "test"
     assert organization_type.__str__() == "test"
     assert str(organization_type) == "test"
+
+
+def test_timeline_event__str__():
+    timeline_event = TimelineEvent()
+    timeline_event.content = "test"
+    assert timeline_event.__str__() == "test"
+    assert str(timeline_event) == "test"

--- a/webook/arrangement/tests/test_models.py
+++ b/webook/arrangement/tests/test_models.py
@@ -17,11 +17,13 @@ from webook.arrangement.models import (
     TimelineEvent,
 )
 
+
 def test_audience__str__():
     audience = Audience()
     audience.name = "test"
     assert audience.__str__() == "test"
     assert str(audience) == "test"
+
 
 def test_arrangement__str__():
     arrangement = Arrangement()
@@ -29,45 +31,9 @@ def test_arrangement__str__():
     assert arrangement.__str__() == "test"
     assert str(arrangement) == "test"
 
+
 def test_location__str__():
     location = Location()
     location.name = "test"
     assert location.__str__() == "test"
     assert str(location) == "test"
-
-def test_room__str__():
-    room = Room()
-    room.name = "test"
-    assert room.__str__() == "test"
-    assert str(room) == "test"
-
-def test_article__str__():
-    article = Article()
-    article.name = "test"
-    assert article.__str__() == "test"
-    assert str(article) == "test"
-
-def test_organization_type__str__():
-    organization_type = OrganizationType()
-    organization_type.name = "test"
-    assert organization_type.__str__() == "test"
-    assert str(organization_type) == "test"
-
-def test_timeline_event__str__():
-    timeline_event = TimelineEvent()
-    timeline_event.content = "test"
-    assert timeline_event.__str__() == "test"
-    assert str(timeline_event) == "test"
-
-def test_service_type__str__():
-    service_type = ServiceType()
-    service_type.name = "test"
-    assert service_type.__str__() == "test"
-    assert str(service_type) == "test"
-
-def test_business_hour__str__():
-    business_hour = BusinessHour()
-    business_hour.start_of_business_hours = time(7, 0)
-    business_hour.end_of_business_hours = time(14, 0) 
-    assert business_hour.__str__() == "07:00 - 14:00"
-    assert str(business_hour) == "07:00 - 14:00"


### PR DESCRIPTION
**Summary**
This PR introduces tests for the arrangements models. (arrangements/models.py)
All tests are on the string methods, testing both model.__str__() and str(model).
Coverage of models.py will be 100% after this PR is in.