### PR TITLE
Fix bug where display layouts not filled in on new timeseries in planning

### DIFF
--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -147,7 +147,7 @@ export class ArrangementCreator {
                                     var event = events[i];
                                     event.arrangement=arrangementId;
                                     event.start = event.from.toISOString();
-                                    event.end=event.to.toISOString();
+                                    event.end = event.to.toISOString();
                                     event.ticket_code = ticket_code;
                                     event.expected_visitors = serie.time.expected_visitors;
                                     event.rooms = serie.rooms;
@@ -212,7 +212,7 @@ export class ArrangementCreator {
 
                                 document.querySelectorAll("input[name='display_layouts']:checked")
                                     .forEach(checkboxElement => {
-                                        $('#id_display_layouts_serie_planner_' + parseInt(checkboxElement.value) - 1)
+                                        $('#id_display_layouts_serie_planner_' + String(parseInt(checkboxElement.value) - 1))
                                             .prop( "checked", true );
                                     })
                                 


### PR DESCRIPTION
### Fix bug where display layouts not filled in on new timeseries in planning

Fix a bug on the Arrangement Creator dialog structure, where selected dialogs on the arrangement info would not be auto-filled when one opened the "New Plan/Time Series" dialog.