### PR TITLE
Fix bug where unique slug constraint would be violated if archived entity had the given slug

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -18,16 +18,6 @@ from webook.utils.crudl_utils.model_mixins import ModelNamingMetaMixin
 from webook.utils.manifest_describe import describe_manifest
 
 
-class ArchiveIrrespectiveAutoSlugField(AutoSlugField):
-    """
-        A subclassed AutoSlugField that can see both archived and non archived entities, thus
-        preventing slug collisions with entities that are archived.
-        Use in tandem with ModelArchiveableMixin.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, manager_name="all_objects")
-
 class ModelArchiveableMixin(models.Model):
     """ Mixin for making a model archivable """
 
@@ -132,7 +122,7 @@ class Audience(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
     name = models.CharField(verbose_name=_("Name"), max_length=255)
     name_en = models.CharField(verbose_name=_("Name(English)"), max_length=255, blank=False, null=True)
     icon_class = models.CharField(verbose_name=_("Icon Class"), max_length=255, blank=True)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_singular = _("Audience")
     entity_name_plural = _("Audiences")
@@ -154,7 +144,7 @@ class ArrangementType(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMi
 
     name = models.CharField(verbose_name=_("Name"), max_length=255)
     name_en = models.CharField(verbose_name=_("Name(English)"), max_length=255, blank=False, null=True)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     def get_absolute_url(self):
         return reverse(
@@ -171,7 +161,7 @@ class RoomPreset (TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin)
         A room preset is a group, or collection, or set, of rooms.
     """
 
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
     name = models.CharField(verbose_name=_("Name"), max_length=256,     null=False, blank=False)
     rooms = models.ManyToManyField(to="Room")
 
@@ -271,7 +261,7 @@ class Arrangement(TimeStampedModel, ModelNamingMetaMixin, ModelTicketCodeMixin, 
     display_text_en = models.CharField(verbose_name=_("Screen Display Text(English)"), max_length=255, blank=True, null=True)
     display_layouts = models.ManyToManyField(to=screen_models.DisplayLayout, verbose_name=_("Display Layout"), related_name="arrangements", blank=True)
 
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_singular = _("Arrangement")
     entity_name_plural = _("Arrangements")
@@ -314,7 +304,7 @@ class Location (TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
             room.archive(person_archiving_this)
 
     name = models.CharField(verbose_name=_("Name"), max_length=255)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_singular = _("Location")
     entity_name_plural = _("Locations")
@@ -361,7 +351,7 @@ class Room(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
     business_hours = models.ManyToManyField(to="BusinessHour", verbose_name=_("Business Hours"))
 
     name = models.CharField(verbose_name=_("Name"), max_length=128)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_singular = _("Room")
     entity_name_plural = _("Rooms")
@@ -389,7 +379,7 @@ class Article(TimeStampedModel, ModelArchiveableMixin):
         verbose_name_plural = _("Articles")
 
     name = models.CharField(verbose_name=_("Name"), max_length=255)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     def __str__(self):
         """Return article name"""
@@ -409,7 +399,7 @@ class OrganizationType(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableM
         verbose_name_plural = _("Organization Types")
 
     name = models.CharField(verbose_name=_("Name"), max_length=255)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_singular = _("Organization Type")
     entity_name_plural = _("Organization Types")
@@ -459,7 +449,7 @@ class ServiceType(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin)
         verbose_name_plural = _("Service Types")
 
     name = models.CharField(verbose_name=_("Name"), max_length=255)
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_singular = "Service Type"
     entity_name_plural = "Service Types"
@@ -564,7 +554,7 @@ class Calendar(TimeStampedModel, ModelArchiveableMixin):
     people_resources = models.ManyToManyField(to="Person", verbose_name=_("People Resources"))
     room_resources = models.ManyToManyField(to="Room", verbose_name=_("Room Resources"))
 
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     def __str__(self):
         """Return calendar name"""
@@ -712,7 +702,7 @@ class Person(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
     business_hours = models.ManyToManyField(to=BusinessHour, verbose_name=_("Business Hours"))
     notes = models.ManyToManyField(to=Note, verbose_name="Notes")
 
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="full_name", unique=True)
+    slug = AutoSlugField(populate_from="full_name", unique=True, manager_name="all_objects")
 
     instance_name_attribute_name = "full_name"
     entity_name_singular = _("Person")
@@ -772,7 +762,7 @@ class Organization(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin
     members = models.ManyToManyField(to=Person, verbose_name=_("Members"), related_name="organizations")
     business_hours = models.ManyToManyField(to=BusinessHour, verbose_name=_("Business Hours"))
 
-    slug = ArchiveIrrespectiveAutoSlugField(populate_from="name", unique=True)
+    slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
     entity_name_plural = _("Organizations")
     entity_name_singular = _("Organization")

--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -26,13 +26,7 @@ class ArchiveIrrespectiveAutoSlugField(AutoSlugField):
     """
 
     def __init__(self, *args, **kwargs):
-        model = kwargs.get("model")
-        manager_name = kwargs.get("manager_name")
-        if getattr(model, "all_objects", None) is not None:
-            manager_name = "all_objects"
-
-        super().__init__(*args, **kwargs, manager_name=manager_name)
-
+        super().__init__(*args, **kwargs, manager_name="all_objects")
 
 class ModelArchiveableMixin(models.Model):
     """ Mixin for making a model archivable """

--- a/webook/users/models.py
+++ b/webook/users/models.py
@@ -1,10 +1,14 @@
-from django.contrib.auth.models import AbstractUser
+import import
+import Person
+from autoslug import AutoSlugField
 from django.contrib.auth.base_user import BaseUserManager
+from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-import webook.users.media_pathing as media_path
-from webook.arrangement.models import Person
+
+import webook.arrangement.models
+import webook.users.media_pathing as media_patfrom
 from autoslug import AutoSlugField
 
 


### PR DESCRIPTION
### Fix bug where unique slug constraint would be violated if archived entity had the given slug

This PR introduces a fix for the ArchiveIrrespectiveAutoSlugField. This field did not work properly and would always default back to the default manager, thus not solving what it was meant for. The core issue is that model always was none, so we would always just go back to defaults. This must have been an oversight on my part, or alternatively maybe I intended to define the model as a parameter when defining the slug fields on the models. At any rate, this is a screw up on my part, and shouldn't have come into production.

I was originally thinking to just do this;
```py
class ArchiveIrrespectiveAutoSlugField(AutoSlugField):
    """
        A subclassed AutoSlugField that can see both archived and non archived entities, thus
        preventing slug collisions with entities that are archived.
        Use in tandem with ModelArchiveableMixin.
    """

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs, manager_name="all_objects")
````

But what we should do is define the manager_name when we're setting up the field itself. This avoids the added complexity of inheriting and so on. I should have done this from the start, and this is the correct solution for getting AutoSlugField to work with another manager.

So like this;
`slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")`