### PR TITLE
Fix main planner name undefined bug

### DIFF
--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -188,7 +188,7 @@ export class PlannerCalendar extends FullCalendarBased {
                 </span>
                 <span class='badge h6 badge-success'>
                     Hovedplanlegger:
-                    ${arrangement.mainPlannerName}
+                    ${arrangement.mainplannername}
                 </span>
                 <span class='badge h6 badge-secondary'>
                     Lokasjon: 


### PR DESCRIPTION
### Fix main planner name undefined bug

Fix main planner name being undefined in event popover