### PR TITLE
Fix bug where editing serie creates duplicate / new serie

### DIFF
--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -439,6 +439,8 @@ export class ArrangementInspector {
                             this.dialogManager.closeDialog("editEventSerieDialog");
                         },
                         onSubmit: async (context, details) => { 
+                            details.serie.event_serie_pk = context.lastTriggererDetails.event_serie_pk;
+
                             context.serie = details.serie;
                             context.collision_resolution = new Map();
                             

--- a/webook/static/modules/planner/querystore.js
+++ b/webook/static/modules/planner/querystore.js
@@ -14,6 +14,10 @@ export class QueryStore {
         var formData = serieConvert(serie, new FormData());
         formData.append("saveAsSerie", true);
         var events = SeriesUtil.calculate_serie(serie);
+
+        if ("event_serie_pk" in serie) {
+            formData.append("predecessorSerie", serie.event_serie_pk);
+        } 
         
         events.forEach(function (event) { 
             event.arrangement = arrangement_pk;


### PR DESCRIPTION
### Fix bug where editing serie creates duplicate / new serie

This PR introduces a fix to a bug where when editing an existing serie and saving a new serie would be created. This happened due to me forgetting to add the ID of the "source" serie after rewriting the methods responsible for saving events (came in with exclusivity).