### PR TITLE
Implement better and more modular handling of header generation for calendar views

### DIFF
--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -80,7 +80,7 @@ export class ArrangementCreator {
                             var registerSerie = async function (serie, arrangementId, csrf_token, ticket_code) {
                                 var events = SeriesUtil.calculate_serie(serie);
                                 var formData = new FormData();
-                                
+
                                 formData = serieConvert(serie, formData);
 
                                 for (let i = 0; i < events.length; i++) {
@@ -178,7 +178,13 @@ export class ArrangementCreator {
                             if (details.serie._uuid === undefined) {
                                 details.serie._uuid = crypto.randomUUID();
                             }
+
                             
+                            var serieFData = serieConvert(details.serie, new FormData(), "");
+                            for (var pair of serieFData.entries()) {
+                                console.log(pair[0]+ ', ' + pair[1]); 
+                            }
+
                             details.serie.collisions = await CollisionsUtil.GetCollisionsForSerie(serieConvert(details.serie, new FormData(), ""), details.csrf_token);
                             context.series.set(details.serie._uuid, details.serie);
                             document.dispatchEvent(new CustomEvent(this.dialogManager.managerName + ".contextUpdated", { detail: { context: context } }))

--- a/webook/static/modules/planner/calendar_utilities/header_generator.js
+++ b/webook/static/modules/planner/calendar_utilities/header_generator.js
@@ -1,0 +1,197 @@
+/**
+ * header_generator.js
+ * Utility for generating friendly and informative headers, based on the FullCalendar view.
+ */
+
+export class ViewClassifiers {
+    static YEAR = Symbol("year");
+    static MONTH = Symbol("month");
+    static WEEK = Symbol("week");
+    static DAY  = Symbol("day");
+}
+
+class StandardGenerator {
+    CLASSIFIER_MAP = new Map([
+        [ViewClassifiers.YEAR, this.year],
+        [ViewClassifiers.MONTH, this.month],
+        [ViewClassifiers.WEEK, this.week],
+        [ViewClassifiers.DAY, this.day],
+    ])
+
+    generate(classifier, date) {
+        if (date instanceof Date === false) {
+            throw "Not a valid date";
+        }
+        if (this.CLASSIFIER_MAP.has(classifier) === false) {
+            throw "Classifier not recognized";
+        }
+
+        var gen_func = this.CLASSIFIER_MAP.get(classifier);
+        
+        if (gen_func instanceof Function === false) {
+            throw "Generation function retrieved from CLASSIFIER_MAP is not a valid callable function.";
+        }
+
+        return gen_func(date);
+    }
+
+    year (date) {
+        return `${date.getFullYear()}`;
+    }
+
+    month(date) {
+        if (date.getDate() !== 1) {
+            date = new Date(date.setMonth(date.getMonth() + 1));
+        }
+
+        var text = `${date.toLocaleString("default", { month: "long" })} ${date.getFullYear()}`;
+        text = text.replace(/^./, text[0].toUpperCase());
+        return text;
+    }
+
+    week(date) {
+        // Refer to: https://stackoverflow.com/questions/9045868/javascript-date-getweek
+        /*getWeek() was developed by Nick Baicoianu at MeanFreePath: http://www.meanfreepath.com */
+        var newYear = new Date(date.getFullYear(),0,1);
+        var day = newYear.getDay(); //the day of week the year begins on
+        day = (day >= 0 ? day : day + 7);
+        var daynum = Math.floor((date.getTime() - newYear.getTime() - 
+        (date.getTimezoneOffset()-newYear.getTimezoneOffset())*60000)/86400000) + 1;
+        var weeknum;
+        //if the year starts before the middle of a week
+        if(day < 4) {
+            weeknum = Math.floor((daynum+day-1)/7) + 1;
+            if(weeknum > 52) {
+                var nYear = new Date(date.getFullYear() + 1,0,1);
+                var nday = nYear.getDay();
+                nday = nday >= 0 ? nday : nday + 7;
+                /*if the next year starts before the middle of
+                    the week, it is week #1 of that year*/
+                weeknum = nday < 4 ? 1 : 53;
+            }
+        }
+        else {
+            weeknum = Math.floor((daynum+day-1)/7);
+        }
+
+        return `Uke ${weeknum}, ${date.toLocaleString("default", { month: "long"})} ${date.getFullYear()}`;
+    }
+
+    day(date) {
+        return [
+            String(date.getDate()).padStart(2, "0"),
+            String(date.getMonth()).padStart(2, "0"),
+            date.getFullYear(),
+        ].join(".");
+    }
+
+    _getWeekOfYearFromDate(date, dowOffset) {
+
+
+        return weeknum;
+    }
+}
+
+var BaseViewClassifications = new Map([
+    /* DayGrid */
+    [
+        "dayGridDay",
+        ViewClassifiers.DAY
+    ],
+    [
+        "dayGridWeek",
+        ViewClassifiers.WEEK
+    ],
+    [
+        "dayGridMonth",
+        ViewClassifiers.MONTH
+    ],
+    /* List */
+    [
+        "listDay",
+        ViewClassifiers.DAY
+    ],
+    [
+        "listWeek",
+        ViewClassifiers.WEEK
+    ],
+    [
+        "listMonth",
+        ViewClassifiers.MONTH
+    ],
+    [
+        "listYear",
+        ViewClassifiers.YEAR
+    ],
+    /* Timegrid */
+    [
+        "timeGridDay",
+        ViewClassifiers.DAY
+    ],
+    [
+        "timeGridWeek",
+        ViewClassifiers.WEEK,
+    ],
+    /* Timeline */
+    [
+        "timelineDay",
+        ViewClassifiers.DAY
+    ],
+    [
+        "timelineWeek",
+        ViewClassifiers.WEEK
+    ],
+    [
+        "timelineMonth",
+        ViewClassifiers.MONTH
+    ],
+    [
+        "timelineYear",
+        ViewClassifiers.YEAR
+    ],
+    /* Resourcetimeline */
+    [
+        "resourceTimelineDay",
+        ViewClassifiers.DAY
+    ],
+    [
+        "resourceTimelineWeek",
+        ViewClassifiers.WEEK
+    ],
+    [
+        "resourceTimelineMonth",
+        ViewClassifiers.MONTH
+    ],
+    [
+        "resourceTimelineYear",
+        ViewClassifiers.YEAR
+    ]
+]);
+
+export class HeaderGenerator {
+    constructor({ generator, customClassifications = undefined } = {}) {
+        if (generator instanceof StandardGenerator === false) {
+            if (generator !== undefined) {
+                console.warn("Given generator is not an instance of StandardGenerator.");
+            }
+
+            this.generator = new StandardGenerator();
+        }
+        else {
+            this.generator = generator;
+        }
+
+        this.classifiers = BaseViewClassifications;
+
+        if (customClassifications instanceof Map) {
+            this.classifiers = new Map( [...this.classifiers].concat([...customClassifications]) );
+        }
+    }
+
+    generate(viewName, date) {
+        return this.generator.generate(
+            this.classifiers.get(viewName),
+            date,
+        );
+    }
+}

--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -1,7 +1,5 @@
-import { FullCalendarEvent, StandardColorProvider, _FC_EVENT, ArrangementStore, FullCalendarResource, FullCalendarBased, LocationStore, _FC_RESOURCE } from "./commonLib.js";
-
-import { PlannerCalendarFilter } from "./plannerCalendarFilter.js";
-import { monthNames } from "./monthNames.js";
+import { HeaderGenerator } from "./calendar_utilities/header_generator.js";
+import { ArrangementStore, FullCalendarBased, LocationStore, StandardColorProvider, _FC_EVENT, _FC_RESOURCE } from "./commonLib.js";
 
 
 export class LocationCalendar extends FullCalendarBased {
@@ -12,6 +10,8 @@ export class LocationCalendar extends FullCalendarBased {
         this._fcCalendar = undefined;
         this._calendarElement = calendarElement;
         this.calendarFilter = calendarFilter;
+
+        this._headerGenerator = new HeaderGenerator();
 
         this._colorProviders = new Map();
         this._colorProviders.set("DEFAULT", new StandardColorProvider());
@@ -125,13 +125,10 @@ export class LocationCalendar extends FullCalendarBased {
                     $('#plannerCalendarHeader').text("");
                     $(".popover").popover('hide');
     
-                    if (dateInfo.view.type == "resourceTimelineMonth") {
-                        var monthIndex = dateInfo.start.getMonth();
-                        if (dateInfo.start.getDate() !== 1) {
-                            monthIndex++;
-                        }
-                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
-                    }
+                    $('#plannerCalendarHeader').text(this._headerGenerator.generate(
+                        dateInfo.view.type,
+                        dateInfo.start,
+                    ));
                 },
                 resources: async (fetchInfo, successCallback, failureCallback) => {
                     await _this._LOCATIONS_STORE._refreshStore();

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -1,5 +1,6 @@
+import { HeaderGenerator } from "./calendar_utilities/header_generator.js";
 import { ArrangementStore, FullCalendarBased, PersonStore, StandardColorProvider, _FC_EVENT, _FC_RESOURCE } from "./commonLib.js";
-import { monthNames } from "./monthNames.js";
+
 
 export class PersonCalendar extends FullCalendarBased {
 
@@ -8,6 +9,8 @@ export class PersonCalendar extends FullCalendarBased {
 
         this._fcCalendar = undefined;
         this._calendarElement = calendarElement;
+        
+        this._headerGenerator = new HeaderGenerator();
         
         this._colorProviders = new Map();
         this._colorProviders.set("DEFAULT", new StandardColorProvider());
@@ -104,13 +107,10 @@ export class PersonCalendar extends FullCalendarBased {
                     $('#plannerCalendarHeader').text("");
                     $(".popover").popover('hide');
     
-                    if (dateInfo.view.type == "resourceTimelineMonth") {
-                        var monthIndex = dateInfo.start.getMonth();
-                        if (dateInfo.start.getDate() !== 1) {
-                            monthIndex++;
-                        }
-                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
-                    }
+                    $('#plannerCalendarHeader').text(this._headerGenerator.generate(
+                        dateInfo.view.type,
+                        dateInfo.start,
+                    ));
                 },
                 resources: async (fetchInfo, successCallback, failureCallback) => {
                     await _this._STORE._refreshStore();

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -1,4 +1,5 @@
 import { ArrangementInspector } from "./arrangementInspector.js";
+import { HeaderGenerator, ViewClassifiers } from "./calendar_utilities/header_generator.js";
 import {
     ArrangementStore, FullCalendarBased, LocationStore,
     PersonStore, StandardColorProvider, _FC_EVENT,
@@ -6,7 +7,6 @@ import {
 } from "./commonLib.js";
 import { EventInspector } from "./eventInspector.js";
 import { FilterDialog } from "./filterDialog.js";
-import { monthNames } from "./monthNames.js";
 
 
 export class PlannerCalendar extends FullCalendarBased {
@@ -25,6 +25,15 @@ export class PlannerCalendar extends FullCalendarBased {
         super();
 
         this.csrf_token = csrf_token;
+        
+        this._headerGenerator = new HeaderGenerator(
+            { customClassifications: new Map([
+                [ "customTimeGridMonth", ViewClassifiers.MONTH ],
+                [ "calendarDayGridMonth", ViewClassifiers.MONTH ],
+                [ "customTimelineMonth", ViewClassifiers.MONTH ],
+                [ "customTimelineYear", ViewClassifiers.YEAR ]
+            ]) }
+        );
         
         this._fcLicenseKey = licenseKey;
         this._fcCalendar = undefined;
@@ -256,14 +265,12 @@ export class PlannerCalendar extends FullCalendarBased {
                     $('#plannerCalendarHeader').text("");
                     $(".popover").popover('hide');
 
-                    if (dateInfo.view.type == "timelineMonth" || dateInfo.view.type == "customTimelineMonth" || dateInfo.view.type == "dayGridMonth" || dateInfo.view.type == "customTimeGridMonth") {
-                        console.log(dateInfo);
-                        var monthIndex = dateInfo.start.getMonth();
-                        if (dateInfo.start.getDate() !== 1) {
-                            monthIndex++;
-                        }
-                        $('#plannerCalendarHeader').text(`${monthNames[monthIndex]} ${dateInfo.start.getFullYear()}`)
-                    }
+                    console.log("dateinfo", dateInfo)
+
+                    $('#plannerCalendarHeader').text(this._headerGenerator.generate(
+                        dateInfo.view.type,
+                        dateInfo.start,
+                    ));
                 },
                 customButtons: {
                     filterButton: {


### PR DESCRIPTION
### Implement better and more modular handling of header generation for calendar views

This PR introduces a new approach to handling header generation for the various calendar views. The old approach was not DRY (ended up having to repeat header/title generation) for similar view types. So I decided to make a small module that can handle this for us, and be extensible in the case of custom views. The latter is not really used, since even with custom views FullCalendar supplies the name of the view that the custom view is based on. For our purposes this is completely acceptable. But should it become necessary to have custom title generation for a custom view then this can be done entirely on the consumer side, while still not repeating the "base" standard header generations that apply to FC default/inbuilt views.

