### PR TITLE
Add archival functionality to dialogs

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -205,7 +205,7 @@ class Arrangement(TimeStampedModel, ModelNamingMetaMixin, ModelTicketCodeMixin, 
     def on_archive(self, person_archiving_this):
         """ Handle extra stuff when an arrangement is archived
             We also need to archive events """
-        events = self.events.all()
+        events = self.event_set.all()
         for event in events:
             event.archive(person_archiving_this)
 

--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -202,6 +202,13 @@ class Arrangement(TimeStampedModel, ModelNamingMetaMixin, ModelTicketCodeMixin, 
         verbose_name = _("Arrangement")
         verbose_name_plural = _("Arrangements")
 
+    def on_archive(self, person_archiving_this):
+        """ Handle extra stuff when an arrangement is archived
+            We also need to archive events """
+        events = self.events.all()
+        for event in events:
+            event.archive(person_archiving_this)
+
     """ TODO: Write article doc in sphinx concerning the arrangements and how they 'flow' """
     """ Arrangement is in the planning phase """
     PLANNING = 'planning'

--- a/webook/arrangement/views/arrangement_views.py
+++ b/webook/arrangement/views/arrangement_views.py
@@ -19,6 +19,7 @@ from webook.arrangement.forms.promote_planner_to_main_form import PromotePlanner
 from webook.arrangement.forms.remove_planner_form import RemovePlannerForm
 from webook.arrangement.forms.add_planner_form import AddPlannerForm
 from webook.arrangement.models import Arrangement, ArrangementFile, Person
+from webook.arrangement.views.generic_views.archive_view import ArchiveView
 from webook.arrangement.views.search_view import SearchView
 from webook.utils.meta_utils.meta_mixin import MetaMixin
 from django.views.generic.edit import FormView
@@ -188,13 +189,16 @@ class ArrangementUpdateView(LoginRequiredMixin, ArrangementSectionManifestMixin,
 arrangement_update_view = ArrangementUpdateView.as_view()
 
 
-class ArrangementDeleteView(LoginRequiredMixin, ArrangementSectionManifestMixin, MetaMixin, DeleteView):
+class ArrangementDeleteView(LoginRequiredMixin, ArrangementSectionManifestMixin, MetaMixin, ArchiveView):
     model = Arrangement
     current_crumb_title = _("Delete Arrangement")
     section_subtitle = _("Edit Arrangement")
     template_name = "arrangement/delete_view.html"
     view_meta = ViewMeta.Preset.delete(Arrangement)
 
+    def get_success_url(self) -> str:
+        return reverse("arrangement:arrangement_list")
+        
 arrangement_delete_view = ArrangementDeleteView.as_view()
 
 

--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -37,6 +37,7 @@ from webook.arrangement.forms.planner.planner_update_event_form import PlannerUp
 from webook.arrangement.forms.remove_person_from_event_form import RemovePersonFromEventForm
 from webook.arrangement.forms.remove_room_from_event_form import RemoveRoomFromEventForm
 from webook.arrangement.forms.upload_files_to_arrangement_form import UploadFilesToArrangementForm
+from webook.arrangement.views.generic_views.archive_view import ArchiveView
 from webook.screenshow.models import DisplayLayout
 from webook.utils.json_serial import json_serial
 from webook.arrangement.forms.add_planners_form import AddPlannersForm
@@ -345,11 +346,11 @@ class PlanPeopleToRequisitionTableComponent(LoginRequiredMixin, ListView):
 plan_people_to_requisition_component_view = PlanPeopleToRequisitionTableComponent.as_view()
 
 
-class PlanDeleteEvent (LoginRequiredMixin, DeleteView):
+class PlanDeleteEvent (LoginRequiredMixin, ArchiveView):
     model = Event
     
     def get_success_url(self) -> str:
-        pass
+        return reverse("arrangement:arrangement_list")
 
 plan_delete_event = PlanDeleteEvent.as_view()
 

--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -443,9 +443,11 @@ class GetArrangementsInPeriod (LoginRequiredMixin, ListView):
                                 LEFT JOIN arrangement_person as participants on participants.id = evp.person_id
                                 LEFT JOIN arrangement_event_rooms as evr on evr.event_id = ev.id
                                 LEFT JOIN arrangement_room as room on room.id = evr.room_id
+                                WHERE arr.is_archived = false
                                 GROUP BY event_pk, audience.icon_class, audience.name, audience.slug,
                             resp.first_name, resp.last_name, arr.id, ev.id, arr.slug,
-                            loc.name, loc.slug, arrtype.name, arrtype.slug''')
+                            loc.name, loc.slug, arrtype.name, arrtype.slug
+                            ''')
             elif (db_vendor == 'sqlite'):
                 cursor.execute(
                     f'''	SELECT audience.icon_class as audience_icon, audience.name as audience, audience.slug as audience_slug, resp.first_name || " " || resp.last_name as mainPlannerName,
@@ -464,7 +466,8 @@ class GetArrangementsInPeriod (LoginRequiredMixin, ListView):
                             LEFT JOIN arrangement_person as participants on participants.id = evp.person_id
                             LEFT JOIN arrangement_event_rooms as evr on evr.event_id = ev.id
                             LEFT JOIN arrangement_room as room on room.id = evr.room_id
-                            GROUP BY event_pk'''
+                            GROUP BY event_pk
+                            WHERE arr.is_archived = 0'''
                 )
             columns = [column[0] for column in cursor.description]
             for row in cursor.fetchall():

--- a/webook/static/css/project.css
+++ b/webook/static/css/project.css
@@ -95,6 +95,10 @@ div.modal-body > .bootbox-close-button {
   color:white;
 }
 
+.swal2-container {
+  z-index: 100000000000!important;
+}
+
 .noBoxShadow {
   box-shadow: none;
 }

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -267,7 +267,6 @@ export class ArrangementStore extends BaseStore {
             } )
         }
 
-        // var locationsMap =          locations !== undefined && locations.length > 0 ? new Map(locations.map(i => [i, true])) : undefined;
         var arrangementTypesMap =   arrangement_types !== undefined && arrangement_types.length > 0 ? new Map(arrangement_types.map(i => [i, true])) : undefined;
         var audienceTypesMap =      audience_types !== undefined && audience_types.length > 0 ? new Map(audience_types.map(i => [i, true])) : undefined;
 

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -97,6 +97,7 @@ export class DialogManager {
 
         this._listenForUpdatedEvent();
         this._listenForSubmitEvent();
+        this._listenForCloseEvent();
 
         this._dialogRepository = new Map(dialogs);
         this.context = {};
@@ -125,8 +126,14 @@ export class DialogManager {
     }
 
     closeAllDialogs() {
-        this._dialogRepository.values.forEach( (dialog) => {
+        this._dialogRepository.forEach( (dialog) => {
             dialog.close();
+        })
+    }
+
+    _listenForCloseEvent() {
+        document.addEventListener(`${this.managerName}.close`, (e) => {
+            this.closeAllDialogs();
         })
     }
 

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -346,34 +346,60 @@ export class PlannerCalendar extends FullCalendarBased {
                         delete_arrangement: {
                             name: "Slett arrangement",
                             callback: (key, opt) => {
-                                var slug = _this._findSlugFromEl(opt.$trigger[0]);
-                                fetch('/arrangement/arrangement/delete/' + slug, {
-                                    method: 'DELETE',
-                                    headers: {
-                                        "X-CSRFToken": this.csrf_token
+                                Swal.fire({
+                                    title: 'Er du sikker?',
+                                    text: "Arrangementet og underliggende aktiviteter vil bli fjernet, og kan ikke hentes tilbake.",
+                                    icon: 'warning',
+                                    showCancelButton: true,
+                                    confirmButtonColor: '#3085d6',
+                                    cancelButtonColor: '#d33',
+                                    confirmButtonText: 'Ja',
+                                    cancelButtonText: 'Avbryt'
+                                }).then((result) => {
+                                    if (result.isConfirmed) {
+                                        var slug = _this._findSlugFromEl(opt.$trigger[0]);
+                                        fetch('/arrangement/arrangement/delete/' + slug, {
+                                            method: 'DELETE',
+                                            headers: {
+                                                "X-CSRFToken": this.csrf_token
+                                            }
+                                        }).then(_ => { 
+                                            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                                        });
                                     }
-                                }).then(_ => { 
-                                    document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
-                                });
+                                })
                             }
                         },
                         delete_event: {
                             name: "Slett aktivitet",
                             callback: (key, opt) => {
-                                var pk = _this._findEventPkFromEl(opt.$trigger[0]);
-                                
-                                var formData = new FormData();
-                                formData.append("eventIds", String(pk));
+                                Swal.fire({
+                                    title: 'Er du sikker?',
+                                    text: "Hendelsen kan ikke hentes tilbake.",
+                                    icon: 'warning',
+                                    showCancelButton: true,
+                                    confirmButtonColor: '#3085d6',
+                                    cancelButtonColor: '#d33',
+                                    confirmButtonText: 'Ja',
+                                    cancelButtonText: 'Avbryt'
+                                }).then((result) => {
+                                    if (result.isConfirmed) {
+                                        var pk = _this._findEventPkFromEl(opt.$trigger[0]);
 
-                                fetch('/arrangement/planner/delete_events/', {
-                                    method: 'POST',
-                                    body: formData,
-                                    headers: {
-                                        "X-CSRFToken": this.csrf_token,
+                                        var formData = new FormData();
+                                        formData.append("eventIds", String(pk));
+
+                                        fetch('/arrangement/planner/delete_events/', {
+                                            method: 'POST',
+                                            body: formData,
+                                            headers: {
+                                                "X-CSRFToken": this.csrf_token,
+                                            }
+                                        }).then(_ => { 
+                                            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                                        });
                                     }
-                                }).then(_ => { 
-                                    document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
-                                });
+                                })
                             }
                         }
                     }

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -341,6 +341,40 @@ export class PlannerCalendar extends FullCalendarBased {
                                 var pk = _this._findEventPkFromEl(opt.$trigger[0]);
                                 this.eventInspectorUtility.inspect(pk);
                             }
+                        },
+                        "section_sep_1": "---------",
+                        delete_arrangement: {
+                            name: "Slett arrangement",
+                            callback: (key, opt) => {
+                                var slug = _this._findSlugFromEl(opt.$trigger[0]);
+                                fetch('/arrangement/arrangement/delete/' + slug, {
+                                    method: 'DELETE',
+                                    headers: {
+                                        "X-CSRFToken": this.csrf_token
+                                    }
+                                }).then(_ => { 
+                                    document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                                });
+                            }
+                        },
+                        delete_event: {
+                            name: "Slett aktivitet",
+                            callback: (key, opt) => {
+                                var pk = _this._findEventPkFromEl(opt.$trigger[0]);
+                                
+                                var formData = new FormData();
+                                formData.append("eventIds", String(pk));
+
+                                fetch('/arrangement/planner/delete_events/', {
+                                    method: 'POST',
+                                    body: formData,
+                                    headers: {
+                                        "X-CSRFToken": this.csrf_token,
+                                    }
+                                }).then(_ => { 
+                                    document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                                });
+                            }
                         }
                     }
                 });

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -422,15 +422,28 @@
     }
 
     function mainPlannerDialog_deleteArrangement() {
-        fetch('/arrangement/arrangement/delete/{{ object.slug }}', {
-            method: 'DELETE',
-            headers: {
-                "X-CSRFToken": '{{ csrf_token }}'
+        Swal.fire({
+            title: 'Er du sikker?',
+            text: "Arrangementet og underliggende aktiviteter vil bli fjernet, og kan ikke hentes tilbake.",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#3085d6',
+            cancelButtonColor: '#d33',
+            confirmButtonText: 'Ja',
+            cancelButtonText: 'Avbryt'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                fetch('/arrangement/arrangement/delete/{{ object.slug }}', {
+                    method: 'DELETE',
+                    headers: {
+                        "X-CSRFToken": '{{ csrf_token }}'
+                    }
+                }).then(_ => { 
+                    document.dispatchEvent(new Event("arrangementInspector.close"));    // Close all dialogs on mainPlannerDialog
+                    document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                });
             }
-        }).then(_ => { 
-            document.dispatchEvent(new Event("arrangementInspector.close"));    // Close all dialogs on mainPlannerDialog
-            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
-        });
+        })
     }
 
     function mainPlannerDialog__deleteFile(file_id) {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -2,17 +2,8 @@
 
 
 <div id="mainDialog" title="{{object.name}}">
-    <!-- <div class="clearfix mb-3">
-        <div class="float-start">
-            <button class="btn btn-sm shadow-0 btn-outline-warning"><i class="fas fa-star"></i></button>
-            <button class="btn btn-sm shadow-0 btn-outline-info"><i class="fas fa-eye"></i></button>
-        </div> 
-        <div class="float-end">
-            <button class="btn btn-sm shadow-0 btn-danger float-end"><i class="fas fa-trash"></i></button>
-            <button class="btn btn-sm shadow-0 btn-info float-end me-2"><i class="fas fa-copy"></i></button>
-        </div>
-    </div>
-     -->
+
+    <button class="btn btn-danger mb-3" onclick="mainPlannerDialog_deleteArrangement()"><i class="fas fa-trash"></i>&nbsp; Slett</button>
 
     <div id="tabs" class="light-tabs">
         <ul>
@@ -428,6 +419,18 @@
                 formData: formData,
             }})
         );
+    }
+
+    function mainPlannerDialog_deleteArrangement() {
+        fetch('/arrangement/arrangement/delete/{{ object.slug }}', {
+            method: 'DELETE',
+            headers: {
+                "X-CSRFToken": '{{ csrf_token }}'
+            }
+        }).then(_ => { 
+            document.dispatchEvent(new Event("arrangementInspector.close"));    // Close all dialogs on mainPlannerDialog
+            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+        });
     }
 
     function mainPlannerDialog__deleteFile(file_id) {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
@@ -259,19 +259,35 @@
     }
 
     function inspectEventDialog__delete() {
-        let formData = new FormData();
-        formData.append("eventIds", "{{object.pk}}");
-        
-        fetch('/arrangement/planner/delete_events/', {
-            method: 'POST',
-            body: formData,
-            headers: {
-                "X-CSRFToken": '{{ csrf_token }}',
+
+        Swal.fire({
+            title: 'Er du sikker?',
+            text: "Hendelsen kan ikke hentes tilbake.",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#3085d6',
+            cancelButtonColor: '#d33',
+            confirmButtonText: 'Ja',
+            cancelButtonText: 'Avbryt'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                let formData = new FormData();
+                formData.append("eventIds", "{{object.pk}}");
+                
+                fetch('/arrangement/planner/delete_events/', {
+                    method: 'POST',
+                    body: formData,
+                    headers: {
+                        "X-CSRFToken": '{{ csrf_token }}',
+                    }
+                }).then(_ => { 
+                    document.dispatchEvent(new Event("eventInspector.close"));
+                    document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                });
             }
-        }).then(_ => { 
-            document.dispatchEvent(new Event("eventInspector.close"));
-            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
-        });
+        })
+
+
     }
 
     function inspectEventDialog__save() {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
@@ -12,6 +12,8 @@
         <button class="btn btn-sm shadow-0 btn-info float-end me-2"><i class="fas fa-copy"></i></button>
     </div> -->
 
+    <button class="btn btn-danger mb-3" onclick="inspectEventDialog__delete()"><i class="fas fa-trash"></i>&nbsp; Slett</button>
+
     <div class="border border-1 bg-secondary rounded-4 mb-2 p-3">
         <div>
             <h5 class="mb-0 d-inline fw-bolder text-white">{{ object.arrangement.name }}</h5>
@@ -254,6 +256,22 @@
         var people_ids = Array.from($("#peopleTableBody")[0].children).map(row => row.getAttribute("rowid"));
         console.log("People", people_ids)
         return people_ids;
+    }
+
+    function inspectEventDialog__delete() {
+        let formData = new FormData();
+        formData.append("eventIds", "{{object.pk}}");
+        
+        fetch('/arrangement/planner/delete_events/', {
+            method: 'POST',
+            body: formData,
+            headers: {
+                "X-CSRFToken": '{{ csrf_token }}',
+            }
+        }).then(_ => { 
+            document.dispatchEvent(new Event("eventInspector.close"));
+            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+        });
     }
 
     function inspectEventDialog__save() {

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -359,7 +359,7 @@
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>
       <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.11.5/af-2.3.7/b-2.2.2/b-colvis-2.2.2/b-html5-2.2.2/b-print-2.2.2/cr-1.5.5/date-1.1.2/fc-4.0.2/fh-3.2.2/kt-2.6.4/r-2.2.9/rg-1.1.4/rr-1.2.8/sc-2.0.5/sb-1.3.2/sp-2.0.0/sl-1.3.4/sr-1.1.0/datatables.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/2.1.2/sweetalert.min.js" integrity="sha512-AA1Bzp5Q0K1KanKKmvN/4d3IRKVlv9PYgwFPvm32nPO6QS8yH1HO7LbgB1pgiOxPtfeg5zEn2ba64MUcqJx6CA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+      <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
 <!-- Latest compiled and minified JavaScript -->
 

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -359,6 +359,7 @@
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>
       <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.11.5/af-2.3.7/b-2.2.2/b-colvis-2.2.2/b-html5-2.2.2/b-print-2.2.2/cr-1.5.5/date-1.1.2/fc-4.0.2/fh-3.2.2/kt-2.6.4/r-2.2.9/rg-1.1.4/rr-1.2.8/sc-2.0.5/sb-1.3.2/sp-2.0.0/sl-1.3.4/sr-1.1.0/datatables.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/2.1.2/sweetalert.min.js" integrity="sha512-AA1Bzp5Q0K1KanKKmvN/4d3IRKVlv9PYgwFPvm32nPO6QS8yH1HO7LbgB1pgiOxPtfeg5zEn2ba64MUcqJx6CA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
 <!-- Latest compiled and minified JavaScript -->
 


### PR DESCRIPTION
### FEAT: Add archival functionality to dialogs and planner calendar

It is now possible to;
1. Archive arrangements from the planner calendar context menu
2. Archive single events from the planner calendar context menu
3. Archive arrangement from the arrangement inspection dialog
4. Archive event from the event inspection dialog

Still need to add deletion functionality to the timeslot overview in arrangement inspection dialog, but this will come with a rewrite of the backend serie handling and the front-end display of series.