### PR TITLE
Fix bug where popover would remain after refresh

### DIFF
--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -121,6 +121,11 @@ export class LocationCalendar extends FullCalendarBased {
                         },
                     }
                 ],
+                loading: function( isLoading ) {
+                    if (isLoading === false) {
+                        $(".popover").popover('hide');
+                    }
+                },
                 datesSet: (dateInfo) => {
                     $('#plannerCalendarHeader').text("");
                     $(".popover").popover('hide');

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -102,6 +102,11 @@ export class PersonCalendar extends FullCalendarBased {
                         },
                     }
                 ],
+                loading: function( isLoading ) {
+                    if (isLoading === false) {
+                        $(".popover").popover('hide');
+                    }
+                },
                 datesSet: (dateInfo) => {
                     $('#plannerCalendarHeader').text("");
                     $(".popover").popover('hide');

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -315,6 +315,11 @@ export class PlannerCalendar extends FullCalendarBased {
                     }
                 ],
 
+                loading: function( isLoading ) {
+                    if (isLoading === false) {
+                        $(".popover").popover('hide');
+                    }
+                },
                 eventDidMount: (arg) => {
                     this._bindPopover(arg.el);
                     this._bindInspectorTrigger(arg.el);


### PR DESCRIPTION
### Fix bug where popover would remain after refresh

This PR fixes a bug where active popovers (shown) would enter a weird orphaned state where they could never be hidden. This happened on refresh, as their "anchors" were removed from underneath them. 
