### PR TITLE
Use to localestring to get monthnames

### DIFF
--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -1,7 +1,5 @@
-import { FullCalendarEvent, StandardColorProvider, _FC_EVENT, ArrangementStore, FullCalendarResource, FullCalendarBased, LocationStore, _FC_RESOURCE } from "./commonLib.js";
+import { ArrangementStore, FullCalendarBased, LocationStore, StandardColorProvider, _FC_EVENT, _FC_RESOURCE } from "./commonLib.js";
 
-import { PlannerCalendarFilter } from "./plannerCalendarFilter.js";
-import { monthNames } from "./monthNames.js";
 
 
 export class LocationCalendar extends FullCalendarBased {
@@ -130,7 +128,7 @@ export class LocationCalendar extends FullCalendarBased {
                         if (dateInfo.start.getDate() !== 1) {
                             monthIndex++;
                         }
-                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
+                        $('#plannerCalendarHeader').text(`${dateInfo.start.toLocaleString('default', { month: 'long' })} ${dateInfo.start.getFullYear()}`)
                     }
                 },
                 resources: async (fetchInfo, successCallback, failureCallback) => {

--- a/webook/static/modules/planner/monthNames.js
+++ b/webook/static/modules/planner/monthNames.js
@@ -1,8 +1,0 @@
-
-/* 
-    This should in time be replaced with a back-end endpoint returning JSON, allowing for easy translations.
-*/
-
-export const monthNames = ["Januar", "Februar", "Mars", "April", "Mai", "Juni",
-"Juli", "August", "September", "Oktober", "November", "Desember"
-];

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -1,5 +1,4 @@
 import { ArrangementStore, FullCalendarBased, PersonStore, StandardColorProvider, _FC_EVENT, _FC_RESOURCE } from "./commonLib.js";
-import { monthNames } from "./monthNames.js";
 
 export class PersonCalendar extends FullCalendarBased {
 
@@ -109,7 +108,7 @@ export class PersonCalendar extends FullCalendarBased {
                         if (dateInfo.start.getDate() !== 1) {
                             monthIndex++;
                         }
-                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
+                        $('#plannerCalendarHeader').text(`${dateInfo.start.toLocaleString('default', { month: 'long' })} ${dateInfo.start.getFullYear()}`)
                     }
                 },
                 resources: async (fetchInfo, successCallback, failureCallback) => {

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -6,7 +6,6 @@ import {
 } from "./commonLib.js";
 import { EventInspector } from "./eventInspector.js";
 import { FilterDialog } from "./filterDialog.js";
-import { monthNames } from "./monthNames.js";
 
 
 export class PlannerCalendar extends FullCalendarBased {
@@ -262,7 +261,7 @@ export class PlannerCalendar extends FullCalendarBased {
                         if (dateInfo.start.getDate() !== 1) {
                             monthIndex++;
                         }
-                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
+                        $('#plannerCalendarHeader').text(`${dateInfo.start.toLocaleString('default', { month: 'long' })} ${dateInfo.start.getFullYear()}`)
                     }
                 },
                 customButtons: {


### PR DESCRIPTION
### Use `toLocaleString()` to get month names

Previously in the calendars we used a hardcoded array to get the month names. This was a naive solution, and JS already has a very good utility for this (date.toLocaleString()) which can give us the month name in the users locale. I have changed the get month logic to use toLocaleString and removed the monthNames.js file which only served the purpose of storing the array.