### PR TITLE
Add support for cascading on_archives, and implement for location model

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -25,6 +25,11 @@ class ModelArchiveableMixin(models.Model):
         self.is_archived = True
         self.archived_by = person_archiving_this
         self.archived_when = datetime.datetime.now()
+
+        on_archive = getattr(self, "on_archive", None)
+        if callable(on_archive):
+            on_archive(person_archiving_this)
+
         self.save()
 
     is_archived = models.BooleanField(
@@ -278,6 +283,11 @@ class Location (TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
     class Meta:
         verbose_name = _("Location")
         verbose_name_plural = _("Locations")
+
+    def on_archive(self, person_archiving_this):
+        rooms = self.rooms.all()
+        for room in rooms:
+            room.archive(person_archiving_this)
 
     name = models.CharField(verbose_name=_("Name"), max_length=255)
     slug = AutoSlugField(populate_from="name", unique=True)

--- a/webook/templates/arrangement/location/location_detail.html
+++ b/webook/templates/arrangement/location/location_detail.html
@@ -101,7 +101,7 @@
 </div>
 
 <script>
-    var resources = JSON.parse('{{ resources_json | safe }}')
+    var resources = JSON.parse(`{{ resources_json | safe }}`)
 
     document.addEventListener('DOMContentLoaded', function() {
         var calendarEl = document.getElementById('location_calendar');


### PR DESCRIPTION
### Add support for cascading on_archive
One of the primary issues with the current archival approach is that there was no way (until now) to cascade the archivals. It makes sense that if you archive a location you also want to archive the rooms contained within that location. This allows for that.

This does demand writing custom logic on each model where cascading archives are needed (or anything else done on archival):
```
# Simple and easy.
class MyLocationModel(models.Model):
    def on_archive(self, person_archiving_this):
        rooms = self.rooms.all()
        for room in rooms:
            room.archive(person_archiving_this)
```

I suppose this could be done automatically too. In which case you could just get all the attributes, find the relationships, and go over and archive recursively. Not sure it's necessary at the moment, but it is an interesting prospect.