### PR TITLE
Fix a bug where incorrect day would shown in summary

### DIFF
--- a/webook/utils/manifest_describe.py
+++ b/webook/utils/manifest_describe.py
@@ -34,7 +34,7 @@ def _days_to_str(manifest) -> str:
     """
 
     # regex replaces the last , with and
-    return re.sub(r'(,)(?!.*\1)', ' and', ", ".join(map(lambda x: calendar.day_name[x], filter(lambda x: x == True, manifest.days))))
+    return re.sub(r'(,)(?!.*\1)', ' and', ", ".join(map(lambda x: calendar.day_name[x], filter(lambda x: manifest.days[x] == True, manifest.days))))
 
 
 describe_pattern = {

--- a/webook/utils/serie_calculator.py
+++ b/webook/utils/serie_calculator.py
@@ -161,7 +161,7 @@ def _pattern_strategy_weekly_standard(cycle: _CycleInstruction) -> List[_Event]:
     counter = 0
     for day in range(cycle.start_date.weekday(), 7):
         if day in cycle.days and cycle.days[day] == True:
-            adjusted_start_date = cycle.start_date + timedelta(days=counter)
+            adjusted_start_date = cycle.start_date + timedelta(days=counter-1)
             events.append(_Event(
                 title=cycle.event.title,
                 start=datetime.combine(adjusted_start_date, cycle.event.start),


### PR DESCRIPTION
### Fix a bug where incorrect day would shown in summary

This PR introduces a fix for a bug where incorrect day (always tuesday) would be shown in the summary when generated using the server-side version of the summary generator.