### PR TITLE
Fix double render bug

### DIFF
--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -10,6 +10,7 @@
         this.onSubmit = onSubmit;
         this.onPreRefresh = onPreRefresh;
         this.dialogOptions = dialogOptions;
+        this._isRendering = false;
     }
 
     _$getDialogEl() {
@@ -18,20 +19,26 @@
 
     async render(context) {
         this.destroy();
-
-        if (this.isOpen() === false) {
-            $('body')
-                .append(await this.htmlFabricator(context))
-                .ready( () => {
-                    this._$getDialogEl().dialog( this.dialogOptions );
-                    this.onRenderedCallback(this, context);
-                    this._$getDialogEl().dialog("widget").find('.ui-dialog-titlebar-close')
-                        .html("<i class='fas fa-times text-danger' style='font-size: 24px'></i>")
-                        .click( () => {
-                            this.destroy();
-                        });
-                    
-                });
+        if (this._isRendering === false) {
+            this._isRendering = true;
+            if (this.isOpen() === false) {
+                $('body')
+                    .append(await this.htmlFabricator(context))
+                    .ready( () => {
+                        this._$getDialogEl().dialog( this.dialogOptions );
+                        this.onRenderedCallback(this, context);
+                        this._$getDialogEl().dialog("widget").find('.ui-dialog-titlebar-close')
+                            .html("<i class='fas fa-times text-danger' style='font-size: 24px'></i>")
+                            .click( () => {
+                                this.destroy();
+                            });
+                        
+                        this._isRendering = false;
+                    });
+            }
+        }
+        else {
+            console.warn("Dialog is already rendering...")
         }
     }
 

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -36,6 +36,9 @@
                         this._isRendering = false;
                     });
             }
+            else {
+                this._isRendering = false;
+            }
         }
         else {
             console.warn("Dialog is already rendering...")


### PR DESCRIPTION
### Fix double render bug

This PR fixes a bug where if one triggered the dialog render event call in a rapid enough succession two dialogs would be rendered. One flat (not in dialog form), and one "active". This fix makes sure that this can not occur, by making sure that only one rendering function can happen at one time.