### PR TITLE
Fix bug where expected_visitors would be sent up as an empty string

### DIFF
--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -30,7 +30,7 @@
                 <label class="d-block">Expected amount of visitors</label>
                 <div class="input-group flex-nowrap">
                     <span class="input-group-text"><i class="fas fa-users"></i></span>
-                    <input type="text" class="form-control" id="expected_visitors" code-qualified-name="title" value="0"/>
+                    <input type="number" class="form-control" id="expected_visitors" code-qualified-name="title" min="0" value="0"/>
                 </div>
             </div>
 


### PR DESCRIPTION
### Fix bug where expected_visitors would be sent up as an empty string

On the create simple event dialog the expected visitors input was a text input. This caused, if no value was defined, expected_visitors to be sent up as an empty string. I have alleviated this by changing this input to be of type number, and have a min="0" and default value="0"