### PR TITLE
Arrangement calendar

### DIFF
--- a/webook/arrangement/urls/planner_urls.py
+++ b/webook/arrangement/urls/planner_urls.py
@@ -16,6 +16,8 @@ from webook.arrangement.views import (
     plan_loose_service_requisitions_component_view,
     plan_people_requisitions_component_view,
     plan_people_to_requisition_component_view,
+    planner_calendar_view,
+    planner_arrangement_events_view,
 )
 
 
@@ -90,4 +92,14 @@ planner_urls = [
         view=plan_people_to_requisition_component_view,
         name="people_to_requisition_table_component"
     ),
+    path(
+        route="planner/calendar",
+        view=planner_calendar_view,
+        name="planner_calendar",
+    ),
+    path(
+        route="planner/arrangements_as_events",
+        view=planner_arrangement_events_view,
+        name="arrangement_events",
+    )
 ]

--- a/webook/arrangement/urls/planner_urls.py
+++ b/webook/arrangement/urls/planner_urls.py
@@ -18,6 +18,7 @@ from webook.arrangement.views import (
     plan_people_to_requisition_component_view,
     planner_calendar_view,
     planner_arrangement_events_view,
+    get_arrangements_in_period_view
 )
 
 
@@ -101,5 +102,10 @@ planner_urls = [
         route="planner/arrangements_as_events",
         view=planner_arrangement_events_view,
         name="arrangement_events",
+    ),
+    path(
+        route="planner/arrangements_in_period",
+        view=get_arrangements_in_period_view,
+        name="arrangements_in_period"
     )
 ]

--- a/webook/arrangement/views/__init__.py
+++ b/webook/arrangement/views/__init__.py
@@ -113,6 +113,8 @@ from .planner_views import (
     plan_loose_service_requisitions_component_view,
     plan_people_requisitions_component_view,
     plan_people_to_requisition_component_view,
+    planner_calendar_view,
+    planner_arrangement_events_view,
 )
 
 from .note_views import (

--- a/webook/arrangement/views/__init__.py
+++ b/webook/arrangement/views/__init__.py
@@ -115,6 +115,7 @@ from .planner_views import (
     plan_people_to_requisition_component_view,
     planner_calendar_view,
     planner_arrangement_events_view,
+    get_arrangements_in_period_view,
 )
 
 from .note_views import (

--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -367,6 +367,7 @@ class PlannerArrangementEvents (LoginRequiredMixin, ListView):
                 "start": arrangement.starts,
                 "end": arrangement.ends,
                 "id": arrangement.slug,
+                "className": f"slug:{arrangement.slug}",
                 "extendedProps": {
                     "icon": arrangement.audience.icon_class
                 }

--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -376,3 +376,30 @@ class PlannerArrangementEvents (LoginRequiredMixin, ListView):
         return HttpResponse(json.dumps(events, default=json_serial), content_type="application/json")
 
 planner_arrangement_events_view =  PlannerArrangementEvents.as_view()
+
+
+class GetArrangementsInPeriod (LoginRequiredMixin, ListView):
+    """ Get all arrangements happening in a given period """
+
+    def get(self, request, *args, **kwargs):
+        arrangements = Arrangement.objects.all()
+        serializable_arrangements = []
+
+        for arrangement in arrangements:
+            serializable_arrangements.append({
+                "slug": arrangement.slug,
+                "name": arrangement.name,
+                "starts": arrangement.starts,
+                "ends": arrangement.ends,
+                "mainPlannerName": arrangement.responsible.full_name,
+                "audience": arrangement.audience.name,
+                "audience_icon": arrangement.audience.icon_class,
+                "arrangement_type": arrangement.arrangement_type.name,
+            })
+
+        return HttpResponse(
+            json.dumps(serializable_arrangements, default=json_serial),
+            content_type="application/json",
+        )
+
+get_arrangements_in_period_view = GetArrangementsInPeriod.as_view()

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -1,0 +1,19 @@
+
+export class FullCalendarEvent {
+    constructor ({title,
+                 start,
+                 end,
+                 color=""} = {}) 
+    {
+        this.title = title;
+        this.start = start;
+        this.end = end;
+        this.color = color;
+    }
+}
+
+export class FullCalendarResource {
+    constructor () {
+        
+    }
+}

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -3,12 +3,16 @@ export class FullCalendarEvent {
     constructor ({title,
                  start,
                  end,
-                 color=""} = {}) 
+                 color="",
+                 classNames=[],
+                 extendedProps={}} = {}) 
     {
         this.title = title;
         this.start = start;
         this.end = end;
         this.color = color;
+        this.classNames = classNames;
+        this.extendedProps = extendedProps;
     }
 }
 

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -1,37 +1,72 @@
-import { FullCalendarEvent, FullCalendarResource } from "./commonLib";
+import { FullCalendarEvent, FullCalendarResource } from "./commonLib.js";
 
-_FC_EVENT = Symbol('EVENT')
-_NATIVE_ARRANGEMENT = Symbol("NATIVE_ARRANGEMENT")
+var _FC_EVENT = Symbol('EVENT');
+var _NATIVE_ARRANGEMENT = Symbol("NATIVE_ARRANGEMENT");
 
 
-class PlannerCalendar {
+export class PlannerCalendar {
 
-    constructor( { calendarElement, eventsSrcUrl } = {}) {
+    constructor( { calendarElement, eventsSrcUrl, colorProviders=[], initialColorProvider="" } = {}) {
         this._fcCalendar = undefined;
         this._calendarElement = calendarElement;
         this._eventsSrcUrl = eventsSrcUrl; /*"{% url 'arrangement:arrangement_events' %}"*/
 
-        this._ARRANGEMENT_STORE = this.ArrangementStore();
+        this._colorProviders = new Map();
+        this._colorProviders.set("DEFAULT", new this.StandardColorProvider())
+        colorProviders.forEach( (bundle) => {
+            this._colorProviders.set(bundle.key, bundle.provider)
+        })
+        this.activeColorProvider = initialColorProvider !== undefined && this._colorProviders.has(initialColorProvider) ? initialColorProvider : "DEFAULT";
+
+        console.log(">> Active Color Provider: " + this.activeColorProvider)
+        console.log(this._colorProviders)
+
+        this._ARRANGEMENT_STORE = new this.ArrangementStore(this);
         this._initCalendar();
+    }
+
+    refresh() {
+        this._initCalendar();
+    }
+
+    StandardColorProvider = class StandardColorProvider {
+        getColor(arrangement) {
+            return "green";
+        }
+    }
+
+    setActiveColorProvider(key) {
+        if (this._colorProviders.has(key)) {
+            this.activeColorProvider = key;
+        }
+        else {
+            console.error(`Color provider with the given key: '${this.key}' does not exist.`)
+        }
+    }
+
+    _getColorProvider() {
+        return this._colorProviders.get(this.activeColorProvider);
     }
 
     /**
      * Stores, fetches, and provides an easy interface from which to retrieve arrangements
      */
     ArrangementStore = class ArrangementStore {
-        constructor () {
+        constructor (plannerCalendar) {
             this._store = new Map();
             this._refreshStore();
+            this.plannerCalendar = plannerCalendar;
         }
 
         /**
-         * Refresh the store. 
+         * Refreshes the store and returns this so you can chain in a get.
          */
         _refreshStore(start, end) {
             this._flushStore();
-            fetch(`/arrangement/planner?start=${start}&end=${end}`)
+            return fetch(`/arrangement/planner/arrangements_in_period?start=${start}&end=${end}`)
                 .then(response => response.json())
                 .then(obj => { obj.forEach((arrangement) => {
+                    console.log(arrangement)
                     this._store.set(arrangement.slug, arrangement);
                 })});
         }
@@ -49,18 +84,27 @@ class PlannerCalendar {
          * @returns 
          */
         _mapArrangementToFullCalendarEvent(arrangement) {
+            let _this = this;
             return new FullCalendarEvent({
                 title: arrangement.name,
                 start: arrangement.starts,
                 end: arrangement.ends,
-            })
+                color: _this.plannerCalendar._getColorProvider().getColor(arrangement),
+                classNames: [ `slug:${arrangement.slug}` ],
+                extendedProps: { 
+                    icon: arrangement.audience_icon, 
+                    starts: arrangement.starts, 
+                    ends: arrangement.ends,
+                    arrangementType: arrangement.arrangement_type
+                },
+            });
         }
 
         /**
          * Get arrangement by the given slug
          * @param {*} slug 
          */
-        get(slug, get_as) {
+        get({ slug, get_as } = {}) {
             if (this._store.has(slug) === false) {
                 console.error(`Can not get arrangement with slug '${slug}' as slug is not known.`)
                 return;
@@ -73,6 +117,23 @@ class PlannerCalendar {
             }
             else if (get_as === _NATIVE_ARRANGEMENT) {
                 return arrangement;
+            }
+        }
+
+        get_all({ get_as } = {}) {
+            console.log(this._store);
+            var arrangements = Array.from(this._store.values());
+
+            if (get_as === _FC_EVENT) {
+                // var mappedEvents = arrangements.map( (arrangement) => { this._mapArrangementToFullCalendarEvent(arrangement) });
+                var mappedEvents = [];
+                arrangements.forEach( (arrangement) => {
+                    mappedEvents.push( this._mapArrangementToFullCalendarEvent(arrangement) );
+                });
+                return mappedEvents;
+            }
+            else if (get_as === _NATIVE_ARRANGEMENT) {
+                return arrangements;
             }
         }
 
@@ -111,7 +172,7 @@ class PlannerCalendar {
             return undefined;
         }
 
-        return slug
+        return slug;
     }
 
     /**
@@ -119,14 +180,25 @@ class PlannerCalendar {
      * @param {*} elementToBindWith 
      */
     _bindPopover (elementToBindWith) {
-
-        var info = {
-            slug: this._findSlugFromEl(elementToBindWith)
-        }
+        var slug = this._findSlugFromEl(elementToBindWith);        
+        var arrangement = this._ARRANGEMENT_STORE.get({
+            slug: slug,
+            get_as: _NATIVE_ARRANGEMENT
+        });
 
         new mdb.Popover(elementToBindWith, {
             trigger: "hover focus",
-            content: `<h5>${info.slug}</h5>`,
+            content: `
+                <span class='badge badge-lg badge-info'>
+                    <i class='${arrangement.audience_icon}'></i>&nbsp;
+                    ${arrangement.audience}
+                </span>
+                <span class='badge h6 badge-success'>
+                    ${arrangement.mainPlannerName}
+                </span>
+                <h5 class='mb-0 mt-2'>${arrangement.name}</h5>
+                <em class='small'>${arrangement.starts} - ${arrangement.ends}</em>
+                `,
             html: true,
         })
     }
@@ -134,18 +206,26 @@ class PlannerCalendar {
     /**
      * First-time initialize the calendar
      */
-    _initCalendar () {
+    async _initCalendar () {
+        let _this = this;
         this._fcCalendar = new FullCalendar.Calendar(this._calendarElement, {
             initialView: 'dayGridMonth',
-            events: (start, end, startStr, endStr, timezone) => {
-                this._ARRANGEMENT_STORE._refreshStore(start, end);
+            events: async (start, end, startStr, endStr, timezone) => {
+                var events = await _this._ARRANGEMENT_STORE._refreshStore(start, end)
+                        .then(a => _this._ARRANGEMENT_STORE.get_all({ get_as: _FC_EVENT }));
+                console.log(events);
+                return events;
             },
             eventContent: (arg) => {
                 var icon_class = arg.event.extendedProps.icon;
-                let html = `<span class="h6">
+                let html = `<span class="h6"
+                                    data-toggle='tooltip'
+                                    title='Right click me to get options'>
+  
                                 <span class='text-white ms-2'>
                                     <i class='${icon_class}'></i>
-                                </span> 
+                                </span>
+                                <em class='small'>${arg.event.extendedProps.starts} - ${arg.event.extendedProps.ends}</em>
                                 ${arg.event.title}
                             </span>`
                 return { html: html }
@@ -158,10 +238,17 @@ class PlannerCalendar {
                     selector: ".fc-event",
                     items: {
                         open: {
-                            name: "{% trans 'Open arrangement' %}",
+                            name: "Open",
                             isHtmlName: false,
                             callback: (key, opt) => {
                                 location.href = "/arrangement/arrangement/" + this._findSlugFromEl(opt.$trigger[0]);
+                            }
+                        },
+                        edit: {
+                            name: "Edit",
+                            isHtmlName: false,
+                            callback: (key, opt) => {
+                                location.href = "/arrangement/arrangement/edit/" + this._findSlugFromEl(opt.$trigger[0]);
                             }
                         },
                     }

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -9,7 +9,7 @@ export class PlannerCalendar {
     constructor( { calendarElement, eventsSrcUrl, colorProviders=[], initialColorProvider="" } = {}) {
         this._fcCalendar = undefined;
         this._calendarElement = calendarElement;
-        this._eventsSrcUrl = eventsSrcUrl; /*"{% url 'arrangement:arrangement_events' %}"*/
+        this._eventsSrcUrl = eventsSrcUrl;
 
         this._colorProviders = new Map();
         this._colorProviders.set("DEFAULT", new this.StandardColorProvider())

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -13,28 +13,39 @@ export class PlannerCalendar {
 
         this._colorProviders = new Map();
         this._colorProviders.set("DEFAULT", new this.StandardColorProvider())
+
         colorProviders.forEach( (bundle) => {
             this._colorProviders.set(bundle.key, bundle.provider)
         })
-        this.activeColorProvider = initialColorProvider !== undefined && this._colorProviders.has(initialColorProvider) ? initialColorProvider : "DEFAULT";
 
-        console.log(">> Active Color Provider: " + this.activeColorProvider)
-        console.log(this._colorProviders)
+        // If user has not supplied an active color provider key we use default color provider as active.
+        this.activeColorProvider = initialColorProvider !== undefined && this._colorProviders.has(initialColorProvider) ? initialColorProvider : "DEFAULT";
 
         this._ARRANGEMENT_STORE = new this.ArrangementStore(this);
         this._initCalendar();
     }
 
+    /**
+     * Refresh the calendar view.
+     */
     refresh() {
         this._initCalendar();
     }
 
+    /**
+     * The standard calendar color provider
+     */
     StandardColorProvider = class StandardColorProvider {
         getColor(arrangement) {
             return "green";
         }
     }
 
+    /**
+     * Set a new active color provider, identified by the given key. 
+     * Set color provider must have been registered on initialization of planner calendar.
+     * @param {*} key 
+     */
     setActiveColorProvider(key) {
         if (this._colorProviders.has(key)) {
             this.activeColorProvider = key;
@@ -44,6 +55,10 @@ export class PlannerCalendar {
         }
     }
 
+    /**
+     * Get the currently active color provider instance
+     * @returns active color provider
+     */
     _getColorProvider() {
         return this._colorProviders.get(this.activeColorProvider);
     }
@@ -120,6 +135,11 @@ export class PlannerCalendar {
             }
         }
 
+        /**
+         * Get all arrangements in the form designated by get_as param.
+         * @param {*} param0 
+         * @returns An array of arrangements, whose form depends on get_as param.
+         */
         get_all({ get_as } = {}) {
             console.log(this._store);
             var arrangements = Array.from(this._store.values());
@@ -187,7 +207,7 @@ export class PlannerCalendar {
         });
 
         new mdb.Popover(elementToBindWith, {
-            trigger: "hover focus",
+            trigger: "click",
             content: `
                 <span class='badge badge-lg badge-info'>
                     <i class='${arrangement.audience_icon}'></i>&nbsp;
@@ -211,10 +231,8 @@ export class PlannerCalendar {
         this._fcCalendar = new FullCalendar.Calendar(this._calendarElement, {
             initialView: 'dayGridMonth',
             events: async (start, end, startStr, endStr, timezone) => {
-                var events = await _this._ARRANGEMENT_STORE._refreshStore(start, end)
+                return await _this._ARRANGEMENT_STORE._refreshStore(start, end)
                         .then(a => _this._ARRANGEMENT_STORE.get_all({ get_as: _FC_EVENT }));
-                console.log(events);
-                return events;
             },
             eventContent: (arg) => {
                 var icon_class = arg.event.extendedProps.icon;

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -1,0 +1,93 @@
+
+
+class PlannerCalendar {
+
+    constructor( { calendarElement, eventsSrcUrl } = {}) {
+        this._fcCalendar = undefined;
+        this._calendarElement = calendarElement;
+        this._eventsSrcUrl = eventsSrcUrl; /*"{% url 'arrangement:arrangement_events' %}"*/
+
+        this._initCalendar();
+    }
+
+    /**
+     * Find the slug value from the given element el
+     * @param {*} el 
+     * @returns A slug, or undefined if none was found
+     */
+    _findSlugFromEl(el) {
+        var slug = undefined;
+
+        el.classList.forEach((classToEvaluate) => {
+            var classSplit = classToEvaluate.split(":");
+        
+            if (classSplit.length > 1 && classSplit[0] == "slug") {
+                slug = classSplit[1];
+            }
+        });
+
+        if (slug === undefined) {
+            console.error("Tried to execute open method for arrangement but could not acquire slug.")
+            return undefined;
+        }
+
+        return slug
+    }
+
+    /**
+     * Bind popover with arrangement info to elementToBindWith
+     * @param {*} elementToBindWith 
+     */
+    _bindPopover (elementToBindWith) {
+
+        var info = {
+            slug: this._findSlugFromEl(elementToBindWith)
+        }
+
+        new mdb.Popover(elementToBindWith, {
+            trigger: "hover focus",
+            content: `<h5>${info.slug}</h5>`,
+            html: true,
+        })
+    }
+
+    /**
+     * First-time initialize the calendar
+     */
+    _initCalendar () {
+        this._fcCalendar = new FullCalendar.Calendar(this._calendarElement, {
+            initialView: 'dayGridMonth',
+            events: this._eventsSrcUrl,
+            eventContent: (arg) => {
+                var icon_class = arg.event.extendedProps.icon;
+                let html = `<span class="h6">
+                                <span class='text-white ms-2'>
+                                    <i class='${icon_class}'></i>
+                                </span> 
+                                ${arg.event.title}
+                            </span>`
+                return { html: html }
+            },
+            eventDidMount: (arg) => {
+                this._bindPopover(arg.el)
+
+                $.contextMenu({
+                    className: "",
+                    selector: ".fc-event",
+                    items: {
+                        open: {
+                            name: "{% trans 'Open arrangement' %}",
+                            isHtmlName: false,
+                            callback: function (key, opt) {
+                                location.href = "/arrangement/arrangement/" + this._findSlugFromEl(opt.$trigger[0]);
+                            }
+                        },
+                    }
+                });
+            }
+        });
+
+        this._fcCalendar.render();
+    }
+
+}

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -89,5 +89,4 @@ class PlannerCalendar {
 
         this._fcCalendar.render();
     }
-
 }

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -78,7 +78,7 @@ class PlannerCalendar {
                         open: {
                             name: "{% trans 'Open arrangement' %}",
                             isHtmlName: false,
-                            callback: function (key, opt) {
+                            callback: (key, opt) => {
                                 location.href = "/arrangement/arrangement/" + this._findSlugFromEl(opt.$trigger[0]);
                             }
                         },

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -1,0 +1,118 @@
+{% extends "arrangement/meta_base.html" %}
+{% load static i18n %}
+
+{% block noheader %}
+
+<style>
+    .stampGroove {
+     border: dashed;   
+    }
+</style>
+
+<div class="clearfix">
+    
+    <div class="float-start">
+        <h2>Planleggingskalender</h2>
+    </div>
+</div>
+
+<div class="btn-group">
+    <button class="btn btn-wemade">
+        Planlegg nytt arrangement
+    </button>
+    <!-- <button class="btn btn-wemade">
+        Planlegg enkelt nytt arrangement
+    </button> -->
+</div>
+
+<!-- <div class="btn-group">
+    <button class="btn btn-success">
+        <i class="fas fa-plus"></i>
+        Ny enkelthendelse
+    </button>
+    <button class="btn btn-success">
+        <i class="fas fa-plus"></i>
+        Ny repeterende hendelse
+    </button>
+</div> -->
+
+<!-- <div class="float-end">
+    <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault" />
+        <label class="form-check-label" for="flexSwitchCheckDefault">Multi-select</label>
+    </div>      
+</div> -->
+
+
+<!-- <ul class="nav light-tabs nav-tabs rounded-top mt-4" id="navTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link text-center" id="overview-tab" data-mdb-toggle="tab" href="#overview" role="tab" aria-controls="overview" aria-selected="true">
+        <span class="h6 mb-0"><i class="fas fa-eye"></i></span>
+        &nbsp; <span class="h6">Arrangementer</span></button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active text-center" id="planner-tab" data-mdb-toggle="tab" href="#planner" role="tab" aria-controls="planner" aria-selected="true"
+          onclick="calendarManager.redraw();">
+        <span class="h6 mb-0"><i class="fas fa-calendar"></i></span>
+        &nbsp; <span class="h6">Lokasjoner</span></button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="planners-tab" data-mdb-toggle="tab" href="#planners" role="tab" aria-controls="planners" aria-selected="false">
+        <span class="h6 mb-0"><i class="fas fa-users"></i></span>
+        &nbsp; <span class="h6">Personer</span>
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="planners-tab" data-mdb-toggle="tab" href="#planners" role="tab" aria-controls="planners" aria-selected="false">
+          <span class="h6 mb-0"><i class="fas fa-calendar"></i></span>
+          &nbsp; <span class="h6">Mine kalendere</span>
+        </button>
+      </li>
+  </ul> -->
+
+
+{% endblock %}
+
+{% block content %}
+
+    <div id="arrangementPlannerCalendar"></div>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-contextmenu/2.9.2/jquery.contextMenu.css" integrity="sha512-EF5k2tHv4ShZB7zESroCVlbLaZq2n8t1i8mr32tgX0cyoHc3GfxuP7IoT8w/pD+vyoq7ye//qkFEqQao7Ofrag==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css" integrity="sha512-aOG0c6nPNzGk+5zjwyJaoRUgCdOrfSDhmMID2u4+OIslr0GjpLKo7Xm0Ao3xmpM4T8AmIouRkqwj1nrdVsLKEQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        var plannerCalendarEl = undefined;
+        document.addEventListener('DOMContentLoaded', function() {
+            plannerCalendarEl = document.getElementById('arrangementPlannerCalendar');
+
+            var plannerCalendar = new FullCalendar.Calendar(plannerCalendarEl, {
+                initialView: 'dayGridMonth',
+                events: "{% url 'arrangement:arrangement_events' %}",
+                eventContent: (arg) => {
+                    var icon_class = arg.event.extendedProps.icon;
+                    let html = `<span class="h6"><span class='text-white ms-2'><i class='${icon_class}'></i></span> ${arg.event.title}</span>`
+                    return { html: html }
+                },
+                eventDidMount: (arg) => {
+                    $.contextMenu({
+                        className: "",
+                        selector: ".fc-event",
+                        items: {
+                            open: {
+                                name: "Åpne",
+                                isHtmlName: false,
+                                callback: function (key, opt) {
+                                    console.log(key)
+                                    console.log(opt)
+                                    // location.href = '/arrangement/arrangement/'
+                                }
+                            },
+                        }
+                    });
+                }
+            });
+
+            plannerCalendar.render();
+        });
+    </script>
+
+{% endblock %}

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -17,9 +17,10 @@
 </div>
 
 <div class="btn-group">
-    <button class="btn btn-wemade">
+    <a class="btn btn-wemade"
+        href="{% url 'arrangement:arrangement_create' %}">
         Planlegg nytt arrangement
-    </button>
+    </a>
     <!-- <button class="btn btn-wemade">
         Planlegg enkelt nytt arrangement
     </button> -->
@@ -80,6 +81,42 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-contextmenu/2.9.2/jquery.contextMenu.css" integrity="sha512-EF5k2tHv4ShZB7zESroCVlbLaZq2n8t1i8mr32tgX0cyoHc3GfxuP7IoT8w/pD+vyoq7ye//qkFEqQao7Ofrag==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css" integrity="sha512-aOG0c6nPNzGk+5zjwyJaoRUgCdOrfSDhmMID2u4+OIslr0GjpLKo7Xm0Ao3xmpM4T8AmIouRkqwj1nrdVsLKEQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script>
+        /**
+         * Get the slug from a calendar dom element node
+         * Returns undefined if no slug was found
+         * */
+        function findSlugFromEl(el) {
+            var slug = undefined;
+
+            el.classList.forEach((classToEvaluate) => {
+                var classSplit = classToEvaluate.split(":");
+            
+                if (classSplit.length > 1 && classSplit[0] == "slug") {
+                    slug = classSplit[1];
+                }
+            });
+
+            if (slug === undefined) {
+                console.error("Tried to execute open method for arrangement but could not acquire slug.")
+                return undefined;
+            }
+
+            return slug
+        }
+
+        function bindPopover (elementToBindWith) {
+
+            var info = {
+                slug: findSlugFromEl(elementToBindWith)
+            }
+
+            new mdb.Popover(elementToBindWith, {
+                trigger: "hover focus",
+                content: `<h5>${info.slug}</h5>`,
+                html: true,
+            })
+        }
+
         var plannerCalendarEl = undefined;
         document.addEventListener('DOMContentLoaded', function() {
             plannerCalendarEl = document.getElementById('arrangementPlannerCalendar');
@@ -89,21 +126,26 @@
                 events: "{% url 'arrangement:arrangement_events' %}",
                 eventContent: (arg) => {
                     var icon_class = arg.event.extendedProps.icon;
-                    let html = `<span class="h6"><span class='text-white ms-2'><i class='${icon_class}'></i></span> ${arg.event.title}</span>`
+                    let html = `<span class="h6">
+                                    <span class='text-white ms-2'>
+                                        <i class='${icon_class}'></i>
+                                    </span> 
+                                    ${arg.event.title}
+                                </span>`
                     return { html: html }
                 },
                 eventDidMount: (arg) => {
+                    bindPopover(arg.el)
+
                     $.contextMenu({
                         className: "",
                         selector: ".fc-event",
                         items: {
                             open: {
-                                name: "Åpne",
+                                name: "{% trans 'Open arrangement' %}",
                                 isHtmlName: false,
                                 callback: function (key, opt) {
-                                    console.log(key)
-                                    console.log(opt)
-                                    // location.href = '/arrangement/arrangement/'
+                                    location.href = "/arrangement/arrangement/" + findSlugFromEl(opt.$trigger[0]);
                                 }
                             },
                         }

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -80,80 +80,15 @@
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-contextmenu/2.9.2/jquery.contextMenu.css" integrity="sha512-EF5k2tHv4ShZB7zESroCVlbLaZq2n8t1i8mr32tgX0cyoHc3GfxuP7IoT8w/pD+vyoq7ye//qkFEqQao7Ofrag==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css" integrity="sha512-aOG0c6nPNzGk+5zjwyJaoRUgCdOrfSDhmMID2u4+OIslr0GjpLKo7Xm0Ao3xmpM4T8AmIouRkqwj1nrdVsLKEQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <script src="{% static 'modules/planner/plannerCalendar.js' %}"></script>
+
     <script>
-        /**
-         * Get the slug from a calendar dom element node
-         * Returns undefined if no slug was found
-         * */
-        function findSlugFromEl(el) {
-            var slug = undefined;
-
-            el.classList.forEach((classToEvaluate) => {
-                var classSplit = classToEvaluate.split(":");
-            
-                if (classSplit.length > 1 && classSplit[0] == "slug") {
-                    slug = classSplit[1];
-                }
-            });
-
-            if (slug === undefined) {
-                console.error("Tried to execute open method for arrangement but could not acquire slug.")
-                return undefined;
-            }
-
-            return slug
-        }
-
-        function bindPopover (elementToBindWith) {
-
-            var info = {
-                slug: findSlugFromEl(elementToBindWith)
-            }
-
-            new mdb.Popover(elementToBindWith, {
-                trigger: "hover focus",
-                content: `<h5>${info.slug}</h5>`,
-                html: true,
-            })
-        }
-
-        var plannerCalendarEl = undefined;
         document.addEventListener('DOMContentLoaded', function() {
-            plannerCalendarEl = document.getElementById('arrangementPlannerCalendar');
-
-            var plannerCalendar = new FullCalendar.Calendar(plannerCalendarEl, {
-                initialView: 'dayGridMonth',
-                events: "{% url 'arrangement:arrangement_events' %}",
-                eventContent: (arg) => {
-                    var icon_class = arg.event.extendedProps.icon;
-                    let html = `<span class="h6">
-                                    <span class='text-white ms-2'>
-                                        <i class='${icon_class}'></i>
-                                    </span> 
-                                    ${arg.event.title}
-                                </span>`
-                    return { html: html }
-                },
-                eventDidMount: (arg) => {
-                    bindPopover(arg.el)
-
-                    $.contextMenu({
-                        className: "",
-                        selector: ".fc-event",
-                        items: {
-                            open: {
-                                name: "{% trans 'Open arrangement' %}",
-                                isHtmlName: false,
-                                callback: function (key, opt) {
-                                    location.href = "/arrangement/arrangement/" + findSlugFromEl(opt.$trigger[0]);
-                                }
-                            },
-                        }
-                    });
-                }
-            });
-
-            plannerCalendar.render();
+            new PlannerCalendar({
+                calendarElement: document.getElementById('arrangementPlannerCalendar'),
+                eventsSrcUrl: "{% url 'arrangement:arrangement_events' %}",
+            })
         });
     </script>
 

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -16,15 +16,64 @@
     </div>
 </div>
 
-<div class="btn-group">
-    <a class="btn btn-wemade"
-        href="{% url 'arrangement:arrangement_create' %}">
-        Planlegg nytt arrangement
-    </a>
-    <!-- <button class="btn btn-wemade">
-        Planlegg enkelt nytt arrangement
-    </button> -->
+
+
+<div class="clearfix">
+    <div class="float-end">
+        <div class="btn-group">
+            <a class="btn btn-wemade"
+                href="{% url 'arrangement:arrangement_create' %}">
+                Planlegg nytt arrangement
+            </a>
+            <!-- <button class="btn btn-wemade">
+                Planlegg enkelt nytt arrangement
+            </button> -->
+        </div>
+    </div>
+
+    <div class="float-start">
+        <div class="text-center text-uppercase text-muted"><i class="fas fa-eye"></i>&nbsp; Fokuser på</div>
+        <select name="" id="calendarFocusSelect" class="form-control">
+            <option value="audience">Audiens</option>
+            <option value="planner">Planlegger</option>
+            <option value="arrangement_type">Arrangementstype</option>
+        </select>
+
+        <!-- <div class="text-center text-uppercase text-muted"><i class="fas fa-filter"></i>
+            &nbsp;
+            Filter
+        </div>
+        <button class="btn btn-light btn-block shadow-0"
+                data-mdb-container="body"
+                data-mdb-toggle="popover"
+                data-mdb-placement="bottom"
+                data-mdb-content=" <div><strong>Arrangementstyper:</strong></div> <div><strong>Audiens: </strong></div> <div><strong>Planlegger: </strong></div>"
+                data-mdb-html="true">
+        <i class="fas fa-chevron-down"></i>
+            &nbsp;
+            Filtrer
+        </button>
+        <div class="text-center text-uppercase text-muted"><i class="fas fa-eye"></i>&nbsp; Fokuser på</div>
+        <div class="btn-group shadow-0">
+            <button class="btn btn-light"
+                data-toggle="tooltip"
+                title="Endre visningen til å fokusere på utheving av audiens">
+                Audiens
+            </button>
+            <button class="btn btn-light"
+                data-toggle="tooltip"
+                title="Endre visningen til å fokusere på utheving av arrangementstype">
+                Arrangementstype
+            </button>
+            <button class="btn btn-light"
+                data-toggle="tooltip"
+                title="Endre visningen til å fokusere på utheving av hovedplanleggere">
+                Hovedplanlegger
+            </button>
+        </div> -->
+    </div>
 </div>
+
 
 <!-- <div class="btn-group">
     <button class="btn btn-success">
@@ -81,13 +130,98 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-contextmenu/2.9.2/jquery.contextMenu.css" integrity="sha512-EF5k2tHv4ShZB7zESroCVlbLaZq2n8t1i8mr32tgX0cyoHc3GfxuP7IoT8w/pD+vyoq7ye//qkFEqQao7Ofrag==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css" integrity="sha512-aOG0c6nPNzGk+5zjwyJaoRUgCdOrfSDhmMID2u4+OIslr0GjpLKo7Xm0Ao3xmpM4T8AmIouRkqwj1nrdVsLKEQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
-    <script src="{% static 'modules/planner/plannerCalendar.js' %}"></script>
+    <!-- <script src="{% static 'modules/planner/plannerCalendar.js' %}" type="module"></script> -->
 
-    <script>
+    <script type="module">
+        import { PlannerCalendar } from "{% static 'modules/planner/plannerCalendar.js' %}";
+
+
+
+        var colorSwatch = [
+            "#ffc2c2", 
+            "#3a0846",
+            "#062664",
+            "#9470bd",
+            "#e1ceff",
+            "#9291cb",
+            "#6668a1",
+            "#937638",
+            "#b90209",
+            "#17222b",
+        ]
+
+        class ColorByMainPlannerColorProvider {
+            constructor () {
+                this._seenPlanners = new Map();
+                this._pickedColors = new Map();
+            }
+
+            _pickUniqueColor() {
+                for (let i = 0; i < colorSwatch.length; i++) {
+                    var color = colorSwatch[i];
+                    if (this._pickedColors.has(color) === false) {
+                        this._pickedColors.set(color, true);
+                        return color;
+                    }
+                }
+
+                return "green";
+            }
+
+            getColor(arrangement) {
+                if (this._seenPlanners.has(arrangement.mainPlannerName)) {
+                    return this._seenPlanners.get(arrangement.mainPlannerName);
+                }
+
+                var color = this._pickUniqueColor();
+
+                this._seenPlanners.set(arrangement.mainPlannerName, color);
+                return color;
+            }
+        }
+
+        class ColorByAudienceColorProvider {
+            constructor () {
+                this._seenAudiences = new Map();
+                this._pickedColors = new Map();
+            }
+
+            _pickUniqueColor() {
+                for (let i = 0; i < colorSwatch.length; i++) {
+                    var color = colorSwatch[i];
+                    if (this._pickedColors.has(color) === false) {
+                        this._pickedColors.set(color, true);
+                        return color;
+                    }
+                }
+
+                return "green";
+            }
+
+            getColor(arrangement) {
+               if (this._seenAudiences.has(arrangement.audience)) {
+                    return this._seenAudiences.get(arrangement.audience);
+                }
+
+                var color = this._pickUniqueColor();
+
+                this._seenAudiences.set(arrangement.audience, color);
+                return color;
+            }
+        }
         document.addEventListener('DOMContentLoaded', function() {
-            new PlannerCalendar({
+            var plannerCalendar = new PlannerCalendar({
                 calendarElement: document.getElementById('arrangementPlannerCalendar'),
                 eventsSrcUrl: "{% url 'arrangement:arrangement_events' %}",
+                colorProviders: [ 
+                    { key: "planner", provider: new ColorByMainPlannerColorProvider() }, 
+                    { key: "audience", provider: new ColorByAudienceColorProvider() },
+                ],
+                initialColorProvider: "audience",
+            });
+            $('#calendarFocusSelect').on("change", function () {
+                plannerCalendar.setActiveColorProvider(this.value);
+                plannerCalendar.refresh();
             })
         });
     </script>

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -85,6 +85,11 @@
           </li>
 
           <li>
+            <a class="sidenav-link ripple-surface" href="{% url "arrangement:planner_calendar" %}" tabindex="-1">
+              <i class="fa fa-suitcase fa-fw me-3" aria-hidden="true"></i><span>{% trans "Planner" %}</span></a>
+          </li>
+
+          <li>
             <a class="sidenav-link ripple-surface" href="{% url "arrangement:location_list" %}" tabindex="-1">
               <i class="fa fa-building fa-fw me-3" aria-hidden="true"></i><span>{% trans "Rooms & Locations" %}</span></a>
           </li>


### PR DESCRIPTION
### FEAT: Arrangement Calendar / Planning Calendar

This PR introduces the arrangement overview calendar, under a new section called planning. (how we organize this isn't really important at this point - we'll deal with that later.)
This calendar shows arrangements as a whole, without including the minute events. This allows for a good top-down view, and an excellent vector from where planning can begin. 

There is a few things I would like some more feedback on, preferably on how we deal with; 
a) Color providers
b) Filtering rules
and c) Resource focuses

![image](https://user-images.githubusercontent.com/62013916/158783835-0791ba15-8e79-4a10-b024-ad037387fbca.png)

I have also taken the liberty of adding a simple popover that displays on-hover of arrangements:
![image](https://user-images.githubusercontent.com/62013916/158784277-412215a3-faae-43fa-b232-ff3e688cbe52.png)
This can be extended further too -- the popover feature allows for quite a lot of interesting possibilities. We just push what HTML we want in, and rock n roll. The way I've set it up means that the backing store gets all the arrangement meta when the calendar wants new data -- so no double requests to populate the popovers. It's all one and done in concert with FullCalendar, and abstracted behind the ArrangementStore class. This gives maximum flexibility, and minimum "housekeeping" concerns in terms of metadata used outside of fc, and data used by fc, and keeping that in conjunction.

As for the context menu:
![image](https://user-images.githubusercontent.com/62013916/158784424-5a875cf8-9a30-4495-adef-4fce5bc60579.png)
It's as simple as can be.

Through the use of colors I have made a "focus" feature, that colors the arrangement event boxes based on what kind of focus one currently uses. One can focus on audiences and planners, as well as arrangement types. Arrangements of the same type of whatever is in focus will be colored with the same color. Adding a color legend on the right side too could be beneficial. This is an interesting idea, I think, but it needs more refinement, especially in how it is structurally set up. I see a few possible problems with the current setup in the future, if we need repeated rules across focuses, something the current paradigm can not easily accede, which would be WET.

Additionally -- I think adding a Resource calendar, that can display both Person and Room in a timegrid fashion, allowing perspecting in both Arrangement level and Event level would be tremendously useful. 