### PR TITLE
Fix bug where deleted events are not removed from dialog context thus reappearing

### DIFF
--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -305,7 +305,7 @@
         return true;
     }
 
-    var has_plans = () => seriesMap !== undefined && seriesMap.size > 0 || eventsMap !== undefined && eventsMao.size > 0;
+    var has_plans = () => seriesMap !== undefined && seriesMap.size > 0 || eventsMap !== undefined && eventsMap.size > 0;
 
     function createArrangementDialog_submit() {
 

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -390,7 +390,6 @@
         tbody.html("")
 
         series.forEach(element => {
-            // seriesMap.set(element._uuid, element);
             collisions_html = "";
             if (element.collisions !== undefined && element.collisions.length > 0) {
                 var collisionsCounter = 0;

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -265,7 +265,6 @@
 
         document.addEventListener("{{managerName}}.contextUpdated", (e) => {
             if (e.detail.context.series !== undefined) {
-                debugger;
                 setSeries(e.detail.context.series);
             }
             if (e.detail.context.events !== undefined) {
@@ -479,14 +478,12 @@
     }
 
     function createArrangementDialog_removeSerie(uuid) {
-        debugger;
         $('#' + uuid).remove();
         seriesMap.delete(uuid);
     }
 
 
     function createArrangementDialog_removeSimpleActivity(uuid) {
-        debugger;
         $('#' + uuid).remove();
         eventsMap.delete(uuid);
     }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -265,6 +265,7 @@
 
         document.addEventListener("{{managerName}}.contextUpdated", (e) => {
             if (e.detail.context.series !== undefined) {
+                debugger;
                 setSeries(e.detail.context.series);
             }
             if (e.detail.context.events !== undefined) {
@@ -305,21 +306,7 @@
         return true;
     }
 
-    function has_plans () {
-        let has_plans = false;
-
-        console.log("SeriesMap", seriesMap);
-        console.log("EventsMap", eventsMap)
-
-        if (seriesMap !== undefined && seriesMap.size > 0) {
-            has_plans = true;
-        }
-        if (eventsMap !== undefined && eventsMap.size > 0) {
-            has_plans = true;
-        }
-
-        return has_plans;
-    }
+    var has_plans = () => seriesMap !== undefined && seriesMap.size > 0 || eventsMap !== undefined && eventsMao.size > 0;
 
     function createArrangementDialog_submit() {
 
@@ -366,13 +353,12 @@
     }
 
     function setEvents(events) {
-        eventsMap = new Map();
+        eventsMap = events;
 
         var tbody = $('#eventsBody');
         tbody.html("");
 
         events.forEach(element => {
-            eventsMap.set(element._uuid, element);
             tbody.append(
                 $(`
                 <div class="border border rounded p-3" id='${element._uuid}'>
@@ -399,14 +385,13 @@
     }
 
     function setSeries(series) {
-        seriesMap = new Map();
-
+        seriesMap = series;
+        
         var tbody = $('#timeplansBody');
         tbody.html("")
 
         series.forEach(element => {
-            var uuid = crypto.randomUUID();
-            seriesMap.set(element._uuid, element);
+            // seriesMap.set(element._uuid, element);
             collisions_html = "";
             if (element.collisions !== undefined && element.collisions.length > 0) {
                 var collisionsCounter = 0;
@@ -494,12 +479,14 @@
     }
 
     function createArrangementDialog_removeSerie(uuid) {
+        debugger;
         $('#' + uuid).remove();
         seriesMap.delete(uuid);
     }
 
 
     function createArrangementDialog_removeSimpleActivity(uuid) {
+        debugger;
         $('#' + uuid).remove();
         eventsMap.delete(uuid);
     }


### PR DESCRIPTION
### Fix bug where deleted events are not removed from dialog context thus reappearing

This PR introduces a fix to a bug where on the planner (create arrangement) dialog deleted events and series would reappear. The dialog wrote these events and series into its own internal map after receiving it from the dialog manager, thus removing from this map would not remove from the dialog managers context version of the event and series maps, thus when adding a new event these would reappear as it got the context version back (where the delete was not applied). I have made it so that the dialog operates on the contexts version of the maps.