### PR TITLE
Correct flag/countrycode on english title label on createSerieDialog

### DIFF
--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -20,7 +20,7 @@
                                 <div class="col-12">
                                     <div class="form-outline mb-2">
                                         <input type="text" id="serie_title_en" class="form-control" />
-                                            <label class="form-label" for="serie_title_en">🇳🇴 Tittel på engelsk</label>
+                                            <label class="form-label" for="serie_title_en">🇬🇧 Tittel på engelsk</label>
                                     </div>  
                                 </div>
                             </div>


### PR DESCRIPTION
### Correct flag/countrycode on english title label on createSerieDialog

Flag/country code was wrong, showed the norwegian one for english title on createSerieDialog form.