### PR TITLE
Implement automatic colon splitting on extended timepicker

### DIFF
--- a/webook/static/js/timepickerExtended.js
+++ b/webook/static/js/timepickerExtended.js
@@ -1,0 +1,39 @@
+
+/**
+ * Extension class to wrap around the mdb timepicker and inject our own functionality
+ */
+export class ExtendedTimepicker {
+    constructor({ timepickerWrapperElement, timepickerInputElement, mdbOptions } = {}) {
+        this.timepickerWrapperElement = timepickerWrapperElement;
+        this.timepickerInputElement = timepickerInputElement;
+        this.mdbOptions = mdbOptions;
+
+        this.#mdbInit();
+        this.#listenForInputChange();
+    }
+
+    /**
+     * Initialize the mdb timepicker
+     */
+    #mdbInit() {
+        this.mdbTimepickerInstance = new mdb.Timepicker(this.timepickerWrapperElement, this.mdbOptions);
+    }
+
+    /**
+     * Listen for the input event to be triggered on the timepickers input element, 
+     * meaning that the user has added or removed from the input.
+     */
+    #listenForInputChange() {
+        $(this.timepickerInputElement).on('input', (event) => {
+            if (event.currentTarget.value.length === 4 && /^[0-9]+$/.test(event.currentTarget.value.length)) {
+                /**
+                 * Add a : character in between when we have 4 characters, and all the characters are digits.
+                 * So you could type 1500 and it would automatically be converted to 15:00.
+                 */
+                $(event.currentTarget)
+                    .val([event.currentTarget.value.slice(0, 2), ":", event.currentTarget.value.slice(2,4)].join(''))
+                    .change();
+            }
+        })
+    }
+}

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -318,6 +318,7 @@
 <script type="module">
     import { SeriesUtil } from "{% static 'modules/planner/seriesutil.js' %}";
     import { SelectComponent, MonthSelectComponent, YearSelectComponent } from "{% static 'modules/planner/selectcomponent.js' %}";
+    import { ExtendedTimepicker } from "{% static 'js/timepickerExtended.js' %}";
 
     class DayOfWeekSelectComponent extends SelectComponent {
         constructor (element_id) {
@@ -391,13 +392,22 @@
         }
     })
     
-    const startTimePicker = new mdb.Timepicker(document.querySelector('#serie_start_picker'), {
-        format24:true,
-        inline: true,
+    const startTimePicker = new ExtendedTimepicker({
+        timepickerWrapperElement: document.getElementById('serie_start_picker'),
+        timepickerInputElement: document.getElementById('serie_start'),
+        mdbOptions: {
+            format24:true,
+            inline: true,
+        }
     });
-    const endTimePicker = new mdb.Timepicker(document.querySelector('#serie_end_picker'), {
-        format24:true,
-        inline: true,
+
+    const endTimePicker = new ExtendedTimepicker({
+        timepickerWrapperElement: document.getElementById('serie_end_picker'),
+        timepickerInputElement: document.getElementById('serie_end'),
+        mdbOptions: {
+            format24:true,
+            inline: true,
+        }
     });
 
     $('#submitBtn').on('click', () => {


### PR DESCRIPTION
### Implement automatic colon splitting on extended timepicker

This PR introduces automatic splitting of the timepickers input (which is a text input), so that when one has 4 characters and all of those are digits, we add a colon in between. 

So say you enter 1500, this would then be converted to 15:00 automatically.