### PR TITLE
Fix "remembering" bug

### DIFF
--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -17,11 +17,10 @@
     }
 
     async render(context) {
-        this.prepareDOM();
-
+        // this.prepareDOM();
+        $( `#${this.dialogElementId}` ).dialog( "destroy" ).remove();
         this.destroy();
 
-        this.dialogOptions.closeText = "hello";
         if (this.isOpen() === false) {
             $('body')
                 .append(await this.htmlFabricator(context))
@@ -29,7 +28,12 @@
                     this._$getDialogEl().dialog( this.dialogOptions );
                     this.onRenderedCallback(this, context);
                     this._$getDialogEl().dialog("widget").find('.ui-dialog-titlebar-close')
-                        .html("<i class='fas fa-times text-danger' style='font-size: 24px'></i>");
+                        .html("<i class='fas fa-times text-danger' style='font-size: 24px'></i>")
+                        .click( () => {
+                            console.log("Clicked X button")
+                            this.destroy();
+                        });
+                    
                 });
         }
     }
@@ -61,22 +65,8 @@
 
     close() {
         if (this.isOpen() === true) {
-            this._$getDialogEl().dialog("close");
+            this.destroy()
         }
-    }
-
-    prepareDOM() {
-
-        var selector = `#${this.dialogElementId}`
-        if (this.dialogElementId == "editEventSerieDialog") {
-            selector += ",#newTimePlanDialog";
-        }
-
-        var elements = document.querySelectorAll(selector);
-
-        elements.forEach(element => {
-            element.remove();
-        })
     }
 
     getInstance() {
@@ -84,7 +74,7 @@
     }
 
     destroy() {
-        $( `#${this.dialogElementId}` ).dialog( "destroy" );
+        $( `#${this.dialogElementId}` ).dialog( "destroy" ).remove();
     }
 
     isOpen() {
@@ -107,6 +97,9 @@ export class DialogManager {
         this._listenForSubmitEvent();
         this._listenForCloseEvent();
         this._listenForReloadEvent();
+        
+        this.discriminator = crypto.randomUUID();
+        global_dialogManagerDiscriminators.set(this.managerName, this.discriminator);
 
         this._dialogRepository = new Map(dialogs);
         this.context = {};

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -17,7 +17,6 @@
     }
 
     async render(context) {
-        // this.prepareDOM();
         $( `#${this.dialogElementId}` ).dialog( "destroy" ).remove();
         this.destroy();
 
@@ -30,7 +29,6 @@
                     this._$getDialogEl().dialog("widget").find('.ui-dialog-titlebar-close')
                         .html("<i class='fas fa-times text-danger' style='font-size: 24px'></i>")
                         .click( () => {
-                            console.log("Clicked X button")
                             this.destroy();
                         });
                     

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -97,9 +97,6 @@ export class DialogManager {
         this._listenForSubmitEvent();
         this._listenForCloseEvent();
         this._listenForReloadEvent();
-        
-        this.discriminator = crypto.randomUUID();
-        global_dialogManagerDiscriminators.set(this.managerName, this.discriminator);
 
         this._dialogRepository = new Map(dialogs);
         this.context = {};


### PR DESCRIPTION
### Fix remembering bug

One of the major issues reported is an irritating problem where old values are "remembered" into the dialog. There is a feature in most dialogs making it so that when you are editing an arrangement, and creating a new Event or TimePlan, that the recurring values will be copied over into the new Event/TimePlan being created. This prevents a lot of repetitive typing, but also retains the option to be as granular as necessary if the need should arise. The way this is done is through JQUERY selectors fetching the value of the input elements from the other dialogs input elements, and placing this into the corresponding inputs in the form of the other dialog. The dialog manager does not always properly close dialogs after a user has exited them, and they may linger in the document, thus causing the jquery select to fetch the value from the wrong input element. 
To resolve this issue I have made some changes to the way the central DialogManager utility manages its dialogs, and how they are closed. When closed these dialogs will be completely removed from the document (as opposed to just using Jquery Dialogs close method). 

I have made sure that the two routes I know of that dismisses dialogs have this functionality. Namely; when you click the "X" on top right of the dialog, and when the dialog JS code calls the .close() method on the dialog, as well as being run pre-render of the dialog. This should cover all bases.

I think this should solve this issue permanently across the board for all dialogs - but it of course needs to be tested more extensively in the production environment.