### PR TITLE
Fix various bugs in schedule/serie calculator

### DIFF
--- a/webook/static/modules/planner/serieConvert.js
+++ b/webook/static/modules/planner/serieConvert.js
@@ -25,7 +25,7 @@ export function serieConvert(serie, formData, keyPrefix=`manifest.`) {
         case "weekly":
             formData.append(`${keyPrefix}interval`, serie.pattern.week_interval);
             var count = 0;
-            for (var day of ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]) {
+            for (var day of ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]) {
                 formData.append(`${keyPrefix}${day}`, serie.pattern.days.get(count));
                 count++;
             }

--- a/webook/static/modules/planner/seriesutil.js
+++ b/webook/static/modules/planner/seriesutil.js
@@ -173,15 +173,9 @@ Date.prototype.addDays = function(days) {
                 continue;
             }
 
-            if (scope.stop_within_date !== undefined) {
-                if (result.from >= scope.stop_within_date) {
-                    break;
-                }
-            }
-            if (scope.instance_limit !== undefined && scope.instance_limit !== undefined) {
-                if (instance_cursor > scope.instance_limit) {
-                    break;
-                }
+            if (scope.stop_within_date !== undefined && result.from >= scope.stop_within_date ||
+                scope.instance_limit !== undefined && scope.instance_limit !== undefined && instance_cursor > scope.instance_limit) {
+                break;
             }
 
             let move_cursor_to = date_cursor


### PR DESCRIPTION
### Fix various bugs in schedule/serie calculator

This PR introduces a few fixes to a few various bugs in the serie calculator.

1. Fixed a bug where selecting Sunday in the every day of week pattern would result in an infinite loop. Selecting sunday should now work. This was due to day indexing being wrong, if I remember correctly.
2. Fixed a bug where "weekly" could end up skipping a week if you selected sunday. This happened because we would always +1 (so if cursor was on sunday == week skipped). The +1 thing addresses a very specific concern in the every weekday strategy, and has been isolated to only be run when that strategy is used. (weekday strategy does not move the date_cursor, so we need to move it +1). I'm not particularly happy with the current fix - but it works. Ideally strategy specific logic should be contained within the strategy. Good candidate for refactoring later on when time allows.