### PR TITLE
Fix arrangement file upload bug

### DIFF
--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -55,7 +55,8 @@ from webook.arrangement.models import (
     Room,
     RoomPreset,
 )
-from webook.arrangement.views.generic_views.archive_view import ArchiveView
+from webook.arrangement.views.generic_views.archive_view import ArchiveView, JsonArchiveView
+from webook.arrangement.views.generic_views.json_form_view import JsonFormView
 from webook.screenshow.models import DisplayLayout
 from webook.utils.collision_analysis import analyze_collisions
 from webook.utils.json_serial import json_serial
@@ -374,12 +375,9 @@ class PlanGetEvents (LoginRequiredMixin, ListView):
 plan_get_events = PlanGetEvents.as_view()
 
 
-class PlanOrderService(LoginRequiredMixin, FormView):
+class PlanOrderService(LoginRequiredMixin, JsonFormView):
     form_class = LooselyOrderServiceForm
     template_name = "_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_invalid(self, form) -> HttpResponse:
         print(" >> OrderServiceForm invalid")
@@ -443,11 +441,8 @@ class PlanPeopleToRequisitionTableComponent(LoginRequiredMixin, ListView):
 plan_people_to_requisition_component_view = PlanPeopleToRequisitionTableComponent.as_view()
 
 
-class PlanDeleteEvent (LoginRequiredMixin, ArchiveView):
+class PlanDeleteEvent (LoginRequiredMixin, JsonArchiveView):
     model = Event
-    
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
 plan_delete_event = PlanDeleteEvent.as_view()
 
@@ -807,12 +802,9 @@ class PlannerArrangementAddPlannerDialog(LoginRequiredMixin, TemplateView):
 arrangement_add_planner_dialog_view = PlannerArrangementAddPlannerDialog.as_view()
 
 
-class PlannerArrangementAddPlannersFormView (LoginRequiredMixin, FormView):
+class PlannerArrangementAddPlannersFormView (LoginRequiredMixin, JsonFormView):
     form_class=AddPlannersForm
     template_name="_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.save()
@@ -825,12 +817,9 @@ class PlannerArrangementAddPlannersFormView (LoginRequiredMixin, FormView):
 arrangement_add_planners_form_view = PlannerArrangementAddPlannersFormView.as_view()
 
 
-class PlannerArrangementRemovePlannersFormView(LoginRequiredMixin, FormView):
+class PlannerArrangementRemovePlannersFormView(LoginRequiredMixin, JsonFormView):
     form_class=RemovePlannersForm
     template_name="_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.save()
@@ -929,12 +918,9 @@ class PlannerCalendarOrderPersonDialogView(LoginRequiredMixin, TemplateView):
 planner_calendar_order_person_dialog_view = PlannerCalendarOrderPersonDialogView.as_view()
 
 
-class PlannerCalendarOrderPersonForSeriesFormView (LoginRequiredMixin, FormView):
+class PlannerCalendarOrderPersonForSeriesFormView (LoginRequiredMixin, JsonFormView):
     form_class = OrderPersonForSerieForm
     template_name="_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.save()
@@ -947,12 +933,9 @@ class PlannerCalendarOrderPersonForSeriesFormView (LoginRequiredMixin, FormView)
 planner_calendar_order_person_for_series_form_view = PlannerCalendarOrderPersonForSeriesFormView.as_view()
 
 
-class PlannerCalendarOrderRoomsForSeriesFormView (LoginRequiredMixin, FormView):
+class PlannerCalendarOrderRoomsForSeriesFormView (LoginRequiredMixin, JsonFormView):
     form_class = OrderRoomForSerieForm
     template_name="_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.save()
@@ -966,12 +949,9 @@ class PlannerCalendarOrderRoomsForSeriesFormView (LoginRequiredMixin, FormView):
 planner_calendar_order_rooms_for_series_form_view = PlannerCalendarOrderRoomsForSeriesFormView.as_view()
 
 
-class PlannerCalendarOrderRoomForEventFormView(LoginRequiredMixin, FormView):
+class PlannerCalendarOrderRoomForEventFormView(LoginRequiredMixin, JsonFormView):
     form_class = OrderRoomForEventForm
     template_name= "_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.save()
@@ -984,12 +964,9 @@ class PlannerCalendarOrderRoomForEventFormView(LoginRequiredMixin, FormView):
 
 planner_calendar_order_room_for_event_form_view = PlannerCalendarOrderRoomForEventFormView.as_view()
 
-class PlannerCalendarOrderPeopleForEventFormView(LoginRequiredMixin, FormView):
+class PlannerCalendarOrderPeopleForEventFormView(LoginRequiredMixin, JsonFormView):
     form_class = OrderPersonForEventForm
     template_name = "_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.save()
@@ -1003,12 +980,9 @@ class PlannerCalendarOrderPeopleForEventFormView(LoginRequiredMixin, FormView):
 planner_calendar_order_people_for_event_form_view = PlannerCalendarOrderPeopleForEventFormView.as_view()
 
 
-class PlannerCalendarRemovePersonFromEventFormView(LoginRequiredMixin, FormView):
+class PlannerCalendarRemovePersonFromEventFormView(LoginRequiredMixin, JsonFormView):
     form_class = RemovePersonFromEventForm
     template_name = "_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.remove()
@@ -1022,12 +996,9 @@ class PlannerCalendarRemovePersonFromEventFormView(LoginRequiredMixin, FormView)
 planner_calendar_remove_person_from_event_form_view = PlannerCalendarRemovePersonFromEventFormView.as_view()
 
 
-class PlannerCalendarRemoveRoomFromEventFormView(LoginRequiredMixin, FormView):
+class PlannerCalendarRemoveRoomFromEventFormView(LoginRequiredMixin, JsonFormView):
     form_class = RemoveRoomFromEventForm
     template_name = "_blank.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def form_valid(self, form):
         form.remove()
@@ -1041,12 +1012,9 @@ class PlannerCalendarRemoveRoomFromEventFormView(LoginRequiredMixin, FormView):
 planner_calendar_remove_room_from_event_form_view = PlannerCalendarRemoveRoomFromEventFormView.as_view()
 
 
-class PlannerCalendarUploadFileToEventSerieDialog(LoginRequiredMixin, FormView):
+class PlannerCalendarUploadFileToEventSerieDialog(LoginRequiredMixin, JsonFormView):
     form_class = UploadFilesToEventSerieForm
     template_name = "arrangement/planner/dialogs/arrangement_dialogs/uploadFilesToEventSerieDialog.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)
@@ -1080,12 +1048,9 @@ class PlannerCalendarUploadFileToEventSerieDialog(LoginRequiredMixin, FormView):
 planner_calendar_upload_file_to_event_serie_dialog_view = PlannerCalendarUploadFileToEventSerieDialog.as_view()
 
 
-class PlannerCalendarUploadFileToArrangementDialog(LoginRequiredMixin, FormView):
+class PlannerCalendarUploadFileToArrangementDialog(LoginRequiredMixin, JsonFormView):
     form_class = UploadFilesToArrangementForm
     template_name = "arrangement/planner/dialogs/arrangement_dialogs/uploadFilesToArrangementDialog.html"
-
-    def get_success_url(self) -> str:
-        return reverse("arrangement:arrangement_list")
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -346,7 +346,7 @@
                                             data-mdb-parent="#accordion_{{event_serie.pk}}"
                                         >
                                             <div class="accordion-body">
-                                                <div id="uploadFilesToArrangementDialog" title="Last opp filer under '{{arrangement.name}}'" class="bg-white">
+                                                <div title="Last opp filer under '{{arrangement.name}}'" class="bg-white">
                                                     <button class="btn btn-sm btn-success float-end"
                                                         onclick="mainPlannerDialog__uploadFilesToEventSerie({{event_serie.pk}})">
                                                         <i class="fas fa-upload"></i>

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -478,11 +478,12 @@
         </div>
         <div id="tabs-5">
             <div class="clearfix">
-                <button class="btn btn-success btn-sm shadow-0 float-end"
-                        id="mainDialog__uploadFilesBtn">
+                <a class="btn btn-success btn-sm text-white shadow-0 float-end"
+                        id="mainDialog__uploadFilesBtn"
+                        href="#">
                     <i class="fas fa-upload"></i>
                     Upload file(s)
-                </button>
+                </a>
             </div>
 
             <div class="table-responsive">


### PR DESCRIPTION
### Fix arrangement file upload bug

This PR introduces a fix to the issue where arrangement file upload would not work. Additionally I have solved the arrangement_list reverse get_success_url problem on all views in PlannerViews. Thought I had fixed these earlier, but it's done now.
The reason I used arrangement_list for get_success_url was primarily naivety. I added it simply to get it to work (as you're supposed to have a success_url to redirect to). This does not really matter on the dialog views where we have zero desire to redirect. To solve this I made JsonFormView. It's a very simple class:
```py
class JsonFormView(FormView):
    def form_valid(self, form) -> JsonResponse:
        return JsonResponse({ "success": True })

    def form_invalid(self, form) -> JsonResponse:
        return JsonResponse({ "success": False, "errors": form.errors })
```
Django's form_valid and form_invalid look like this;
```py
    def form_valid(self, form):
        """If the form is valid, redirect to the supplied URL."""
        return HttpResponseRedirect(self.get_success_url())

    def form_invalid(self, form):
        """If the form is invalid, render the invalid form."""
        return self.render_to_response(self.get_context_data(form=form))
```

So overriding these methods and returning JSON seems to me to be a correct and sane approach.

This does illustrate a deeper flaw, I think, in the dialog manager approach I have chosen to roll. Maybe it would be more ideal to not override form_invalid, rather taking its html and overwriting the dialog body with it. Then we would get Django's form messages/validation errors on form_invalid. I don't think this is necessary at this point however, but it certainly would be a nice feature to have, and would allow us to use Django's forms fully in the dialogs. I will look into it.