### PR TITLE
Make inspector refreshable

### DIFF
--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -1,8 +1,20 @@
+/**
+ * arrangementInspector.js
+ * 
+ * This should, when time allows, be split into a more re-usable component. The business logic
+ * is too integrated with dialog management and dialog concerns. I think the best solution is to
+ * split this up into a dialog manager, and then a consumer of said manager. Allows us to use the dialog approach
+ * in more than just the main calendar -- which may be neat.
+ */
+
 class Dialog {
-    constructor ({ dialogElementId, htmlFabricator, onRenderedCallback, dialogOptions } = {}) {
+    constructor ({ dialogElementId, triggerElementId, htmlFabricator, onRenderedCallback, onUpdatedCallback, onPreRefresh, dialogOptions } = {}) {
         this.dialogElementId = dialogElementId;
+        this.triggerElementId = triggerElementId;
         this.htmlFabricator = htmlFabricator;
         this.onRenderedCallback = onRenderedCallback;
+        this.onUpdatedCallback = onUpdatedCallback;
+        this.onPreRefresh = onPreRefresh;
         this.dialogOptions = dialogOptions;
     }
 
@@ -17,9 +29,35 @@ class Dialog {
             $('body')
                 .append(await this.htmlFabricator(arrangement))
                 .ready( () => {
-                    this.onRenderedCallback();
+                    this.onRenderedCallback(this);
                     this._$getDialogEl().dialog( this.dialogOptions );       
                 });
+        }
+    }
+
+    async refresh(arrangement) {
+        if (this.isOpen() === true) {
+            if (this.onPreRefresh !== undefined) {
+                await this.onPreRefresh(this);
+            }
+
+            var html = await this.htmlFabricator(arrangement);
+            var holderEl = document.createElement("span");
+            holderEl.innerHTML = html;
+            var realHtml = holderEl.querySelector("#" + this.dialogElementId).innerHTML;
+            document.querySelector("#" + this.dialogElementId).innerHTML = realHtml;
+
+            this.onRenderedCallback(this);
+
+            return;
+        }
+
+        console.warn("Tried refreshing a non-open dialog.")
+    }
+
+    close() {
+        if (this.isOpen() === true) {
+            this._$getDialogEl().dialog("close");
         }
     }
 
@@ -45,86 +83,136 @@ class Dialog {
 export class ArrangementInspector {
     constructor () {
         this._listenForRepopRequest();
+        this._listenForUpdatedRequest();
+
         this._dialogRepository = new Map([
             [ 
-                "_mainDialog", 
-                new Dialog({ 
+                "mainDialog", 
+                new Dialog({
                     dialogElementId: "mainDialog",
+                    triggerElementId: "_mainDialog",
                     htmlFabricator: this._fabricateMainDialog,
-                    onRenderedCallback: () => { $('#tabs').tabs(); this._makeAware(); },
+                    onPreRefresh: (dialog) => {
+                        var active = $('#tabs').tabs ( "option", "active" );
+                        dialog._active_tab = active;
+                    },
+                    onRenderedCallback: (dialog) => {
+                        $('#tabs').tabs(); 
+
+                        if (dialog._active_tab !== undefined) {
+                            $('#tabs').tabs("option", "active", dialog._active_tab);
+                            dialog._active_tab = undefined;
+                        }
+
+                        this._makeAware(); 
+                    },
+                    onUpdatedCallback: () => { return false; },
                     dialogOptions: { width: 600 }
                 }) 
             ],
             [
-                "mainDialog__addPlannerBtn",
+                "addPlannerDialog",
                 new Dialog({
                     dialogElementId: "addPlannerDialog",
+                    triggerElementId: "mainDialog__addPlannerBtn",
                     htmlFabricator: this._fabricateAddPlannerDialog,
                     onRenderedCallback: () => { console.info("Rendered"); },
+                    onUpdatedCallback: ( ) => { this.reloadDialog("mainDialog"); this.closeDialog("addPlannerDialog"); },
                     dialogOptions: { width: 700 }
                 })
             ],
             [
-                "mainPlannerDialog__newTimePlan",
+                "newTimePlanDialog",
                 new Dialog({
                     dialogElementId: "newTimePlanDialog",
+                    triggerElementId: "mainPlannerDialog__newTimePlan",
                     htmlFabricator: this._fabricateNewTimePlanDialog,
                     onRenderedCallback: () => { console.info("Rendered"); },
+                    onUpdatedCallback: () => { this.reloadDialog("mainDialog"); this.closeDialog("newTimePlanDialog"); },
                     dialogOptions: { width: 700 }
                 })
             ],
             [
-                "mainPlannerDialog__newSimpleActivity",
+                "newSimpleActivityDialog",
                 new Dialog({
                     dialogElementId: "newSimpleActivityDialog",
+                    triggerElementId: "mainPlannerDialog__newSimpleActivity",
                     htmlFabricator: this._fabricateNewSimpleActivityDialog,
                     onRenderedCallback: () => { console.info("Rendered") },
+                    onUpdatedCallback: () => { this.reloadDialog("mainDialog"); this.closeDialog("newSimpleActivityDialog"); },
                     dialogOptions: { width: 500 }
                 })
             ],
             [
-                "mainPlannerDialog__showInCalendarForm",
+                "calendarFormDialog",
                 new Dialog({
                     dialogElementId: "calendarFormDialog",
+                    triggerElementId: "mainPlannerDialog__showInCalendarForm",
                     htmlFabricator: this._fabricateCalendarFormDialog,
                     onRenderedCallback: () => { console.info("Rendered") },
+                    onUpdatedCallback: () => { return false; },
                     dialogOptions: { width: 1200, height: 700 }
                 })
             ],
             [
-                "mainPlannerDialog__promotePlannerBtn",
+                "promotePlannerDialog",
                 new Dialog({
                     dialogElementId: "promotePlannerDialog",
+                    triggerElementId: "mainPlannerDialog__promotePlannerBtn",
                     htmlFabricator: this._fabricatePromotePlannerDialog,
                     onRenderedCallback: () => { console.info("Rendered") },
+                    onUpdatedCallback: () => { this.reloadDialog("mainDialog"); this.closeDialog("promotePlannerDialog"); },
                     dialogOptions: { width: 500 },
                 })
             ],
             [
-                "mainPlannerDialog__newNoteBtn",
+                "newNoteDialog",
                 new Dialog({
                     dialogElementId: "newNoteDialog",
+                    triggerElementId: "mainPlannerDialog__newNoteBtn",
                     htmlFabricator: this._fabricateNewNoteDialog,
                     onRenderedCallback: () => { console.info("Rendered") },
+                    onUpdatedCallback: () => { this.reloadDialog("mainDialog"); this.closeDialog("newNoteDialog");  },
                     dialogOptions: { width: 500 },
                 })
             ],
             [
-                "mainPlannerDialog__addPlannerBtn",
+                "addPlannerDialog",
                 new Dialog({
                     dialogElementId: "addPlannerDialog",
+                    triggerElementId: "mainPlannerDialog__addPlannerBtn",
                     htmlFabricator: this._fabricateAddPlannerDialog,
                     onRenderedCallback: () => { console.info("Rendered") },
-                    dialogOptions: { width: 500 }
+                    onUpdatedCallback: () => { this.reloadDialog("mainDialog"); this.closeDialog("addPlannerDialog");  },
+                    dialogOptions: { width: 500 },  
                 })
             ],
-        ])
+        ]);
+
+        this.dialogElIdToDialogTriggerKey = new Map();
+        this._dialogRepository.forEach((value, key) => {
+            this.dialogElIdToDialogTriggerKey.set(value.dialogElementId, key);
+        });
+    }
+
+    reloadDialog(dialogId) {
+        this._dialogRepository.get(dialogId).refresh(this.arrangement);
+    }
+
+    closeDialog(dialogId) {
+        this._dialogRepository.get(dialogId).close();
     }
 
     _listenForRepopRequest() {
         document.addEventListener("arrangementPlannerDialogs.repop", () => {
             this.repop();
         })
+    }
+    _listenForUpdatedRequest() {
+        document.addEventListener("arrangementPlannerDialogs.hasBeenUpdated", (e) => {
+            console.log(">> UPDATED HANDLER!!")
+            this._dialogRepository.get(e.detail.dialog).onUpdatedCallback();
+        });
     }
 
     repop() {
@@ -141,7 +229,7 @@ export class ArrangementInspector {
 
     inspectArrangement( arrangement ) {
         this.arrangement = arrangement;
-        this._dialogRepository.get("_mainDialog").render(arrangement);
+        this._dialogRepository.get("mainDialog").render(arrangement);
 
         this.$nameField = undefined;
         this.$targetAudienceField = undefined;
@@ -160,7 +248,9 @@ export class ArrangementInspector {
 
     _setTriggers() {
         this._dialogRepository.forEach( (value, key, map) => {
-            $("#" + key).on('click', () => {
+            console.log(" >> Binding to " + value.triggerElementId)
+            console.log(value);
+            $("#" + value.triggerElementId).on('click', () => {
                 value.render(this.arrangement);
             });
         })

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -10,10 +10,6 @@ class Dialog {
         return $("#" + this.dialogElementId);
     }
 
-    _loadHtml() {
-        
-    }
-
     async render(arrangement) {
         this.prepareDOM();
 

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -236,7 +236,7 @@ export class PlannerCalendar extends FullCalendarBased {
                     selector: ".fc-event",
                     items: {
                         open: {
-                            name: "Open",
+                            name: "Åpne",
                             icon: "",
                             isHtmlName: false,
                             callback: (key, opt) => {
@@ -244,18 +244,11 @@ export class PlannerCalendar extends FullCalendarBased {
                             }
                         },
                         edit: {
-                            name: "Edit",
-                            icon: "edit",
-                            isHtmlName: false,
+                            name: "Rediger",
                             callback: (key, opt) => {
                                 location.href = "/arrangement/arrangement/edit/" + this._findSlugFromEl(opt.$trigger[0]);
                             }
                         },
-                        audience: {
-                            name: "Status",
-                            type: "select",
-                            options: { 1: "Planlegges", 2: "Venter kvittering", 3: "Ferdig" }
-                        }
                     }
                 });
             }

--- a/webook/templates/arrangement/arrangement/arrangement_form.html
+++ b/webook/templates/arrangement/arrangement/arrangement_form.html
@@ -200,7 +200,12 @@
                 <i class="fas fa-question-circle"></i>
                 <span class="ps-2">{% trans "Who is responsible for this arrangement?" %}</em>
             </div>
-
+            {{ form.responsible.choices }}
+            <select name="" id="" class="form-control">
+                {% for option in form.responsible.queryset %}
+                    <option value="">{{option}}</option>
+                {% endfor %}
+            </select>
             {{ form.responsible }}
 
             {% if form.responsible.errors|length > 0 %}

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -62,7 +62,11 @@
                     <tr>
                         <td colspan='2'>
                             <strong>Starter:</strong>
-                            {{form.starts}}
+                            <!-- {{form.starts}} -->
+                            <input type="date"
+                                id="{{ form.starts.id_for_label }}"
+                                name="{{ form.starts.name }}"
+                                value="{{ form.starts.value|date:'Y-m-d'|default:'' }}">
 
                             <span>( <a href='#' class='text-primary'>I dag</a> )</span>
                         </td>
@@ -72,7 +76,10 @@
                     <tr>
                         <td colspan='2'>
                             <strong>Slutter:</strong>
-                            {{form.ends}}
+                            <input type="date"
+                                id="{{ form.ends.id_for_label }}"
+                                name="{{ form.ends.name }}"
+                                value="{{ form.ends.value|date:'Y-m-d'|default:'' }}">
                             <span>( <a href='#' class='text-primary'>I dag</a> )</span>
                         </td>
                         <td><i class='fas fa-question-circle text-muted'></i></td>

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/newNoteDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/newNoteDialog.html
@@ -23,8 +23,12 @@
             method: 'POST',
             body: data,
             credentials: 'same-origin',
+        }).then( _ => { 
+            document.dispatchEvent(
+                new CustomEvent("arrangementPlannerDialogs.hasBeenUpdated", {'detail': {
+                    dialog: "newNoteDialog",
+                }})
+            )
         });
-
-        document.dispatchEvent(new Event("arrangementPlannerDialogs.repop"));
     }
 </script>

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/promotePlannerDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/promotePlannerDialog.html
@@ -25,7 +25,6 @@
         let formData = new FormData();
         formData.append("arrangement_id", "{{arrangementPk}}");
         formData.append("promotee", $("input[name='plannerToPromoteRadio']:checked").val())
-
         
         fetch("{% url 'arrangement:arrangement_promote_planner_to_main' %}", {
             method: 'POST',
@@ -34,8 +33,11 @@
                 'X-CSRFToken': '{{csrf_token}}'
             },
             credentials: 'same-origin'
-        })
-
-        document.dispatchEvent(new Event("arrangementPlannerDialogs.repop"));
+        }).then(_ => { document.dispatchEvent(
+                new CustomEvent("arrangementPlannerDialogs.hasBeenUpdated", { "detail": {
+                    dialog: "promotePlannerDialog",
+                }})
+            )}
+        )
     }
 </script>


### PR DESCRIPTION
### FEAT: Make inspector refreshable

This PR introduces automatic refreshing to the arrangement inspector. The core issue it solves is that for instance after adding a note, the main planner dialog does not refresh to reflect the new note. The previous solution was the "repop" - which just closed and reopened the dialogs, which was too unfriendly. This way each dialog can customize their own "logic" when they are executed, so to speak, as to how it should affect other dialogs, and what needs to be refreshed. Kinda neat.