### PR TITLE
Set FC license key setting default to trial key

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -305,7 +305,7 @@ APP_TITLE = env(
 
 FULLCALENDAR_LICENSE_KEY = env(
     "FULLCALENDAR_LICENSE_KEY",
-    default="'CC-Attribution-NonCommercial-NoDerivatives'"
+    default="CC-Attribution-NonCommercial-NoDerivatives"
 )
 
 ASSET_SERVER_URL = env(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -305,7 +305,7 @@ APP_TITLE = env(
 
 FULLCALENDAR_LICENSE_KEY = env(
     "FULLCALENDAR_LICENSE_KEY",
-    default=""
+    default="'CC-Attribution-NonCommercial-NoDerivatives'"
 )
 
 ASSET_SERVER_URL = env(


### PR DESCRIPTION
### FEAT: Set FC license key setting default to trial key

Closes #59 

This PR changes the default value of FULLCALENDAR_LICENSE_KEY setting to be the trial key.

Reviewer should also double check the licensing terms of FullCalendar to make sure this is in order;
https://fullcalendar.io/docs/premium
https://creativecommons.org/licenses/by-nc-nd/4.0/