### PR TITLE
Improve room selector

### DIFF
--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
@@ -92,6 +92,8 @@
     }
 
     $(document).ready(function () {
+        $('#roomsTable').DataTable().destroy();
+
         const dt = $('#roomsTable').DataTable( { 
             paging: false,
             dom: 't',

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
@@ -23,7 +23,7 @@
 
         {% endfor %}
 
-        <table class="table table-sm" id="roomsTable">
+        <table class="table table-sm" id="roomsTable" style="max-height: 25rem;overflow: auto;display:inline-block;">
             <thead>
                 <tr>
                     <th>Velg</th>


### PR DESCRIPTION
### Improve room selector

This PR introduces improvements to the room selector, namely:

1. Add a vertical scrollbar to the rooms table, and set a max height. This will avoid the dialog becoming unwieldly long when one has a large amount of locations and rooms defined.
2. Destroy datatables instance before init()

I am not entirely sure about 2, but as we have seen in production instances a datatables error is thrown due to there in some cases already being an instance in the document of the table. This should theoretically make sure that any existing instance is properly destroyed before we try to initialize the table. We need to test and see this actually work in production though, as I am not able to reproduce the bug itself.