### PR TITLE
fix statustype coloring in popovers (add bg color to status badges)

### DIFF
--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -233,7 +233,6 @@ export class DialogSimpleRenderer extends DialogBaseRenderer {
                         dialog._$getDialogEl().dialog( dialog.dialogOptions );
                         dialog.onRenderedCallback(dialog, context);
 
-                        console.log("el", dialog._$getDialogEl())
                         dialog._$getDialogEl().parent().find('.ui-dialog-titlebar-close')
                             .html("<span id='railing'></span><span class='dialogCloseButton'><i class='fas fa-times float-end'></i></span>")
                             .click( () => {

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -8,6 +8,7 @@ import {
 import { EventInspector } from "./eventInspector.js";
 // import { FilterDialog } from "./filterDialog.js";
 
+const ARIA_ATTRIBUTE_PATTERN = /^aria-[\w-]*$/i;
 
 export class PlannerCalendar extends FullCalendarBased {
 
@@ -240,8 +241,41 @@ export class PlannerCalendar extends FullCalendarBased {
             </span>`
         }
 
+        console.log("statusColor", arrangement.status_color);
         new mdb.Popover(elementToBindWith, {
             trigger: "hover",
+            allowList: {
+                '*': ['class', 'dir', 'id', 'lang', 'role', ARIA_ATTRIBUTE_PATTERN],
+                a: ['target', 'href', 'title', 'rel'],
+                area: [],
+                b: [],
+                br: [],
+                col: [],
+                code: [],
+                div: ['style'],
+                em: [],
+                hr: [],
+                h1: [],
+                h2: [],
+                h3: [],
+                h4: [],
+                h5: [],
+                h6: [],
+                i: [],
+                img: ['src', 'srcset', 'alt', 'title', 'width', 'height'],
+                li: [],
+                ol: [],
+                p: [],
+                pre: [],
+                s: [],
+                small: [],
+                span: [],
+                sub: [],
+                sup: [],
+                strong: [],
+                u: [],
+                ul: [],
+            },
             content: `
                 <h5 class='mb-0 mt-2 fw-bold'>${arrangement.name}</h5>
                 <div>
@@ -278,7 +312,7 @@ export class PlannerCalendar extends FullCalendarBased {
                         ${arrangement.arrangement_type}
                     </div>
                     <div class='col-12 text-center mt-2'>
-                        <div class='border border-1 p-2 rounded-pill fw-bold'>
+                        <div class='border border-1 p-2 rounded-pill fw-bold' style='background-color: ${arrangement.status_color}'>
                             ${ arrangement.status_name ?? "Ingen status" }
                         </div>
                     </div>

--- a/webook/templates/common/dialog_list_view.html
+++ b/webook/templates/common/dialog_list_view.html
@@ -1,4 +1,4 @@
-{% extends "arrangement/meta_base.html" %}
+{% extends "common/meta_base.html" %}
 {% load static i18n %}
 
 


### PR DESCRIPTION
### Fix statustype coloring in popovers

Status types are badge-like in popovers. These badges should have the background color which corresponds to the color picked for the statustype. I was not able to get this done initially, and let it be as it was (white background). Style attributes were not respected due to them not being in the popover whitelist/allowlist. I have fixed this, and added this as an allowed attribute in this specific instance.