### PR TITLE
Remember arrangement info new timeplan and activity

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Python: Django",
             "type": "python",
             "request": "launch",
-            "program": "${workspaceFolder}\\manage.py",
+            "program": "${workspaceFolder}/manage.py",
             "args": [
                 "runserver"
             ],

--- a/webook/arrangement/urls/arrangement_urls.py
+++ b/webook/arrangement/urls/arrangement_urls.py
@@ -12,10 +12,16 @@ from webook.arrangement.views import (
     arrangement_search_view,
     arrangement_create_json_view,
     arrangement_delete_file_view,
+    arrangement_recurring_information_json_view,
 )
 
 
 arrangement_urls = [
+    path(
+        route="arrangement/<int:pk>/detail",
+        view=arrangement_recurring_information_json_view,
+        name="arrangement_recurring_info_json",
+    ),
     path(
         route="arrangement/create/",
         view=arrangement_create_view,

--- a/webook/arrangement/views/__init__.py
+++ b/webook/arrangement/views/__init__.py
@@ -85,6 +85,7 @@ from .arrangement_views import (
     arrangement_promote_planner_to_main_view,
     arrangement_create_json_view,
     arrangement_delete_file_view,
+    arrangement_recurring_information_json_view,
 )
 
 from .audience_views import (

--- a/webook/arrangement/views/arrangement_views.py
+++ b/webook/arrangement/views/arrangement_views.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -25,10 +26,36 @@ from webook.arrangement.views.mixins.json_response_mixin import JSONResponseMixi
 from webook.arrangement.views.generic_views.search_view import SearchView
 from webook.utils.meta_utils.meta_mixin import MetaMixin
 from django.views.generic.edit import FormView
-from django.http import JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from webook.utils.meta_utils.section_manifest import SectionCrudlPathMap
 from webook.utils.crudl_utils.view_mixins import GenericListTemplateMixin
 from webook.utils.meta_utils import SectionManifest, ViewMeta, SectionCrudlPathMap
+
+
+class ArrangementRecurringInformationJsonView(LoginRequiredMixin, DetailView, JSONResponseMixin):
+    """ A view for getting the JSON 'recurrent' information
+        This is name, name in english, ticket code, expected visitors
+    """
+    model = Arrangement
+    pk_url_kwarg = "pk"
+
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.object = self.get_object()
+        context = self.get_context_data(object=self.object)
+        return self.render_to_json_response(context, safe=False)
+
+    def get_data(self, context):
+        arrangement = context["object"]
+
+        return {
+            "title": arrangement.name,
+            "title_en": arrangement.name_en,
+            "ticket_code": arrangement.ticket_code,
+            "expected_visitors": arrangement.expected_visitors,
+            "display_layouts": [ display_layout.pk for display_layout in arrangement.display_layouts.all() ]
+        }
+
+arrangement_recurring_information_json_view = ArrangementRecurringInformationJsonView.as_view()
 
 
 class ArrangementCreateView (LoginRequiredMixin, MetaMixin, CreateView):

--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -536,7 +536,7 @@ class GetArrangementsInPeriod (LoginRequiredMixin, ListView):
             elif (db_vendor == 'sqlite'):
                 cursor.execute(
                     f'''	SELECT audience.icon_class as audience_icon, audience.name as audience, audience.slug as audience_slug, resp.first_name || " " || resp.last_name as mainPlannerName,
-                            arr.id as arrangement_pk, ev.id as event_pk, arr.slug as slug, ev.name as name, ev.start as starts,
+                            arr.id as arrangement_pk, ev.id as event_pk, arr.slug as slug, ev.title as name, ev.start as starts,
                             ev.end as ends, loc.name as location, loc.slug as location_slug, arrtype.name as arrangement_type, arrtype.slug as arrangement_type_slug,
                             GROUP_CONCAT( DISTINCT room.name) as room_names, 
                             GROUP_CONCAT( DISTINCT participants.first_name || " " || participants.last_name ) as people_names,

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -12,9 +12,13 @@ export class ArrangementInspector {
         this.dialogManager = this._createDialogManager();
     }
 
-    inspect( arrangement ) {
+    async inspect( arrangement ) {
         this.dialogManager.setContext({ arrangement: arrangement });
         this.dialogManager.openDialog( "mainDialog" );
+    }
+
+    async _getRecurringInfo(arrangementPk) {
+        return await fetch(`/arrangement/arrangement/${arrangementPk}/detail`).then( response => response.json() );
     }
 
     _listenToOrderRoomForSingleEventBtnClick() {
@@ -155,9 +159,17 @@ export class ArrangementInspector {
                             return await fetch("/arrangement/planner/dialogs/create_serie?slug=" + context.arrangement.slug + "&dialog=newTimePlanDialog&managerName=" + MANAGER_NAME + "&orderRoomDialog=nestedOrderRoomDialog&orderPersonDialog=nestedOrderPersonDialog")
                                 .then(response => response.text());
                         },
-                        onRenderedCallback: () => { 
-                            $('#serie_title').attr('value', $('#id_name').val() );
-                            $('#serie_title_en').attr('value', $('#id_name_en').val() );
+                        onRenderedCallback: async (dialogManager, context) => { 
+                            var info = await this._getRecurringInfo( context.arrangement.arrangement_pk );
+                            $('#serie_title').attr('value', info.title);
+                            $('#serie_title_en').attr('value', info.title_en);
+                            $('#serie_ticket_code').attr('value', info.ticket_code);
+                            $('#serie_expected_visitors').attr('value', info.expected_visitors);
+
+                            info.display_layouts.forEach(display_layout => {
+                                $('#id_display_layouts_serie_planner_' + ( display_layout - 1))
+                                    .prop( "checked", true );
+                            })
                         },
                         onUpdatedCallback: () => { 
                             this.dialogManager.reloadDialog("mainDialog"); 
@@ -278,7 +290,18 @@ export class ArrangementInspector {
                             return await fetch('/arrangement/planner/dialogs/create_simple_event?slug=' + context.arrangement.slug + "&managerName=" + MANAGER_NAME + "&orderRoomDialog=nestedOrderRoomDialog&orderPersonDialog=nestedOrderPersonDialog")
                                 .then(response => response.text());
                         },
-                        onRenderedCallback: () => { console.info("Rendered") },
+                        onRenderedCallback: async (dialogManager, context) => { 
+                            var info = await this._getRecurringInfo( context.arrangement.arrangement_pk );
+                            $('#title').attr('value', info.title);
+                            $('#title_en').attr('value', info.title_en);
+                            $('#ticket_code').attr('value', info.ticket_code);
+                            $('#expected_visitors').attr('value', info.expected_visitors);
+
+                            info.display_layouts.forEach(display_layout => {
+                                $('#' + ( display_layout - 1) + "_dlcheck")
+                                    .prop( "checked", true );
+                            })
+                        },
                         onUpdatedCallback: () => { 
                             this.dialogManager.reloadDialog("mainDialog"); 
                             this.dialogManager.closeDialog("newSimpleActivityDialog"); 

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -53,7 +53,7 @@
             document.querySelector("#" + this.dialogElementId).innerHTML 
                 = holderEl.querySelector("#" + this.dialogElementId).innerHTML;
 
-            this.onRenderedCallback(this);
+            this.onRenderedCallback(this, context);
 
             return;
         }


### PR DESCRIPTION
### Remember arrangement info new timeplan and activity
 
Automatically get and fill in information from arrangement (title, title_en, expected_visitors, display_layouts) when opening new timeplan and new event dialogs on an existing arrangement, as is done in the planning phase.