### PR TITLE
Fix flat dialogs bug

### DIFF
--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -17,7 +17,6 @@
     }
 
     async render(context) {
-        $( `#${this.dialogElementId}` ).dialog( "destroy" ).remove();
         this.destroy();
 
         if (this.isOpen() === false) {

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -71,7 +71,10 @@
     }
 
     destroy() {
-        $( `#${this.dialogElementId}` ).dialog( "destroy" ).remove();
+        $( this.dialogElementId ).dialog( "destroy" );
+        $(`[id=${this.dialogElementId}]`).each(function (index, $dialogElement) {
+            $dialogElement.remove();
+        })
     }
 
     isOpen() {


### PR DESCRIPTION
### Fix flat dialogs bug

In some cases it is possible for a dialog to be duplicated twice in the DOM. This seems to be exclusively on the CreateSerieDialog dialog, but I remember to have seen it on other dialogs too that are deeply nested. I am not entirely sure as to the root cause, but I have developed a fix that stops this from happening and causing problems.
These duplications would never be removed as when we are using the by-id selector on dialog.destroy() it gets one element (the latest added to document i think? Not entirely sure on that), thus the duplicate stays down there under the calendar and does not get cleaned up properly. I have solved this by refactoring the destroy method on dialog to A) destroy the dialog instance, B) find all elements with the given id, and remove them from the document.