### PR TITLE
Fix popover orphaning on calendar refresh

### DIFF
--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -82,6 +82,10 @@ export class PlannerCalendar extends FullCalendarBased {
 
     _listenToRefreshEvents() {
         document.addEventListener("plannerCalendar.refreshNeeded", () => {
+            /* Remove all shown popovers, if we refresh the events without doing this we'll be "pulling the rug" up from under the popovers, 
+            in so far as removing the elements they are anchored/bound to. In effect this puts the popover in a stuck state, in which it can't be hidden or
+            removed without refresh. Hence we do this. */
+            $("[data-toggle='popover']").popover('hide');
             this.init();
         });
     }


### PR DESCRIPTION
Fix an annoying bug where popovers would be stuck if open when calendar is refreshed. They are bound to the events so this makes sense, as those elements are gone on calendar refresh, and they lose whatever element they were anchored to. A state less than ideal.
This fix makes sure that all popovers are removed or hidden before we run calendar re-initialization. 