### PR TITLE
Fix bug causing main planner name to be undefined in popover

### DIFF
--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -201,7 +201,7 @@ export class PlannerCalendar extends FullCalendarBased {
                 </span>
                 <span class='badge h6 badge-success'>
                     Hovedplanlegger:
-                    ${arrangement.mainplannername}
+                    ${arrangement.mainPlannerName}
                 </span>
                 <span class='badge h6 badge-secondary'>
                     Lokasjon: 


### PR DESCRIPTION
### Fix bug causing main planner name to be undefined in popover

Fix a name / case issue that caused the main planner name to be displayed as "undefined" in popover.