### PR TITLE
Adjustments again on room dialog

### DIFF
--- a/webook/static/css/nasj_style.css
+++ b/webook/static/css/nasj_style.css
@@ -22,6 +22,11 @@
     text-transform: none;
 }
 
+.webook-tabs .nav-link.active {
+    color: var(--ACTIVE-TEXT-COLOR);
+    border-bottom: solid 3.2px var(--ACTIVE-TEXT-COLOR);
+}
+
 .webook-tabs > .nav-item > .nav-link.active {
     color: var(--ACTIVE-TEXT-COLOR);
     border-bottom: solid 3.2px var(--ACTIVE-TEXT-COLOR);

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -316,7 +316,6 @@ class DialogEventCommunicationLane {
      * @param {*} payload Payload
      */
     send(typeName, payload) {
-        console.log(">> send " + typeName, { dialogElement: this.dialogElement, payload:payload });
         this.dialogElement.dispatchEvent(new CustomEvent("laneCommunication", { "detail": { name: typeName, payload: payload } }));
     }
 }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
@@ -29,8 +29,8 @@
 
             <h5 class="mt-3">Eller velg rom manuelt</h5>
             <div class="row">
-                <div class="col-3">
-                  <div class="nav flex-column nav-tabs text-center"
+                <div class="col-12 mb-2">
+                  <div class="nav flex-column webook-tabs text-center"
                     id="tabs-tab"
                     role="tablist"
                     aria-orientation="vertical">
@@ -49,7 +49,7 @@
                   </div>
                 </div>
               
-                <div class="col-9">
+                <div class="col-12">
                   <div class="tab-content" id="v-tabs-tabContent">
                       {% for location in locations %}
                         <div

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderRoomDialog.html
@@ -59,7 +59,7 @@
                             aria-labelledby="tabs-{{location.slug}}-tab">
 
                             <div class="table-responsive">
-                                <table class="table table-sm table-striped mt-2" id="{{location.slug}}_roomsTable">
+                                <table class="table table-sm table-striped mt-2 rooms-in-location-table" id="{{location.slug}}_roomsTable">
                                     <thead>
                                         <tr>
                                             <th>Rom</th>
@@ -165,6 +165,16 @@
                         {% endfor %}
                     ]),
                     checkboxIdPrefix: "roomCheck",
+                    rooms: new Map([
+                        {% for location in locations %}
+                            {% for room in location.rooms.all %}
+                            [
+                                {{ room.pk }}, "{{ room.name }}"
+                            ],
+                            {% endfor %}
+                        {% endfor %}
+                    ]),
+                    datatables: ( dialog ) => { return dialog.querySelectorAll("table.rooms-in-location-table") },
                 }
             }
         ],


### PR DESCRIPTION
### Adjustments again on room dialog

Introduces a few adjustments on the room dialog to alleviate some of the pains with it.
1. Locations tabs will now appear on top of the tables (thus freeing up some horizontal real-estate for the table), which will probably/hopefully help in avoiding locations overflowing into rooms table.
2. Made a few alterations and patches to fix state management of the order room dialog. Datatables removes elements from the document when they are not in view -- but the code was assuming these to exist. I have made a few tactical adjustments to make sure that this does not affect us. We now alternatively keep a track of state internally in the dialog plugin, and when any of the datatables are being drawn (which will also be triggered by paginate) we try to check all the checkboxes we know of internally in the plugin. It works well. That being said there should probably be a rewrite of this plugin, but the inadequacies of its implementation are localized I suppose, so there isn't really any worthwhile reason to do so except for more brief and succinct code.