### PR TITLE
Fix a bug where display layouts would be transferred incorrectly across dialogs

### DIFF
--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -155,7 +155,7 @@ export class ArrangementCreator {
 
                                 document.querySelectorAll("input[name='display_layouts']:checked")
                                     .forEach(checkboxElement => {
-                                        $('#id_display_layouts_serie_planner_' + String(parseInt(checkboxElement.value) - 1))
+                                        $('#id_display_layouts_serie_planner_' + checkboxElement.value)
                                             .prop( "checked", true );
                                     })
                                 

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -74,7 +74,12 @@
                         <td colspan="2">
                             <br>
                                 <label class="d-block"><i class='fas fa-desktop'></i>&nbsp; {% trans "Show on:" %}: </label>
-                            {{ form.display_layouts_serie_planner }}
+                                <ul>
+                                    {% for choice_id, choice_label in form.display_layouts_serie_planner.field.choices %}
+                                        <li class='your class'> <input type="checkbox" value="{{choice_id}}" name="display_layouts_serie_planner" id="id_display_layouts_serie_planner_{{choice_id}}" />
+                                        <label for="id_display_layouts_serie_planner_{{choice_id}}">{{choice_label}}</label></li>
+                                    {% endfor %}
+                                </ul>      
                         </td>
                     </tr>
                     </tbody>

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -137,14 +137,12 @@
 
             <div class="form-group mt-3">
                 <label class="d-block"><i class='fas fa-desktop text-muted'></i>&nbsp; {% trans "Show on:" %}</label>
-                <!-- {{form.display_layouts}} -->
                 <ul>
                     {% for choice_id, choice_label in form.display_layouts.field.choices %}
                         <li class='your class'> <input type="checkbox" value="{{choice_id}}" name="display_layouts_create_event" id="{{choice_id}}_dlcheck" />
                         <label for="{{choice_id}}_dlcheck">{{choice_label}}</label></li>
                     {% endfor %}
-                </ul>
-                    
+                </ul>       
             </div>
 
             <div class="row mt-4">


### PR DESCRIPTION
### Fix a bug where display layouts would be transferred incorrectly across dialogs

This PR introduces a fix to a bug where display layouts from CreateArrangementDialog would not be transferred correctly to NewTimePlanDialog.