### PR TITLE
Implement date navigation in planner calendar

### DIFF
--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -318,7 +318,6 @@ export class ArrangementStore extends BaseStore {
 }
 
 export class FullCalendarBased {
-
     _findSlugFromEl(el) { 
         var slug = undefined;
 
@@ -360,6 +359,10 @@ export class FullCalendarBased {
         this.init();
     }
 
+    /**
+     * Get the FullCalendar calendar instance
+     */
+    getFcCalendar() { }
     teardown() { }
     init() { }
 

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -318,6 +318,20 @@ export class ArrangementStore extends BaseStore {
 }
 
 export class FullCalendarBased {
+    constructor() {
+        this._listenToRefreshEvents();
+    }
+
+    _listenToRefreshEvents() {
+        document.addEventListener("plannerCalendar.refreshNeeded", async () => {
+            await this.init();
+            /* Remove all shown popovers, if we refresh the events without doing this we'll be "pulling the rug" up from under the popovers, 
+            in so far as removing the elements they are anchored/bound to. In effect this puts the popover in a stuck state, in which it can't be hidden or
+            removed without refresh. Hence we do this. */
+            $(".popover").popover('hide');
+        });
+    }
+
     _findSlugFromEl(el) { 
         var slug = undefined;
 
@@ -364,7 +378,7 @@ export class FullCalendarBased {
      */
     getFcCalendar() { }
     teardown() { }
-    init() { }
+    async init() { }
 
 }
 

--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -1,10 +1,8 @@
 import { FullCalendarEvent, StandardColorProvider, _FC_EVENT, ArrangementStore, FullCalendarResource, FullCalendarBased, LocationStore, _FC_RESOURCE } from "./commonLib.js";
 
 import { PlannerCalendarFilter } from "./plannerCalendarFilter.js";
+import { monthNames } from "./monthNames.js";
 
-const monthNames = ["Januar", "Februar", "Mars", "April", "Mai", "Juni",
-  "Juli", "August", "September", "Oktober", "November", "Desember"
-];
 
 export class LocationCalendar extends FullCalendarBased {
 

--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -25,22 +25,10 @@ export class LocationCalendar extends FullCalendarBased {
         // // If user has not supplied an active color provider key we use default color provider as active.
         // this.activeColorProvider = initialColorProvider !== undefined && this._colorProviders.has(initialColorProvider) ? initialColorProvider : this._colorProviders.get("DEFAULT");
 
-        this._listenToRefreshEvents();
-
         this._ARRANGEMENT_STORE = new ArrangementStore(this._colorProviders.get("arrangement"));
         this._LOCATIONS_STORE = new LocationStore(this);
 
         this.init()
-    }
-
-    _listenToRefreshEvents() {
-        document.addEventListener("plannerCalendar.refreshNeeded", async () => {
-            await this.init();
-            /* Remove all shown popovers, if we refresh the events without doing this we'll be "pulling the rug" up from under the popovers, 
-            in so far as removing the elements they are anchored/bound to. In effect this puts the popover in a stuck state, in which it can't be hidden or
-            removed without refresh. Hence we do this. */
-            $(".popover").popover('hide');
-        });
     }
 
     getFcCalendar() {

--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -27,6 +27,10 @@ export class LocationCalendar extends FullCalendarBased {
         this.init()
     }
 
+    getFcCalendar() {
+        return this._fcCalendar;
+    }
+
     /**
      * Set a new active color provider, identified by the given key. 
      * Set color provider must have been registered on initialization of planner calendar.

--- a/webook/static/modules/planner/monthNames.js
+++ b/webook/static/modules/planner/monthNames.js
@@ -1,0 +1,8 @@
+
+/* 
+    This should in time be replaced with a back-end endpoint returning JSON, allowing for easy translations.
+*/
+
+export const monthNames = ["Januar", "Februar", "Mars", "April", "Mai", "Juni",
+"Juli", "August", "September", "Oktober", "November", "Desember"
+];

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -26,19 +26,7 @@ export class PersonCalendar extends FullCalendarBased {
         this._ARRANGEMENT_STORE = new ArrangementStore(this._colorProviders.get("arrangement"));
         this._STORE = new PersonStore(this);
 
-        this._listenToRefreshEvents();
-
         this.init()
-    }
-
-    _listenToRefreshEvents() {
-        document.addEventListener("plannerCalendar.refreshNeeded", async () => {
-            await this.init();
-            /* Remove all shown popovers, if we refresh the events without doing this we'll be "pulling the rug" up from under the popovers, 
-            in so far as removing the elements they are anchored/bound to. In effect this puts the popover in a stuck state, in which it can't be hidden or
-            removed without refresh. Hence we do this. */
-            $(".popover").popover('hide');
-        });
     }
 
     getFcCalendar() {

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -1,8 +1,5 @@
 import { ArrangementStore, FullCalendarBased, PersonStore, StandardColorProvider, _FC_EVENT, _FC_RESOURCE } from "./commonLib.js";
-
-const monthNames = ["Januar", "Februar", "Mars", "April", "Mai", "Juni",
-  "Juli", "August", "September", "Oktober", "November", "Desember"
-];
+import { monthNames } from "./monthNames.js";
 
 export class PersonCalendar extends FullCalendarBased {
 

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -26,6 +26,10 @@ export class PersonCalendar extends FullCalendarBased {
         this.init()
     }
 
+    getFcCalendar() {
+        return this._fcCalendar;
+    }
+
     refresh() {
         this.init()
     }

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -70,23 +70,12 @@ export class PlannerCalendar extends FullCalendarBased {
             this.init();
         });
         
-        this._listenToRefreshEvents();
         this._listenToInspectArrangementEvents();
         this._listenToInspectEvent();
     }
 
     getFcCalendar() {
         return this._fcCalendar;
-    }
-
-    _listenToRefreshEvents() {
-        document.addEventListener("plannerCalendar.refreshNeeded", async () => {
-            await this.init();
-            /* Remove all shown popovers, if we refresh the events without doing this we'll be "pulling the rug" up from under the popovers, 
-            in so far as removing the elements they are anchored/bound to. In effect this puts the popover in a stuck state, in which it can't be hidden or
-            removed without refresh. Hence we do this. */
-            $(".popover").popover('hide');
-        });
     }
 
     _listenToInspectArrangementEvents() {

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -236,193 +236,192 @@ export class PlannerCalendar extends FullCalendarBased {
         let _this = this;
 
         var initialView = 'timelineMonth';
-        if (this._fcCalendar !== undefined) {
-            initialView = this._fcCalendar.view.type;
-        }
 
-        this._fcCalendar = new FullCalendar.Calendar(this._calendarElement, {
-            schedulerLicenseKey: this._fcLicenseKey,
-            initialView: initialView,
-            selectable: true,
-            weekNumbers: true,
-            navLinks: true,
-            minTime: "06:00",
-            themeSystem: 'bootstrap',
-            maxTime: "23:00",
-            slotEventOverlap: false,
-            locale: 'nb',
-            views: {
-                customTimeGridMonth: {
-                    type: "timeGrid",
-                    duration: { month: 1 },
-                    buttonText: "Tidsgrid Måned"
-                },
-                calendarDayGridMonth: {
-                    type: 'dayGridMonth',
-                    buttonText: 'Kalender'
-                },
-                customTimelineMonth: {
-                    type: 'timelineMonth',
-                    buttonText: 'Tidslinje - Måned'
-                },
-                customTimelineYear: {
-                    type: 'timelineYear',
-                    buttonText: 'Tidslinje - År'
-                }
-            },
-            datesSet: (dateInfo) => {
-                console.log(dateInfo)
-                $('#plannerCalendarHeader').text("");
-                $(".popover").popover('hide');
-
-                if (dateInfo.view.type == "timelineMonth" || dateInfo.view.type == "customTimelineMonth" || dateInfo.view.type == "dayGridMonth" || dateInfo.view.type == "customTimeGridMonth") {
-                    var monthIndex = dateInfo.start.getMonth();
-                    console.log(dateInfo.start.getDate());
-                    if (dateInfo.start.getDate() !== 1) {
-                        monthIndex++;
-                    }
-                    $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
-                }
-            },
-            customButtons: {
-                filterButton: {
-                    text: 'Filtrering',
-                    click: () => {
-                        this.filterDialog.openFilterDialog();
-                    }
-                },
-                arrangementsCalendarButton: {
-                    text: 'Arrangementer',
-                    click: () => {
-                        // $('#plannerCalendarHeader').text("");
-                        $('#overview-tab')[0].click();
-                    }
-                },
-                locationsCalendarButton: {
-                    text: 'Lokasjoner',
-                    click: () => {
-                        // $('#plannerCalendarHeader').text("");
-                        $('#locations-tab')[0].click();
-                    }
-                },
-                peopleCalendarButton: {
-                    text: 'Personer',
-                    click: () => {
-                        // $('#plannerCalendarHeader').text("");
-                        $('#people-tab')[0].click();
-                    }
-                }
-            },
-            headerToolbar: { left: 'arrangementsCalendarButton,locationsCalendarButton,peopleCalendarButton' , center: 'customTimeGridMonth,timeGridDay,dayGridMonth,timeGridWeek,customTimelineMonth,customTimelineYear', },
-            eventSources: [
-                {
-                    events: async (start, end, startStr, endStr, timezone) => {
-                        return await _this._ARRANGEMENT_STORE._refreshStore(start, end)
-                            .then(_ => this.calendarFilter.getFilteredSlugs().map( function (slug) { return { id: slug, name: "" } }))
-                            .then(filterSet => _this._ARRANGEMENT_STORE.get_all(
-                                { 
-                                    get_as: _FC_EVENT, 
-                                    locations: this.$locationFilterSelectEl.val(),
-                                    arrangement_types: this.$arrangementTypeFilterSelectEl.val(),
-                                    audience_types: this.$audienceTypeFilterSelectEl.val(),
-                                    filterSet: filterSet
-                                }
-                            ));
+        if (this._fcCalendar === undefined) {
+            this._fcCalendar = new FullCalendar.Calendar(this._calendarElement, {
+                schedulerLicenseKey: this._fcLicenseKey,
+                initialView: initialView,
+                selectable: true,
+                weekNumbers: true,
+                navLinks: true,
+                minTime: "06:00",
+                // themeSystem: 'bootstrap',
+                maxTime: "23:00",
+                slotEventOverlap: false,
+                locale: 'nb',
+                views: {
+                    customTimeGridMonth: {
+                        type: "timeGrid",
+                        duration: { month: 1 },
+                        buttonText: "Tidsgrid Måned"
                     },
-                }
-            ],
+                    calendarDayGridMonth: {
+                        type: 'dayGridMonth',
+                        buttonText: 'Kalender'
+                    },
+                    customTimelineMonth: {
+                        type: 'timelineMonth',
+                        buttonText: 'Tidslinje - Måned'
+                    },
+                    customTimelineYear: {
+                        type: 'timelineYear',
+                        buttonText: 'Tidslinje - År'
+                    }
+                },
+                datesSet: (dateInfo) => {
+                    $('#plannerCalendarHeader').text("");
+                    $(".popover").popover('hide');
 
-            eventDidMount: (arg) => {
-                this._bindPopover(arg.el);
-                this._bindInspectorTrigger(arg.el);
-
-                $.contextMenu({
-                    className: "",
-                    selector: ".fc-event",
-                    items: {
-                        arrangement_inspector: {
-                            name: "Inspiser arrangement",
-                            callback: (key, opt) => {
-                                var pk = _this._findEventPkFromEl(opt.$trigger[0]);
-                                var arrangement = _this._ARRANGEMENT_STORE.get({
-                                    pk: pk,
-                                    get_as: _NATIVE_ARRANGEMENT
-                                });
-                        
-                                this.arrangementInspectorUtility.inspect(arrangement);
-                            }
-                        },
-                        event_inspector: {
-                            name: "Inspiser tidspunkt",
-                            callback: (key, opt) => {
-                                var pk = _this._findEventPkFromEl(opt.$trigger[0]);
-                                this.eventInspectorUtility.inspect(pk);
-                            }
-                        },
-                        "section_sep_1": "---------",
-                        delete_arrangement: {
-                            name: "Slett arrangement",
-                            callback: (key, opt) => {
-                                Swal.fire({
-                                    title: 'Er du sikker?',
-                                    text: "Arrangementet og underliggende aktiviteter vil bli fjernet, og kan ikke hentes tilbake.",
-                                    icon: 'warning',
-                                    showCancelButton: true,
-                                    confirmButtonColor: '#3085d6',
-                                    cancelButtonColor: '#d33',
-                                    confirmButtonText: 'Ja',
-                                    cancelButtonText: 'Avbryt'
-                                }).then((result) => {
-                                    if (result.isConfirmed) {
-                                        var slug = _this._findSlugFromEl(opt.$trigger[0]);
-                                        fetch('/arrangement/arrangement/delete/' + slug, {
-                                            method: 'DELETE',
-                                            headers: {
-                                                "X-CSRFToken": this.csrf_token
-                                            }
-                                        }).then(_ => { 
-                                            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
-                                        });
-                                    }
-                                })
-                            }
-                        },
-                        delete_event: {
-                            name: "Slett aktivitet",
-                            callback: (key, opt) => {
-                                Swal.fire({
-                                    title: 'Er du sikker?',
-                                    text: "Hendelsen kan ikke hentes tilbake.",
-                                    icon: 'warning',
-                                    showCancelButton: true,
-                                    confirmButtonColor: '#3085d6',
-                                    cancelButtonColor: '#d33',
-                                    confirmButtonText: 'Ja',
-                                    cancelButtonText: 'Avbryt'
-                                }).then((result) => {
-                                    if (result.isConfirmed) {
-                                        var pk = _this._findEventPkFromEl(opt.$trigger[0]);
-
-                                        var formData = new FormData();
-                                        formData.append("eventIds", String(pk));
-
-                                        fetch('/arrangement/planner/delete_events/', {
-                                            method: 'POST',
-                                            body: formData,
-                                            headers: {
-                                                "X-CSRFToken": this.csrf_token,
-                                            }
-                                        }).then(_ => { 
-                                            document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
-                                        });
-                                    }
-                                })
-                            }
+                    if (dateInfo.view.type == "timelineMonth" || dateInfo.view.type == "customTimelineMonth" || dateInfo.view.type == "dayGridMonth" || dateInfo.view.type == "customTimeGridMonth") {
+                        console.log(dateInfo);
+                        var monthIndex = dateInfo.start.getMonth();
+                        if (dateInfo.start.getDate() !== 1) {
+                            monthIndex++;
+                        }
+                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
+                    }
+                },
+                customButtons: {
+                    filterButton: {
+                        text: 'Filtrering',
+                        click: () => {
+                            this.filterDialog.openFilterDialog();
+                        }
+                    },
+                    arrangementsCalendarButton: {
+                        text: 'Arrangementer',
+                        click: () => {
+                            $('#overview-tab')[0].click();
+                        }
+                    },
+                    locationsCalendarButton: {
+                        text: 'Lokasjoner',
+                        click: () => {
+                            $('#locations-tab')[0].click();
+                        }
+                    },
+                    peopleCalendarButton: {
+                        text: 'Personer',
+                        click: () => {
+                            $('#people-tab')[0].click();
                         }
                     }
-                });
-            }
-        });
+                },
+                headerToolbar: { left: 'arrangementsCalendarButton,locationsCalendarButton,peopleCalendarButton' , center: 'customTimeGridMonth,timeGridDay,dayGridMonth,timeGridWeek,customTimelineMonth,customTimelineYear', },
+                eventSources: [
+                    {
+                        events: async (start, end, startStr, endStr, timezone) => {
+                            return await _this._ARRANGEMENT_STORE._refreshStore(start, end)
+                                .then(_ => this.calendarFilter.getFilteredSlugs().map( function (slug) { return { id: slug, name: "" } }))
+                                .then(filterSet => _this._ARRANGEMENT_STORE.get_all(
+                                    { 
+                                        get_as: _FC_EVENT, 
+                                        locations: this.$locationFilterSelectEl.val(),
+                                        arrangement_types: this.$arrangementTypeFilterSelectEl.val(),
+                                        audience_types: this.$audienceTypeFilterSelectEl.val(),
+                                        filterSet: filterSet
+                                    }
+                                ));
+                        },
+                    }
+                ],
+
+                eventDidMount: (arg) => {
+                    this._bindPopover(arg.el);
+                    this._bindInspectorTrigger(arg.el);
+
+                    $.contextMenu({
+                        className: "",
+                        selector: ".fc-event",
+                        items: {
+                            arrangement_inspector: {
+                                name: "Inspiser arrangement",
+                                callback: (key, opt) => {
+                                    var pk = _this._findEventPkFromEl(opt.$trigger[0]);
+                                    var arrangement = _this._ARRANGEMENT_STORE.get({
+                                        pk: pk,
+                                        get_as: _NATIVE_ARRANGEMENT
+                                    });
+                            
+                                    this.arrangementInspectorUtility.inspect(arrangement);
+                                }
+                            },
+                            event_inspector: {
+                                name: "Inspiser tidspunkt",
+                                callback: (key, opt) => {
+                                    var pk = _this._findEventPkFromEl(opt.$trigger[0]);
+                                    this.eventInspectorUtility.inspect(pk);
+                                }
+                            },
+                            "section_sep_1": "---------",
+                            delete_arrangement: {
+                                name: "Slett arrangement",
+                                callback: (key, opt) => {
+                                    Swal.fire({
+                                        title: 'Er du sikker?',
+                                        text: "Arrangementet og underliggende aktiviteter vil bli fjernet, og kan ikke hentes tilbake.",
+                                        icon: 'warning',
+                                        showCancelButton: true,
+                                        confirmButtonColor: '#3085d6',
+                                        cancelButtonColor: '#d33',
+                                        confirmButtonText: 'Ja',
+                                        cancelButtonText: 'Avbryt'
+                                    }).then((result) => {
+                                        if (result.isConfirmed) {
+                                            var slug = _this._findSlugFromEl(opt.$trigger[0]);
+                                            fetch('/arrangement/arrangement/delete/' + slug, {
+                                                method: 'DELETE',
+                                                headers: {
+                                                    "X-CSRFToken": this.csrf_token
+                                                }
+                                            }).then(_ => { 
+                                                document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                                            });
+                                        }
+                                    })
+                                }
+                            },
+                            delete_event: {
+                                name: "Slett aktivitet",
+                                callback: (key, opt) => {
+                                    Swal.fire({
+                                        title: 'Er du sikker?',
+                                        text: "Hendelsen kan ikke hentes tilbake.",
+                                        icon: 'warning',
+                                        showCancelButton: true,
+                                        confirmButtonColor: '#3085d6',
+                                        cancelButtonColor: '#d33',
+                                        confirmButtonText: 'Ja',
+                                        cancelButtonText: 'Avbryt'
+                                    }).then((result) => {
+                                        if (result.isConfirmed) {
+                                            var pk = _this._findEventPkFromEl(opt.$trigger[0]);
+
+                                            var formData = new FormData();
+                                            formData.append("eventIds", String(pk));
+
+                                            fetch('/arrangement/planner/delete_events/', {
+                                                method: 'POST',
+                                                body: formData,
+                                                headers: {
+                                                    "X-CSRFToken": this.csrf_token,
+                                                }
+                                            }).then(_ => { 
+                                                document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")); // Tell the planner calendar that it needs to refresh the event set
+                                            });
+                                        }
+                                    })
+                                }
+                            }
+                        }
+                    });
+                }
+            })
+        }
+        else {
+            // initialView = this._fcCalendar.view.type;
+            this._fcCalendar.refetchEvents();
+        }
 
         this._fcCalendar.render();
     }

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -75,6 +75,10 @@ export class PlannerCalendar extends FullCalendarBased {
         this._listenToInspectEvent();
     }
 
+    getFcCalendar() {
+        return this._fcCalendar;
+    }
+
     _listenToRefreshEvents() {
         document.addEventListener("plannerCalendar.refreshNeeded", async () => {
             await this.init();

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -6,12 +6,7 @@ import {
 } from "./commonLib.js";
 import { EventInspector } from "./eventInspector.js";
 import { FilterDialog } from "./filterDialog.js";
-
-
-
-const monthNames = ["Januar", "Februar", "Mars", "April", "Mai", "Juni",
-  "Juli", "August", "September", "Oktober", "November", "Desember"
-];
+import { monthNames } from "./monthNames.js";
 
 
 export class PlannerCalendar extends FullCalendarBased {

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -497,6 +497,10 @@
                 plannerCalendar.refresh();
             });
 
+            $('#dateNavigationPicker').on("change", function () {
+                
+            })
+
             document.addEventListener('zenmode.activated', (event) => {
                 plannerCalendar.refresh();
             })

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -67,8 +67,8 @@
     <div class="col-2">
         <div  id="plannerCalendarFilter">
             <div class="form-outline datepicker">
-                <input type="text" class="form-control form-control-lg" id="exampleDatepicker11" />
-                <label for="exampleDatepicker11" class="form-label">Dato</label>
+                <input type="text" class="form-control form-control-lg" id="dateNavigationPicker" />
+                <label for="dateNavigationPicker" class="form-label">Dato</label>
               </div>
         </div>
 

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -65,9 +65,9 @@
 
 <div class="row">
     <div class="col-2">
-        <div  id="plannerCalendarFilter">
+        <div  id="dateNavigationPicker">
             <div class="form-outline datepicker">
-                <input type="text" class="form-control form-control-lg" id="dateNavigationPicker" />
+                <input type="text" class="form-control form-control-lg" />
                 <label for="dateNavigationPicker" class="form-label">Dato</label>
               </div>
         </div>
@@ -290,46 +290,46 @@
         import { PlannerCalendarFilter } from "{% static 'modules/planner/plannerCalendarFilter.js' %}";
 
         var colorSwatch = [
-    "#63b598", "#ce7d78", "#ea9e70", "#a48a9e", "#c6e1e8", "#648177", "#0d5ac1",
-    "#f205e6", "#1c0365", "#14a9ad", "#4ca2f9", "#a4e43f", "#d298e2", "#6119d0",
-    "#d2737d", "#c0a43c", "#f2510e", "#651be6", "#79806e", "#61da5e", "#cd2f00",
-    "#9348af", "#01ac53", "#c5a4fb", "#996635", "#b11573", "#4bb473", "#75d89e",
-    "#2f3f94", "#2f7b99", "#da967d", "#34891f", "#b0d87b", "#ca4751", "#7e50a8",
-    "#c4d647", "#e0eeb8", "#11dec1", "#289812", "#566ca0", "#ffdbe1", "#2f1179",
-    "#935b6d", "#916988", "#513d98", "#aead3a", "#9e6d71", "#4b5bdc", "#0cd36d",
-    "#250662", "#cb5bea", "#228916", "#ac3e1b", "#df514a", "#539397", "#880977",
-    "#f697c1", "#ba96ce", "#679c9d", "#c6c42c", "#5d2c52", "#48b41b", "#e1cf3b",
-    "#5be4f0", "#57c4d8", "#a4d17a", "#be608b", "#96b00c", "#088baf", "#f158bf",
-    "#e145ba", "#ee91e3", "#05d371", "#5426e0", "#4834d0", "#802234", "#6749e8",
-    "#0971f0", "#8fb413", "#b2b4f0", "#c3c89d", "#c9a941", "#41d158", "#fb21a3",
-    "#51aed9", "#5bb32d", "#21538e", "#89d534", "#d36647", "#7fb411", "#0023b8",
-    "#3b8c2a", "#986b53", "#f50422", "#983f7a", "#ea24a3", "#79352c", "#521250",
-    "#c79ed2", "#d6dd92", "#e33e52", "#b2be57", "#fa06ec", "#1bb699", "#6b2e5f",
-    "#64820f", "#21538e", "#89d534", "#d36647", "#7fb411", "#0023b8", "#3b8c2a",
-    "#986b53", "#f50422", "#983f7a", "#ea24a3", "#79352c", "#521250", "#c79ed2",
-    "#d6dd92", "#e33e52", "#b2be57", "#fa06ec", "#1bb699", "#6b2e5f", "#64820f",
-    "#9cb64a", "#996c48", "#9ab9b7", "#06e052", "#e3a481", "#0eb621", "#fc458e",
-    "#b2db15", "#aa226d", "#792ed8", "#73872a", "#520d3a", "#cefcb8", "#a5b3d9",
-    "#7d1d85", "#c4fd57", "#f1ae16", "#8fe22a", "#ef6e3c", "#243eeb", "#dd93fd",
-    "#3f8473", "#e7dbce", "#421f79", "#7a3d93", "#635f6d", "#93f2d7", "#9b5c2a",
-    "#15b9ee", "#0f5997", "#409188", "#911e20", "#1350ce", "#10e5b1", "#fff4d7",
-    "#cb2582", "#ce00be", "#32d5d6", "#608572", "#c79bc2", "#00f87c", "#77772a",
-    "#6995ba", "#fc6b57", "#f07815", "#8fd883", "#060e27", "#96e591", "#21d52e",
-    "#d00043", "#b47162", "#1ec227", "#4f0f6f", "#1d1d58", "#947002", "#bde052",
-    "#e08c56", "#28fcfd", "#36486a", "#d02e29", "#1ae6db", "#3e464c", "#a84a8f",
-    "#911e7e", "#3f16d9", "#0f525f", "#ac7c0a", "#b4c086", "#c9d730", "#30cc49",
-    "#3d6751", "#fb4c03", "#640fc1", "#62c03e", "#d3493a", "#88aa0b", "#406df9",
-    "#615af0", "#2a3434", "#4a543f", "#79bca0", "#a8b8d4", "#00efd4", "#7ad236",
-    "#7260d8", "#1deaa7", "#06f43a", "#823c59", "#e3d94c", "#dc1c06", "#f53b2a",
-    "#b46238", "#2dfff6", "#a82b89", "#1a8011", "#436a9f", "#1a806a", "#4cf09d",
-    "#c188a2", "#67eb4b", "#b308d3", "#fc7e41", "#af3101", "#71b1f4", "#a2f8a5",
-    "#e23dd0", "#d3486d", "#00f7f9", "#474893", "#3cec35", "#1c65cb", "#5d1d0c",
-    "#2d7d2a", "#ff3420", "#5cdd87", "#a259a4", "#e4ac44", "#1bede6", "#8798a4",
-    "#d7790f", "#b2c24f", "#de73c2", "#d70a9c", "#88e9b8", "#c2b0e2", "#86e98f",
-    "#ae90e2", "#1a806b", "#436a9e", "#0ec0ff", "#f812b3", "#b17fc9", "#8d6c2f",
-    "#d3277a", "#2ca1ae", "#9685eb", "#8a96c6", "#dba2e6", "#76fc1b", "#608fa4",
-    "#20f6ba", "#07d7f6", "#dce77a", "#77ecca"
-]
+            "#63b598", "#ce7d78", "#ea9e70", "#a48a9e", "#c6e1e8", "#648177", "#0d5ac1",
+            "#f205e6", "#1c0365", "#14a9ad", "#4ca2f9", "#a4e43f", "#d298e2", "#6119d0",
+            "#d2737d", "#c0a43c", "#f2510e", "#651be6", "#79806e", "#61da5e", "#cd2f00",
+            "#9348af", "#01ac53", "#c5a4fb", "#996635", "#b11573", "#4bb473", "#75d89e",
+            "#2f3f94", "#2f7b99", "#da967d", "#34891f", "#b0d87b", "#ca4751", "#7e50a8",
+            "#c4d647", "#e0eeb8", "#11dec1", "#289812", "#566ca0", "#ffdbe1", "#2f1179",
+            "#935b6d", "#916988", "#513d98", "#aead3a", "#9e6d71", "#4b5bdc", "#0cd36d",
+            "#250662", "#cb5bea", "#228916", "#ac3e1b", "#df514a", "#539397", "#880977",
+            "#f697c1", "#ba96ce", "#679c9d", "#c6c42c", "#5d2c52", "#48b41b", "#e1cf3b",
+            "#5be4f0", "#57c4d8", "#a4d17a", "#be608b", "#96b00c", "#088baf", "#f158bf",
+            "#e145ba", "#ee91e3", "#05d371", "#5426e0", "#4834d0", "#802234", "#6749e8",
+            "#0971f0", "#8fb413", "#b2b4f0", "#c3c89d", "#c9a941", "#41d158", "#fb21a3",
+            "#51aed9", "#5bb32d", "#21538e", "#89d534", "#d36647", "#7fb411", "#0023b8",
+            "#3b8c2a", "#986b53", "#f50422", "#983f7a", "#ea24a3", "#79352c", "#521250",
+            "#c79ed2", "#d6dd92", "#e33e52", "#b2be57", "#fa06ec", "#1bb699", "#6b2e5f",
+            "#64820f", "#21538e", "#89d534", "#d36647", "#7fb411", "#0023b8", "#3b8c2a",
+            "#986b53", "#f50422", "#983f7a", "#ea24a3", "#79352c", "#521250", "#c79ed2",
+            "#d6dd92", "#e33e52", "#b2be57", "#fa06ec", "#1bb699", "#6b2e5f", "#64820f",
+            "#9cb64a", "#996c48", "#9ab9b7", "#06e052", "#e3a481", "#0eb621", "#fc458e",
+            "#b2db15", "#aa226d", "#792ed8", "#73872a", "#520d3a", "#cefcb8", "#a5b3d9",
+            "#7d1d85", "#c4fd57", "#f1ae16", "#8fe22a", "#ef6e3c", "#243eeb", "#dd93fd",
+            "#3f8473", "#e7dbce", "#421f79", "#7a3d93", "#635f6d", "#93f2d7", "#9b5c2a",
+            "#15b9ee", "#0f5997", "#409188", "#911e20", "#1350ce", "#10e5b1", "#fff4d7",
+            "#cb2582", "#ce00be", "#32d5d6", "#608572", "#c79bc2", "#00f87c", "#77772a",
+            "#6995ba", "#fc6b57", "#f07815", "#8fd883", "#060e27", "#96e591", "#21d52e",
+            "#d00043", "#b47162", "#1ec227", "#4f0f6f", "#1d1d58", "#947002", "#bde052",
+            "#e08c56", "#28fcfd", "#36486a", "#d02e29", "#1ae6db", "#3e464c", "#a84a8f",
+            "#911e7e", "#3f16d9", "#0f525f", "#ac7c0a", "#b4c086", "#c9d730", "#30cc49",
+            "#3d6751", "#fb4c03", "#640fc1", "#62c03e", "#d3493a", "#88aa0b", "#406df9",
+            "#615af0", "#2a3434", "#4a543f", "#79bca0", "#a8b8d4", "#00efd4", "#7ad236",
+            "#7260d8", "#1deaa7", "#06f43a", "#823c59", "#e3d94c", "#dc1c06", "#f53b2a",
+            "#b46238", "#2dfff6", "#a82b89", "#1a8011", "#436a9f", "#1a806a", "#4cf09d",
+            "#c188a2", "#67eb4b", "#b308d3", "#fc7e41", "#af3101", "#71b1f4", "#a2f8a5",
+            "#e23dd0", "#d3486d", "#00f7f9", "#474893", "#3cec35", "#1c65cb", "#5d1d0c",
+            "#2d7d2a", "#ff3420", "#5cdd87", "#a259a4", "#e4ac44", "#1bede6", "#8798a4",
+            "#d7790f", "#b2c24f", "#de73c2", "#d70a9c", "#88e9b8", "#c2b0e2", "#86e98f",
+            "#ae90e2", "#1a806b", "#436a9e", "#0ec0ff", "#f812b3", "#b17fc9", "#8d6c2f",
+            "#d3277a", "#2ca1ae", "#9685eb", "#8a96c6", "#dba2e6", "#76fc1b", "#608fa4",
+            "#20f6ba", "#07d7f6", "#dce77a", "#77ecca"
+        ]
 
         function _listenToLocationCheckboxes () {
             var checkboxes = document.querySelectorAll("input[type=checkbox][name=filterLocationsCheckboxArray]");
@@ -438,10 +438,10 @@
         }
 
         var arrangementCreator;
+        var activeCalendar;
+        var activeDate = new Date();
 
         document.addEventListener('DOMContentLoaded', function() {
-
-
             arrangementCreator = new ArrangementCreator();
             _listenToLocationCheckboxes();
             $('#newArrangementBtn').on('click', () => {
@@ -490,6 +490,8 @@
 
             });
 
+            activeCalendar = plannerCalendar; // default active calendar
+
             var mainCalendarFilterWrapper = $('#plannerCalendarFilter');
             
             $('#calendarFocusSelect').on("change", function () {
@@ -497,23 +499,52 @@
                 plannerCalendar.refresh();
             });
 
-            $('#dateNavigationPicker').on("change", function () {
-                
-            })
+            // new mdb.Datepicker(document.getElementById('dateNavigationPicker'))
+
+            document.getElementById('dateNavigationPicker').addEventListener('dateChange.mdb.datepicker', (e) => {
+                console.log("dateChange.mdb.datepicker", e)
+                activeCalendar.getFcCalendar().gotoDate(e.date);
+                activeDate = e.date;
+            });
 
             document.addEventListener('zenmode.activated', (event) => {
                 plannerCalendar.refresh();
             })
 
+            document.addEventListener('plannerCalendar.calendarChange', function (e) {
+                console.log("PLANNERCALENDAR.CALENDARCHANGE", activeDate, e.detail)
+                activeCalendar = e.detail.changeTo;
+                console.log("One of a kind;", activeDate)
+                activeCalendar.getFcCalendar().gotoDate(activeDate);
+            })
+
             $('#overview-tab')[0].addEventListener('shown.mdb.tab', (event) => {
+                document.dispatchEvent(new CustomEvent('plannerCalendar.calendarChange', {
+                    detail: {
+                        changeTo: plannerCalendar
+                    }
+                }));
+
                 mainCalendarFilterWrapper.show();
-                plannerCalendar.refresh();
+                // plannerCalendar.refresh();
             })
             $('#locations-tab')[0].addEventListener('shown.mdb.tab', (event) => {
+                document.dispatchEvent(new CustomEvent('plannerCalendar.calendarChange', {
+                    detail: {
+                        changeTo: locationsCalendar
+                    }
+                }));
+
                 mainCalendarFilterWrapper.hide();
                 locationsCalendar.refresh();
             })
             $('#people-tab')[0].addEventListener('shown.mdb.tab', (event) => {
+                document.dispatchEvent(new CustomEvent('plannerCalendar.calendarChange', {
+                    detail: {
+                        changeTo: peopleCalendar
+                    }
+                }));
+
                 mainCalendarFilterWrapper.hide();
                 peopleCalendar.refresh();
             })


### PR DESCRIPTION
### Implement date navigation in planner calendar

This PR introduces date navigation functionality in the calendar. This in practice means you can navigate in the calendar via the datepicker utility, which is useful when one needs to go far back or forward in time, in which case the +1/-1 arrow navigation is not optimal.
I also encountered some weird inconsistencies that I resolved with the refreshing logic of the calendars. The location and person calendars did not heed the plannerCalendar.refreshNeeded event, and as thus would not refresh on event creation, ergo not showing new events as they are made. This should be fine now. 

So, for the changelog;
1. Introduced date navigation functionality (made the datepicker up top left in the planner calendar actually do something)
2. Fixed a bug where only the plannercalendar would have events refetched after the refresh call has been made (like for example after creating an arrangement). Now all (Planner, Location, People) calendars should have their events refetched when a refetch event is raised.

![image](https://user-images.githubusercontent.com/62013916/172837532-4005858e-69b2-4fee-972a-c57ea4fdaa63.png)
