### PR TITLE
Fix zen mode scaling bug

### DIFF
--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -266,7 +266,7 @@
         }
       }
 
-      #mainBodyContainer {
+      .container-sidebar-padded-in {
         padding-left: 280px;
       }
 
@@ -277,7 +277,7 @@
     <div style="margin-top:100px"></div>
     {% endblock %}
 
-    <div class="container-fluid" id="mainBodyContainer">
+    <div class="container-fluid container-sidebar-padded-in" id="mainBodyContainer">
       {% block noheader %}
       <section class="bg-white  header-fonted">
         <h1 class="h1 fw-bolder header-fonted">
@@ -360,17 +360,13 @@
           $('#zenModeCheckbox').change(function () {
             if (this.checked) {
               console.log("<< Zen Mode Activated >>")
-              $('#mainBodyContainer').addClass("container-fluid");
-              $('#mainBodyContainer').removeClass("container");
-
+              $('#mainBodyContainer').removeClass("container-sidebar-padded-in");
               document.dispatchEvent(new Event("zenmode.activated"))
-
               instance.hide();
             }
             else {
               console.log("<< Zen Mode Deactivated >>")
-              $('#mainBodyContainer').addClass("container");
-              $('#mainBodyContainer').removeClass("container-fluid");
+              $('#mainBodyContainer').addClass("container-sidebar-padded-in");
               instance.show();
             }
           });

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -362,12 +362,12 @@
               console.log("<< Zen Mode Activated >>")
               $('#mainBodyContainer').removeClass("container-sidebar-padded-in");
               document.dispatchEvent(new Event("zenmode.activated"))
-              instance.hide();
+              sidebarInstance.hide();
             }
             else {
               console.log("<< Zen Mode Deactivated >>")
               $('#mainBodyContainer').addClass("container-sidebar-padded-in");
-              instance.show();
+              sidebarInstance.show();
             }
           });
 
@@ -402,7 +402,7 @@
 
 
           const sidenav = document.getElementById("sidenav-1");
-          const instance = mdb.Sidenav.getInstance(sidenav);
+          const sidebarInstance = mdb.Sidenav.getInstance(sidenav);
 
           let innerWidth = null;
 
@@ -415,11 +415,11 @@
             innerWidth = window.innerWidth;
 
             if (window.innerWidth < 1400) {
-              instance.changeMode("over");
-              instance.hide();
+              sidebarInstance.changeMode("over");
+              sidebarInstance.hide();
             } else {
-              instance.changeMode("side");
-              instance.show();
+              sidebarInstance.changeMode("side");
+              sidebarInstance.show();
             }
           };
 


### PR DESCRIPTION
### Fix zen mode scaling bug

The zen mode "scaling utility" has not been working properly ever since I made some changes to how the sidenav and the main container are sized (was a lot of empty whitespace that we didn't use, that we desperately needed for the planner calendar). The problematic behaviour was that when Zen Mode was deactivated it returned back to the normal Container styling, and not the new default sizing, hence ending up with a more constrained container than intended or wanted.
I have done some quality improvements too, to make this be a bit more readable and understandable. 