### PR TITLE
Fix up list posts once and for all

### DIFF
--- a/webook/arrangement/forms/event_forms.py
+++ b/webook/arrangement/forms/event_forms.py
@@ -18,11 +18,6 @@ _ALWAYS_FIELDS = ( "title",
 
 
 class BaseEventForm(forms.ModelForm):
-
-    rooms_cs = CharField(max_length=5000, required=False)
-    people_cs = CharField(max_length=5000, required=False)
-    display_layouts_cs = CharField(max_length=5000, required=False)
-
     def save(self, commit=True):
         if self.instance.serie is not None:
             """ 
@@ -32,15 +27,7 @@ class BaseEventForm(forms.ModelForm):
             """
             self.instance.degrade_to_association_status(commit=False)
 
-        parse_comma_sep_string = lambda comma_sep_str: [int(x) for x in comma_sep_str.split(",") if x] if comma_sep_str else []
-
         super().save(commit)
-
-        self.instance.rooms.set(parse_comma_sep_string(self.cleaned_data["rooms_cs"]))
-        self.instance.people.set(parse_comma_sep_string(self.cleaned_data["people_cs"]))
-        self.instance.display_layouts.set(parse_comma_sep_string(self.cleaned_data["display_layouts_cs"]))
-
-        self.instance.save()
 
 
     class Meta:

--- a/webook/arrangement/forms/event_forms.py
+++ b/webook/arrangement/forms/event_forms.py
@@ -18,7 +18,7 @@ _ALWAYS_FIELDS = ( "title",
 
 
 class BaseEventForm(forms.ModelForm):
-    def save(self, commit=True):
+    def save(self, commit: bool=True):
         if self.instance.serie is not None:
             """ 
             When a serie event has been edited it has become more specific - thus we want to degrade it to "association" status.

--- a/webook/arrangement/forms/exclusivity_analysis/serie_manifest_form.py
+++ b/webook/arrangement/forms/exclusivity_analysis/serie_manifest_form.py
@@ -20,8 +20,8 @@ class SerieManifestForm(forms.Form):
     title = forms.CharField(max_length=512)
     title_en = forms.CharField(max_length=512, required=False)
     rooms = forms.ModelMultipleChoiceField(queryset=Room.objects.all(), required=False)
-    people = forms.CharField(max_length=5000, required=False)
-    display_layouts = forms.CharField(max_length=5000, required=False)
+    people = forms.ModelMultipleChoiceField(queryset=Person.objects.all(), required=False)
+    display_layouts = forms.ModelMultipleChoiceField(queryset=DisplayLayout.objects.all(), required=False)
     interval = forms.IntegerField(required=False)
     day_of_month = forms.IntegerField(required=False)
     arbitrator = forms.IntegerField(required=False)
@@ -71,11 +71,9 @@ class SerieManifestForm(forms.Form):
         
         plan_manifest.save()
 
-        parse_comma_sep_string = lambda comma_sep_str: [int(x) for x in comma_sep_str.split(",") if x] if comma_sep_str else []
-
-        plan_manifest.rooms.set(parse_comma_sep_string(self.cleaned_data["rooms"]))
-        plan_manifest.people.set(parse_comma_sep_string(self.cleaned_data["people"]))
-        plan_manifest.display_layouts.set(parse_comma_sep_string(self.cleaned_data["display_layouts"]))
+        plan_manifest.rooms.set(self.cleaned_data["rooms"])
+        plan_manifest.people.set(self.cleaned_data["people"])
+        plan_manifest.display_layouts.set(self.cleaned_data["display_layouts"])
 
         plan_manifest.save()
 

--- a/webook/arrangement/forms/exclusivity_analysis/serie_manifest_form.py
+++ b/webook/arrangement/forms/exclusivity_analysis/serie_manifest_form.py
@@ -19,7 +19,7 @@ class SerieManifestForm(forms.Form):
     expectedVisitors = forms.IntegerField(min_value=0)
     title = forms.CharField(max_length=512)
     title_en = forms.CharField(max_length=512, required=False)
-    rooms = forms.CharField(max_length=5000, required=False)
+    rooms = forms.ModelMultipleChoiceField(queryset=Room.objects.all(), required=False)
     people = forms.CharField(max_length=5000, required=False)
     display_layouts = forms.CharField(max_length=5000, required=False)
     interval = forms.IntegerField(required=False)

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -56,6 +56,7 @@ export class ArrangementCreator {
                                 
                                 if (details.events !== undefined) {
                                     details.events.forEach((event) => event.arrangement = arrId.arrangementPk);
+                                    debugger;
                                     await QueryStore.SaveEvents(details.events, csrf_token);
                                 }
                               })
@@ -271,7 +272,6 @@ export class ArrangementCreator {
                                 .then(response => response.text());
                         },
                         onRenderedCallback: (dialogManager, context) => {
-
                             document.querySelectorAll('.form-outline').forEach((formOutline) => {
                                 new mdb.Input(formOutline).init();
                             });

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -56,7 +56,6 @@ export class ArrangementCreator {
                                 
                                 if (details.events !== undefined) {
                                     details.events.forEach((event) => event.arrangement = arrId.arrangementPk);
-                                    debugger;
                                     await QueryStore.SaveEvents(details.events, csrf_token);
                                 }
                               })

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -448,6 +448,8 @@ export class ArrangementInspector {
                             this.dialogManager.closeDialog("editEventSerieDialog");
                         },
                         onSubmit: async (context, details) => {
+                            debugger;
+
                             details.serie.event_serie_pk = context.editing_serie_pk;
 
                             context.serie = details.serie;

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -448,8 +448,6 @@ export class ArrangementInspector {
                             this.dialogManager.closeDialog("editEventSerieDialog");
                         },
                         onSubmit: async (context, details) => {
-                            debugger;
-
                             details.serie.event_serie_pk = context.editing_serie_pk;
 
                             context.serie = details.serie;

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -400,8 +400,9 @@ export function convertObjToFormData(obj, convertArraysToList=false) {
 
     for (var key in obj) {
         if (convertArraysToList === true && Array.isArray(obj[key])) {
+            var counter = 0;
             obj[key].forEach((val) => {
-                form_data.append(key + "[]", val);
+                form_data.append(`${key}`, val);
             });
 
             continue;

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -395,21 +395,29 @@ export function writeSlugClass(slug) {
     return `slug:${slug}`;
 }
 
+/**
+ * Append a given array to the given formData instance
+ * @param {*Array} arrayToAppend 
+ * @param {*FormData} formDataToAppendTo 
+ * @param {*String} key
+ */
+export function appendArrayToFormData(arrayToAppend, formDataToAppendTo, key) {
+    arrayToAppend.forEach((item) => {
+        formDataToAppendTo.append(key, item);
+    });
+}
+
 export function convertObjToFormData(obj, convertArraysToList=false) {
-    var form_data = new FormData();
+    var formData = new FormData();
 
     for (var key in obj) {
         if (convertArraysToList === true && Array.isArray(obj[key])) {
-            var counter = 0;
-            obj[key].forEach((val) => {
-                form_data.append(`${key}`, val);
-            });
-
+            appendArrayToFormData(obj, formData, key)
             continue;
         }
 
-        form_data.append(key, obj[key]);
+        formData.append(key, obj[key]);
     }
     
-    return form_data;
+    return formData;
 }

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -408,7 +408,9 @@ export function appendArrayToFormData(arrayToAppend, formDataToAppendTo, key) {
 
     if (arrayToAppend.length > 0) {
         arrayToAppend.forEach((item) => {
-            formDataToAppendTo.append(key, item);
+            if (item) {
+                formDataToAppendTo.append(key, item);
+            }
         });
     }
 }

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -402,9 +402,15 @@ export function writeSlugClass(slug) {
  * @param {*String} key
  */
 export function appendArrayToFormData(arrayToAppend, formDataToAppendTo, key) {
-    arrayToAppend.forEach((item) => {
-        formDataToAppendTo.append(key, item);
-    });
+    if (Array.isArray(arrayToAppend) !== true) {
+        throw "Value of parameter arrayToAppend is not an array", arrayToAppend;
+    }
+
+    if (arrayToAppend.length > 0) {
+        arrayToAppend.forEach((item) => {
+            formDataToAppendTo.append(key, item);
+        });
+    }
 }
 
 export function convertObjToFormData(obj, convertArraysToList=false) {
@@ -412,7 +418,7 @@ export function convertObjToFormData(obj, convertArraysToList=false) {
 
     for (var key in obj) {
         if (convertArraysToList === true && Array.isArray(obj[key])) {
-            appendArrayToFormData(obj, formData, key)
+            appendArrayToFormData(obj[key], formData, key)
             continue;
         }
 

--- a/webook/static/modules/planner/eventInspector.js
+++ b/webook/static/modules/planner/eventInspector.js
@@ -26,7 +26,7 @@ export class EventInspector {
                             this.dialogManager.closeDialog("inspectEventDialog");
                         },
                         onSubmit: async (context, details) => {
-                            await QueryStore.SaveEvents( [context.event], details.csrf_token )
+                            await QueryStore.UpdateEvents( [details.event], details.csrf_token )
                                 .then(_ => document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")));
                         }
                     }),

--- a/webook/static/modules/planner/eventInspector.js
+++ b/webook/static/modules/planner/eventInspector.js
@@ -1,4 +1,5 @@
 import { Dialog, DialogManager } from "./dialog_manager/dialogManager.js";
+import { QueryStore } from "./querystore.js";
 
 export class EventInspector {
     constructor () {
@@ -25,14 +26,8 @@ export class EventInspector {
                             this.dialogManager.closeDialog("inspectEventDialog");
                         },
                         onSubmit: async (context, details) => {
-                            var url = '/arrangement/planner/update_event/' + context.event.pk;
-                            await fetch(url, {
-                                method: "POST",
-                                body: details.formData,
-                                headers: {
-                                    "X-CSRFToken": details.csrf_token
-                                }
-                            }).then(_ => document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")));
+                            await QueryStore.SaveEvents( [context.event], details.csrf_token )
+                                .then(_ => document.dispatchEvent(new Event("plannerCalendar.refreshNeeded")));
                         }
                     }),
                 ],

--- a/webook/static/modules/planner/querystore.js
+++ b/webook/static/modules/planner/querystore.js
@@ -2,7 +2,7 @@ import { convertObjToFormData } from "./commonLib.js";
 import { serieConvert } from "./serieConvert.js";
 
 
-const COMMA_SEPARATED_LIST_SPLITS = ["display_layouts", "rooms", "people"];
+const COMMA_SEPARATED_LIST_SPLITS = ["rooms", "people", "display_layouts"];
 
 /**
  * A store of common queries
@@ -37,47 +37,8 @@ export class QueryStore {
      * @param {*} preset_formdata Pass a custom FormData instance in to inject values, or let be undefined for standard
      * @returns {*} promise
      */
-    static async SaveEvents(events, csrf_token, preset_formdata = undefined) {
-        var formData = preset_formdata !== undefined && preset_formdata instanceof FormData ? preset_formdata : new FormData();
-        for (var i = 0; i < events.length; i++) {
-            var event = events[i];
-            for (var key in event) {
-                formData.append("events[" + i + "]." + key, event[key]);
-            }
-        }
-
-        var evMap = new Map();
-        for (var event_pair of formData.entries()) {
-            var key_without_index = event_pair[0].split(".")[1];
-            var index = event_pair[0].slice(6, 1)
-
-            var event = {};
-
-            if (evMap.has(index)) {
-                event = evMap.get(index);
-            }
-
-            if (key_without_index === "display_layouts") {
-                key_without_index = "display_layouts_cs";
-            }
-            if (key_without_index === "rooms") {
-                key_without_index = "rooms_cs";
-            }
-            if (key_without_index === "people") {
-                key_without_index = "people_cs";
-            }
-
-            // if (COMMA_SEPARATED_LIST_SPLITS.includes(key_without_index)) {
-            //     event_pair[1] = event_pair[1].split(",");
-            // }
-
-            event[key_without_index] = event_pair[1];
-            evMap.set(index, event);
-        }
-
-        for (const ev of evMap) {
-            var formData = convertObjToFormData(ev[1], true);
-
+    static async SaveEvents(events, csrf_token) {
+        for (const formData of events.map((event) => convertObjToFormData(event, true))) {
             await fetch("/arrangement/event/create", {
                 method: "POST",
                 body: formData,

--- a/webook/static/modules/planner/querystore.js
+++ b/webook/static/modules/planner/querystore.js
@@ -49,4 +49,18 @@ export class QueryStore {
             })
         }
     }
+
+
+    static async UpdateEvents (events, csrf_token) {
+        for (const formData of events.map((event) => convertObjToFormData(event, true))) {
+            await fetch("/arrangement/planner/update_event/" + formData.get("id"), {
+                method: "POST",
+                body: formData,
+                headers: {
+                    "X-CSRFToken": csrf_token
+                },
+                credentials: 'same-origin',
+            })
+        }
+    }
 }

--- a/webook/static/modules/planner/serieConvert.js
+++ b/webook/static/modules/planner/serieConvert.js
@@ -1,3 +1,5 @@
+import { appendArrayToFormData } from "./commonLib.js";
+
 export function serieConvert(serie, formData, keyPrefix=`manifest.`) {
     formData.append(`${keyPrefix}pattern`, serie.pattern.pattern_type);
     formData.append(`${keyPrefix}patternRoutine`, serie.pattern.pattern_routine);
@@ -10,11 +12,9 @@ export function serieConvert(serie, formData, keyPrefix=`manifest.`) {
     formData.append(`${keyPrefix}title`, serie.time.title);
     formData.append(`${keyPrefix}title_en`, serie.time.title_en);
 
-    formData.append(`${keyPrefix}rooms`, serie.rooms);
-    formData.append(`${keyPrefix}people`, serie.people);
-    formData.append(`${keyPrefix}display_layouts`, serie.display_layouts.split(","));
-
-    debugger;
+    appendArrayToFormData(serie.rooms, formData, `${keyPrefix}rooms`);
+    appendArrayToFormData(serie.people, formData, `${keyPrefix}people`);
+    appendArrayToFormData(serie.display_layouts.split(","), formData, `${keyPrefix}display_layouts`)
 
     switch(serie.pattern.pattern_type) {
         case "daily":

--- a/webook/static/modules/planner/serieConvert.js
+++ b/webook/static/modules/planner/serieConvert.js
@@ -10,24 +10,11 @@ export function serieConvert(serie, formData, keyPrefix=`manifest.`) {
     formData.append(`${keyPrefix}title`, serie.time.title);
     formData.append(`${keyPrefix}title_en`, serie.time.title_en);
 
-    // var splitAndAddCommaSeparatedStringToFormDataAsList = function (commaSeparatedString, key) {
-    //     commaSeparatedString.split(",").forEach((artifact) => {
-    //         formData.append(key + "[]", artifact);
-    //     })
-    // }
-    // var convertListToFormDataList = function (list, key) {
-    //     list.forEach( (item) => {
-    //         formData.append(key + "[]", item);
-    //     } )
-    // }
+    formData.append(`${keyPrefix}rooms`, serie.rooms);
+    formData.append(`${keyPrefix}people`, serie.people);
+    formData.append(`${keyPrefix}display_layouts`, serie.display_layouts.split(","));
 
-    formData.append(`${keyPrefix}rooms`, serie.rooms.join(","));
-    formData.append(`${keyPrefix}people`, serie.people.join(","));
-    formData.append(`${keyPrefix}display_layouts`, serie.display_layouts);
-    
-    // convertListToFormDataList(serie.rooms, `${keyPrefix}rooms`);
-    // convertListToFormDataList(serie.people, `${keyPrefix}people`);
-    // splitAndAddCommaSeparatedStringToFormDataAsList(serie.display_layouts, `${keyPrefix}display_layouts`);
+    debugger;
 
     switch(serie.pattern.pattern_type) {
         case "daily":

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -409,7 +409,7 @@
             seriesMap.set(element._uuid, element);
             collisions_html = "";
             console.log(element)
-            if (element.collisions !== undefined) {
+            if (element.collisions !== undefined && element.collisions.length > 0) {
                 var collisionsCounter = 0;
                 element.collisions.forEach(collisionRecord => {
                     collisions_html += `

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -408,7 +408,6 @@
             var uuid = crypto.randomUUID();
             seriesMap.set(element._uuid, element);
             collisions_html = "";
-            console.log(element)
             if (element.collisions !== undefined && element.collisions.length > 0) {
                 var collisionsCounter = 0;
                 element.collisions.forEach(collisionRecord => {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -232,17 +232,16 @@
     }
 
     function dialogCreateEvent__getSelectedRoomIds() {
-        var room_ids = Array.from($("#roomsTbody__d1")[0].children).map(row => row.getAttribute("rowid"));
-        return room_ids;
+        return Array.from($("#roomsTbody__d1")[0].children).map(row => row.getAttribute("rowid"));
     }
 
     function dialogCreateEvent__getSelectedPeopleIds() {
-        var people_ids = Array.from($("#peopleTbody__d1")[0].children).map(row => row.getAttribute("rowid"));
-        return people_ids;
+        return Array.from($("#peopleTbody__d1")[0].children).map(row => row.getAttribute("rowid"));
     }
 
     function dialogCreateEvent__submit() {
         if (validateNewSimpleActivityForm() === false) {
+            console.warn("Validation failed.")
             return;
         }
 
@@ -261,13 +260,9 @@
             room_name_map: roomsNameMap,    // Kept due to edit - not pertinent for save
         }
 
-        console.log("qualifiedEvent", qualifiedEvent)
-
-        let displayLayouts = [];
-        document.querySelectorAll("input[name='display_layouts_create_event'][type='checkbox']:checked").forEach(element => {
-            displayLayouts.push(element.value)
-        })
-        qualifiedEvent.display_layouts = displayLayouts.join(",");
+        qualifiedEvent.display_layouts = 
+            [...document.querySelectorAll("input[name='display_layouts_create_event'][type='checkbox']:checked")]
+                .map(element => element.value);
 
         document.dispatchEvent(
             new CustomEvent(

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
@@ -381,35 +381,26 @@
             return;
         }
 
-        let formData = new FormData();
-        var start = new Date( $('#id_start_date').val() + "T" + $('#start_time').val() ).toISOString();
-        var end = new Date( $('#id_end_date').val() + "T" + $('#end_time').val() ).toISOString();
-
-        formData.append("id",           '{{object.pk}}');
-        formData.append("title",        $('#id_title').val());
-        formData.append("title_en",     $('#id_title_en').val());
-        formData.append("ticket_code",  $('#id_ticket_code').val())
-        formData.append("start",        start);
-        formData.append("end",          end);
-        formData.append("expected_visitors", $('#id_expected_visitors').val());
-        formData.append("actual_visitors", $('#id_actual_visitors').val())
-        formData.append("arrangement", '{{object.arrangement.pk}}');
-        formData.append("people_cs",       inspectEventDialog__getSelectedPeopleIds().join(","));
-        formData.append("rooms_cs",        inspectEventDialog__getSelectedRoomIds().join(","));
-        formData.append("csrf_token",   "{{ csrf_token }}");
-
-        let displayLayouts = [];
-        document.querySelectorAll("input[name='display_layouts'][type='checkbox']:checked").forEach(element => {
-            // formData.append("display_layouts", element.value);
-            displayLayouts.push(element.value);
-        })
-        formData.append("display_layouts_cs", displayLayouts.join(","));
+        var qualifiedEvent = {
+            id: '{{object.pk}}',
+            title: $('#id_title').val(),
+            title_en: $('#id_title_en').val(),
+            ticket_code: $('#id_ticket_code').val(),
+            start: new Date( $('#id_start_date').val() + "T" + $('#start_time').val() ).toISOString(),
+            end: new Date( $('#id_end_date').val() + "T" + $('#end_time').val() ).toISOString(),
+            expected_visitors: $('#id_expected_visitors').val(),
+            actual_visitors: $('#id_actual_visitors').val(),
+            arrangement: '{{object.arrangement.pk}}',
+            people: inspectEventDialog__getSelectedPeopleIds(),
+            rooms: inspectEventDialog__getSelectedRoomIds(),
+            display_layouts: [...document.querySelectorAll("input[name='display_layouts'][type='checkbox']:checked")]
+                                .map(element => element.value)
+        };
 
         document.dispatchEvent(
             new CustomEvent("eventInspector.submit", { "detail": {
                 dialog: "inspectEventDialog",
-                formData: formData,
-                event_pk: '{{ object.pk }}',
+                event: qualifiedEvent,
                 csrf_token: '{{ csrf_token }}',
             }})
         );


### PR DESCRIPTION
### Fix up list posts once and for all

This PR introduces a permanent solution to the list postings that is not using comma separated strings, and taking use of the Django frameworks functionality in the forms. I am still not entirely sure how I managed to miss this, but miss it I did.

For a simple demo;
```py
class ShoppingTripPlanForm(forms.ModelForm):
    shopping_list = forms.ModelMultipleChoiceField(queryset=Article.objects.all(), required=False)
   
    def save(self, commit: bool):
          shopping_list = self.cleaned_data["shopping_list"]
          # shopping list is then a queryset of model Article
```

```js
formData.append("shoppingList", "Apple");
formData.append("shopplingList", "Orange");
```

When Django then receives this it is all good and set up like a QuerySet - which is extremely neat.

I have implemented and tested with this approach for event creation, serie creation, editing existing event (inspection), editing existing serie. It works flawlessly from my testing. There were some bugs with collision analysis (as it did not expect to receive a list, but rather a comma separated string -- this was an oversight on my part and should be fixed now. Everything is triggered correctly).
Other than that there is a few improvements here and there.