### PR TITLE
Add scrollbar on room filter dialog

### DIFF
--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/roomFilterDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/roomFilterDialog.html
@@ -14,7 +14,9 @@
         </p>
     </div>
 
-    <div id="transfer-basic" class="transfer shadow-0"></div>
+    <div style="overflow-y:scroll; max-height: 600px;">
+        <div id="transfer-basic" class="transfer shadow-0"></div>
+    </div>
 
     <div class="clearfix">
         <div class="float-end">


### PR DESCRIPTION
### Add scrollbar on room filter dialog

Add scrollbar on room filter dialog, so it doesn't end up extremely unwieldy and long should the amount of rooms registered on the location be great.