### PR TITLE
Fix bug where x button would not show when creating new timeplan/serie

### DIFF
--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -1,5 +1,5 @@
-import { DialogManager, Dialog } from "./dialog_manager/dialogManager.js";
-import { SeriesUtil } from "./seriesutil.js"
+import { Dialog, DialogManager } from "./dialog_manager/dialogManager.js";
+import { SeriesUtil } from "./seriesutil.js";
 
 
 export class ArrangementCreator {
@@ -215,8 +215,6 @@ export class ArrangementCreator {
                                         $('#id_display_layouts_serie_planner_' + parseInt(checkboxElement.value) - 1)
                                             .prop( "checked", true );
                                     })
-                                    
-                                createSerieDialog__evaluateEnTitleObligatory();
                                 
                                 $('#serie_uuid').val(crypto.randomUUID());
 

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -374,6 +374,7 @@
     }
 
     $(document).ready(function () {
+        createSerieDialog__evaluateEnTitleObligatory();
         $("input[name='display_layouts_serie_planner'][type='checkbox']").on("change", (e) => {
             createSerieDialog__evaluateEnTitleObligatory();
         });


### PR DESCRIPTION
### Fix bug where X button would not show when creating new timeplan/serie

Due to a bug in arrangementCreator.js (calling a function before its available) the X button on new timeplan/serie (createSerieDialog) did not show. I have fixed this so that this function is called later on document.ready in the dialog itself, and moved this out of the dialog manager.