### PR TITLE
Communication between dialogs

### DIFF
--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -358,7 +358,7 @@ class GetArrangementsInPeriod (LoginRequiredMixin, ListView):
                             ev.buffer_after_event_id as after_buffer_ev_id, ev.buffer_before_event_id as before_buffer_ev_id,
                             (SELECT EXISTS(SELECT id from arrangement_event WHERE buffer_before_event_id = ev.id OR buffer_after_event_id = ev.id)) AS is_rigging,
                             GROUP_CONCAT( DISTINCT room.name) as room_names, 
-                            GROUP_CONCAT( DISTINCT participants.first_name || " " || participants.las   t_name ) as people_names,
+                            GROUP_CONCAT( DISTINCT participants.first_name || " " || participants.last_name ) as people_names,
                             (loc.slug || "," || GROUP_CONCAT(DISTINCT room.slug ) || "," || GROUP_CONCAT(DISTINCT participants.slug) ) as slug_list
                             from arrangement_arrangement as arr 
                             JOIN arrangement_arrangementtype as arrtype on arrtype.id = arr.arrangement_type_id

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -134,7 +134,9 @@ export class ArrangementCreator {
                                     let serie = context.series.get(context.lastTriggererDetails.serie_uuid);
                                     const $dialogElement = $(this.dialogManager.$getDialogElement("newTimePlanDialog"));
                                     
-                                    PopulateCreateSerieDialogFromSerie(serie, $dialogElement);
+                                    this.dialogManager._dialogRepository.get("newTimePlanDialog");
+
+                                    PopulateCreateSerieDialogFromSerie(serie, $dialogElement, "newTimePlanDialog");
                                 }
                             }
                             

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -357,7 +357,7 @@ export class ArrangementCreator {
                             
                             this.dialogManager.setTitle("newSimpleActivityDialog", "Rediger aktivitet");
                             const $dialogElement = $(this.dialogManager.$getDialogElement("newSimpleActivityDialog"));
-                            PopulateCreateEventDialog(context.events.get(context.lastTriggererDetails.event_uuid), $dialogElement);
+                            PopulateCreateEventDialog(context.events.get(context.lastTriggererDetails.event_uuid), $dialogElement, "newSimpleActivityDialog");
 
                             document.querySelectorAll('.form-outline').forEach((formOutline) => {
                                 new mdb.Input(formOutline).init();

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -568,7 +568,7 @@ export class ArrangementInspector {
                             let $dialogElement = $(this.dialogManager.$getDialogElement("editEventSerieDialog"));
                             let manifest = await QueryStore.GetSerieManifest(context.editing_serie_pk);
                             
-                            PopulateCreateSerieDialogFromManifest(manifest, context.editing_serie_pk, $dialogElement);
+                            PopulateCreateSerieDialogFromManifest(manifest, context.editing_serie_pk, $dialogElement, "editEventSerieDialog");
 
                             const editEventSerieDialog = this.dialogManager._dialogRepository.get("editEventSerieDialog");
                             editEventSerieDialog.communicationLane.send("setAudienceFromParent", manifest.audience);

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -1,4 +1,4 @@
-import { CollisionsUtil } from "./collisions_util.js";
+    import { CollisionsUtil } from "./collisions_util.js";
 import { convertObjToFormData } from "./commonLib.js";
 import { Dialog, DialogManager } from "./dialog_manager/dialogManager.js";
 import { PopulateCreateSerieDialogFromManifest } from "./form_populating_routines.js";

--- a/webook/static/modules/planner/broadcast.js
+++ b/webook/static/modules/planner/broadcast.js
@@ -1,0 +1,53 @@
+class Recipient {
+    constructor(name) {
+        this.name = name;
+        this._messages = new Map();
+    }
+
+    leaveMessage(messageKey, message) {
+        if (!messageKey)
+            messageKey = crypto.randomUUID();
+
+        this._messages.set(messageKey, message);
+    }
+
+    getMessage(messageKey) {
+        return this._messages.get(messageKey);
+    }
+
+    allMessages() {
+        return Array.from(this._messages.values());
+    }
+
+    clear() {
+        this._messages = [];
+    }
+}
+
+export class MessagesFacility {
+    constructor() {
+        this._recipients = new Map();
+        this._subscriptions = new Map();
+    }
+
+    send(recipient, payload, key=undefined) {
+        if (!this._recipients.has(recipient))
+            this._recipients.set(recipient, new Recipient(recipient));
+        
+        this._recipients.get(recipient).leaveMessage(key, payload);
+        
+        if (this._subscriptions.get(recipient))
+            this._subscriptions.get(recipient).forEach((subscriptionFunction) => { subscriptionFunction(key, payload) });
+    }
+
+    addressedTo(recipient) {
+        return this._recipients.get(recipient);
+    }
+
+    subscribe( recipient, onChange ) {
+        if (this._subscriptions.has( recipient ))
+            this._subscriptions.get( recipient ).push( onChange );
+        else
+            this._subscriptions.set( recipient, [ onChange ] );
+    }
+}

--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -39,6 +39,7 @@ class Dialog {
         this._listenToEventLaneCommunication()
         
         this.oldMessages = window.MessagesFacility.addressedTo(this.dialogId)?._messages;
+        console.log("oldMessages", this.oldMessages);
         if (this.oldMessages) {
             for (let [key, value] of this.oldMessages)
             {
@@ -55,8 +56,8 @@ class Dialog {
     _listenToGlobalBroadcasts () {
         window.MessagesFacility.subscribe(
             this.dialogId,
-            this._handleMessage,
-        )
+            this._handleMessage.bind(this),
+        );
     }
 
     _handleMessage(messageKey, message) {
@@ -75,6 +76,7 @@ class Dialog {
                 this._whenMap.set(when.eventKnownAs, when.do);
             });
         }
+        console.log("doneMapped")
     }
 
     _listenToEventLaneCommunication() {

--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -44,7 +44,7 @@ class Dialog {
             {
                 this._handleMessage(key, value);
             }
-            window.MessagesFacility.addressedTo(self.dialogId)?.clear();
+            window.MessagesFacility.addressedTo(this.dialogId)?.clear();
         }
 
         this._listenToGlobalBroadcasts();

--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -16,6 +16,8 @@ class Dialog {
         this.dialogId = dialogId;
         this.discriminator = discriminator;
 
+        this.dialogId = dialogId;
+
         this.data = data;
         this.when = when;
         this.plugins = plugins;
@@ -36,8 +38,14 @@ class Dialog {
         this._initializePlugins();
         this._listenToEventLaneCommunication()
         
-        this.oldMessages = window.MessagesFacility.addressedTo(self.dialogId)?._messages;
-        window.MessagesFacility.addressedTo(self.dialogId)?.clear();
+        this.oldMessages = window.MessagesFacility.addressedTo(this.dialogId)?._messages;
+        if (this.oldMessages) {
+            for (let [key, value] of this.oldMessages)
+            {
+                this._handleMessage(key, value);
+            }
+            window.MessagesFacility.addressedTo(self.dialogId)?.clear();
+        }
 
         this._listenToGlobalBroadcasts();
 
@@ -47,15 +55,13 @@ class Dialog {
     _listenToGlobalBroadcasts () {
         window.MessagesFacility.subscribe(
             this.dialogId,
-            (messageKey, message) => { 
-                console.log("TRIGGER::::" + messageKey, message)
-                if (this._whenMap.has(messageKey))
-                {
-                    console.log("TRIGGER::::" + messageKey, message)
-                    this._whenMap.get(messageKey)(this, message);
-                }
-            }
+            this._handleMessage,
         )
+    }
+
+    _handleMessage(messageKey, message) {
+        if (this._whenMap.has(messageKey))
+            this._whenMap.get(messageKey)(this, message);
     }
 
     _mapWhenMethods() {

--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -60,6 +60,9 @@ class Dialog {
     }
 
     _handleMessage(messageKey, message) {
+        if (this === undefined || this._whenMap === undefined)
+            return null;
+
         if (this._whenMap.has(messageKey))
             this._whenMap.get(messageKey)(this, message);
     }

--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -36,7 +36,26 @@ class Dialog {
         this._initializePlugins();
         this._listenToEventLaneCommunication()
         
+        this.oldMessages = window.MessagesFacility.addressedTo(self.dialogId)?._messages;
+        window.MessagesFacility.addressedTo(self.dialogId)?.clear();
+
+        this._listenToGlobalBroadcasts();
+
         postInit(this);
+    }
+
+    _listenToGlobalBroadcasts () {
+        window.MessagesFacility.subscribe(
+            this.dialogId,
+            (messageKey, message) => { 
+                console.log("TRIGGER::::" + messageKey, message)
+                if (this._whenMap.has(messageKey))
+                {
+                    console.log("TRIGGER::::" + messageKey, message)
+                    this._whenMap.get(messageKey)(this, message);
+                }
+            }
+        )
     }
 
     _mapWhenMethods() {
@@ -50,6 +69,7 @@ class Dialog {
     }
 
     _listenToEventLaneCommunication() {
+        console.log("whens listen on ---> ", this.$dialogElement);
         this.$dialogElement.on("laneCommunication", (event) => {
             this._whenMap.get(event.detail.name)(this, event.detail.payload);
         });

--- a/webook/static/modules/planner/form_populating_routines.js
+++ b/webook/static/modules/planner/form_populating_routines.js
@@ -167,7 +167,8 @@ export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dia
         { to: '#id_display_text_en', value: manifest.display_text_en },
     ].forEach( (mapping) => { $dialogElement.find(mapping.to).val(mapping.value ).trigger('change'); } );
 
-    console.log("manifest", manifest)
+    window.MessagesFacility.send(dialogId, manifest.audience, "setAudienceFromParent");
+    window.MessagesFacility.send(dialogId, manifest.arrangement_type, "setArrangementTypeFromParent");
 
     if (manifest.rooms) {
         manifest.rooms.allPresets = new Map([
@@ -181,8 +182,7 @@ export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dia
     }
 
     manifest.display_layouts.forEach(display_layout => {
-        $dialogElement.find('#id_display_layouts_serie_planner_' + display_layout.id)
-            .prop( "checked", true );
+        $dialogElement.find('#id_display_layouts_serie_planner_' + display_layout.id).prop( "checked", true );
     })
 
     switch(manifest.recurrence_strategy) {

--- a/webook/static/modules/planner/form_populating_routines.js
+++ b/webook/static/modules/planner/form_populating_routines.js
@@ -1,4 +1,5 @@
-export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialog) {
+
+export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialogId, discriminator) {
     if (serie === undefined) {
         console.error("Serie is undefined", serie);
         debugger;
@@ -33,30 +34,50 @@ export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialog
         $dialogElement.find( mapping.target ).val( mapping.value );
     } );
 
-    // This is fairly messy I am afraid, but the gist of what we're doing here is simulating that the user
-    // has "selected" rooms as they would through the dialog interface.
-    if (serie.people.length > 0) {
-        let peopleSelectContext = Object();
-        peopleSelectContext.people = serie.people.join(",");
-        peopleSelectContext.people_name_map = serie.people_name_map;
-        document.dispatchEvent(new CustomEvent(
-            "arrangementCreator.d2_peopleSelected",
-            { detail: {
-                context: peopleSelectContext
-            } }
-        ));
+    if (serie.room_payload) {
+        window.MessagesFacility.send(dialogId, serie.room_payload, "roomsSelected");
     }
-    if (serie.rooms.length > 0) {
-        let roomSelectContext = Object();
-        roomSelectContext.rooms = serie.rooms.join(",");
-        roomSelectContext.room_name_map = serie.room_name_map;
-        document.dispatchEvent(new CustomEvent(
-            "arrangementCreator.d2_roomsSelected",
-            { detail: {
-                context: roomSelectContext
-            } }
-        ));
-    }
+    if (serie.people_payload)
+        $dialogElement.find("#" + dialogId)[0].dispatchEvent(new CustomEvent("peopleSelected", {
+            detail: {
+                payload: serie.people_payload
+            }
+        }));
+
+    // if (serie.people.length > 0) {
+    //     $dialogElement[0].dispatchEvent("peopleSelected", {
+    //         detail: {
+    //             payload: { 
+    //                 viewables: {  }
+    //             }
+    //         }
+    //     })
+    // }
+
+    // // This is fairly messy I am afraid, but the gist of what we're doing here is simulating that the user
+    // // has "selected" rooms as they would through the dialog interface.
+    // if (serie.people.length > 0) {
+    //     let peopleSelectContext = Object();
+    //     peopleSelectContext.people = serie.people.join(",");
+    //     peopleSelectContext.people_name_map = serie.people_name_map;
+    //     document.dispatchEvent(new CustomEvent(
+    //         "arrangementCreator.d2_peopleSelected",
+    //         { detail: {
+    //             context: peopleSelectContext
+    //         } }
+    //     ));
+    // }
+    // if (serie.rooms.length > 0) {
+    //     let roomSelectContext = Object();
+    //     roomSelectContext.rooms = serie.rooms.join(",");
+    //     roomSelectContext.room_name_map = serie.room_name_map;
+    //     document.dispatchEvent(new CustomEvent(
+    //         "arrangementCreator.d2_roomsSelected",
+    //         { detail: {
+    //             context: roomSelectContext
+    //         } }
+    //     ));
+    // }
 
     serie.display_layouts.split(",").forEach(element => {
         $dialogElement.find('#id_display_layouts_serie_planner_' + element).prop( "checked", true );

--- a/webook/static/modules/planner/form_populating_routines.js
+++ b/webook/static/modules/planner/form_populating_routines.js
@@ -34,50 +34,14 @@ export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialog
         $dialogElement.find( mapping.target ).val( mapping.value );
     } );
 
+    console.log("serie", serie);
+
     if (serie.room_payload) {
         window.MessagesFacility.send(dialogId, serie.room_payload, "roomsSelected");
     }
-    if (serie.people_payload)
-        $dialogElement.find("#" + dialogId)[0].dispatchEvent(new CustomEvent("peopleSelected", {
-            detail: {
-                payload: serie.people_payload
-            }
-        }));
-
-    // if (serie.people.length > 0) {
-    //     $dialogElement[0].dispatchEvent("peopleSelected", {
-    //         detail: {
-    //             payload: { 
-    //                 viewables: {  }
-    //             }
-    //         }
-    //     })
-    // }
-
-    // // This is fairly messy I am afraid, but the gist of what we're doing here is simulating that the user
-    // // has "selected" rooms as they would through the dialog interface.
-    // if (serie.people.length > 0) {
-    //     let peopleSelectContext = Object();
-    //     peopleSelectContext.people = serie.people.join(",");
-    //     peopleSelectContext.people_name_map = serie.people_name_map;
-    //     document.dispatchEvent(new CustomEvent(
-    //         "arrangementCreator.d2_peopleSelected",
-    //         { detail: {
-    //             context: peopleSelectContext
-    //         } }
-    //     ));
-    // }
-    // if (serie.rooms.length > 0) {
-    //     let roomSelectContext = Object();
-    //     roomSelectContext.rooms = serie.rooms.join(",");
-    //     roomSelectContext.room_name_map = serie.room_name_map;
-    //     document.dispatchEvent(new CustomEvent(
-    //         "arrangementCreator.d2_roomsSelected",
-    //         { detail: {
-    //             context: roomSelectContext
-    //         } }
-    //     ));
-    // }
+    if (serie.people_payload) {
+        window.MessagesFacility.send(dialogId, serie.people_payload, "peopleSelected");
+    }
 
     serie.display_layouts.split(",").forEach(element => {
         $dialogElement.find('#id_display_layouts_serie_planner_' + element).prop( "checked", true );
@@ -342,7 +306,7 @@ export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dia
  *
  * @param {*} event
  */
-export function PopulateCreateEventDialog(event, $dialogElement) {
+export function PopulateCreateEventDialog(event, $dialogElement, dialogId) {
     let parseDateOrStringToArtifacts = function (dateOrString) {
         if (dateOrString instanceof String)
             return Utils.splitStrDate(dateOrString);
@@ -387,36 +351,15 @@ export function PopulateCreateEventDialog(event, $dialogElement) {
 
     if (Array.isArray(event.display_layouts)) {
         event.display_layouts.forEach(element => {
-            $dialogElement.find(`#${String(parseInt(element))}_dlcheck`)
-                .prop( "checked", true );
+            $dialogElement.find(`#${String(parseInt(element))}_dlcheck`).prop( "checked", true );
         })
     }
     else {
         throw "Display layouts must be an array";
     }
 
-    // This is fairly messy I am afraid, but the gist of what we're doing here is simulating that the user
-    // has "selected" rooms as they would through the dialog interface.
-    if (event.people.length > 0) {
-        var peopleSelectContext = Object();
-        peopleSelectContext.people = event.people.join(",");
-        peopleSelectContext.people_name_map = event.people_name_map;
-        document.dispatchEvent(new CustomEvent(
-            "arrangementCreator.d1_peopleSelected",
-            { detail: {
-                context: peopleSelectContext
-            } }
-        ));
-    }
-    if (event.rooms.length > 0) {
-        var roomSelectContext = Object();
-        roomSelectContext.rooms = event.rooms.join(",");
-        roomSelectContext.room_name_map = event.room_name_map;
-        document.dispatchEvent(new CustomEvent(
-            "arrangementCreator.d1_roomsSelected",
-            { detail: {
-                context: roomSelectContext
-            } }
-        ));
-    }
+    if (event.people_payload)
+        window.MessagesFacility.send(dialogId, event.people_payload, "peopleSelected");
+    if (event.room_payload)
+        window.MessagesFacility.send(dialogId, event.room_payload, "roomsSelected");
 }

--- a/webook/static/modules/planner/form_populating_routines.js
+++ b/webook/static/modules/planner/form_populating_routines.js
@@ -149,7 +149,7 @@ export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialog
  *
  * @param {*} manifest
  */
-export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dialogElement) {
+export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dialogElement, dialogId) {
     [
         { to: "#serie_uuid", value: serie_uuid },
         { to: "#serie_title", value: manifest.title },
@@ -167,39 +167,17 @@ export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dia
         { to: '#id_display_text_en', value: manifest.display_text_en },
     ].forEach( (mapping) => { $dialogElement.find(mapping.to).val(mapping.value ).trigger('change'); } );
 
-    if (manifest.rooms.length > 0) {
-        let roomSelectContext = Object();
-        roomSelectContext.rooms = manifest.rooms.map(a => a.id).join(",");
-        roomSelectContext.room_name_map = new Map();
+    console.log("manifest", manifest)
 
-        for (let i = 0; i < manifest.rooms.length; i++) {
-            let room = manifest.rooms[i];
-            roomSelectContext.room_name_map.set(String(room.id), room.name);
-        }
+    if (manifest.rooms) {
+        manifest.rooms.allPresets = new Map([
+            Object.entries(manifest.rooms.allPresets).map(x => [ x, manifest.rooms.allPresets[x]] )
+        ]);
 
-        document.dispatchEvent(new CustomEvent(
-            "arrangementInspector.d2_roomsSelected",
-            { detail: {
-                context: roomSelectContext
-            } }
-        ));
+        window.MessagesFacility.send(dialogId, manifest.rooms, "roomsSelected");
     }
-    if (manifest.people.length > 0) {
-        let peopleSelectContext = Object();
-        peopleSelectContext.people = manifest.people.map(a => a.id).join(",");
-        peopleSelectContext.people_name_map = new Map();
-
-        for (let i = 0; i < manifest.people.length; i++) {
-            let person = manifest.people[i];
-            peopleSelectContext.people_name_map.set(String(person.id), person.name);
-        }
-
-        document.dispatchEvent(new CustomEvent(
-            "arrangementInspector.d2_peopleSelected",
-            { detail: {
-                context: peopleSelectContext
-            } }
-        ));
+    if (manifest.people) {
+        window.MessagesFacility.send(dialogId, manifest.people, "peopleSelected");
     }
 
     manifest.display_layouts.forEach(display_layout => {
@@ -360,6 +338,7 @@ export function PopulateCreateEventDialog(event, $dialogElement, dialogId) {
 
     if (event.people_payload)
         window.MessagesFacility.send(dialogId, event.people_payload, "peopleSelected");
-    if (event.room_payload)
+    if (event.room_payload) {
         window.MessagesFacility.send(dialogId, event.room_payload, "roomsSelected");
+    }
 }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -1122,6 +1122,8 @@
         },
         when: [
             { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
+                console.log("roomsSelected!!", payload);
+
                 let wrapper = dialog.$( '#roomChips' );
                 wrapper.empty();
                 

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -1166,10 +1166,16 @@
                 dialog.data.peoplePayload = payload;
             } },
             { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
-                dialog.data.audienceJsTreeSelect.setSelected(payload);
+                if (dialog.data.audienceJsTreeSelect)
+                    dialog.data.audienceJsTreeSelect.setSelected(payload);
+                else
+                    dialog.$('#_backingAudienceId').val(payload);
             } },
             { eventKnownAs: "setArrangementTypeFromParent", do: (dialog, payload) => {
-                dialog.data.arrangementTypeJsTreeSelect.setSelected(payload);
+                if (dialog.data.arrangementTypeJsTreeSelect)
+                    dialog.data.arrangementTypeJsTreeSelect.setSelected(payload)
+                else
+                    dialog.$('#_backingArrangementTypeId').val(payload);
             } },
         ],
         plugins: [

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -593,6 +593,9 @@
         managerName: '{{ managerName }}',
         discriminator: '{{ discriminator }}',
         postInit: function (dialog) {
+
+            console.log(dialog.oldMessages);
+
             dialog.data.audienceJsTreeSelect = new JSTreeSelect({
                 element: dialog.querySelector('#audience_jstree_select'),
                 treeJsonSrcUrl: "/arrangement/audience/tree",
@@ -1008,7 +1011,9 @@
                 serie.rooms = Array.from(dialog.data.selectedRoomIds.keys());
                 serie.people = Array.from(dialog.data.selectedPeopleIds.keys());
                 serie.room_name_map = dialog.data.roomsNameMap;
+                serie.room_payload = dialog.data.roomPayload;
                 serie.people_name_map = dialog.data.peopleNameMap;
+                serie.people_payload = dialog.data.peoplePayload;
                 serie.display_layouts = display_layouts.join(",");
 
                 dialog.raiseSubmitEvent({
@@ -1117,6 +1122,7 @@
         },
         when: [
             { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
+                console.log("!!roomsSelected!! -- " + dialog.dialogId, payload)
                 let wrapper = dialog.$( '#roomChips' );
                 wrapper.empty();
 
@@ -1134,11 +1140,13 @@
                 dialog.data.roomPresets = new Map();
                 payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );
                 payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
+
+                dialog.data.roomPayload = payload;
             } },
             { eventKnownAs: "peopleSelected", do: (dialog, payload) => { 
                 let wrapper = dialog.$( '#peopleChips' );
                 wrapper.empty();
-
+                
                 payload.viewables.forEach((person) => {
                     wrapper.append(
                         $(`<selected-pill name='${person.text}'
@@ -1153,6 +1161,8 @@
                 dialog.data.personPresets = new Map();
                 payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedPeopleIds.set(x.id, true) );
                 payload.selectedPresets.forEach( (presetId) => dialog.data.personPresets.set(presetId, payload.allPresets.get(presetId)) );
+
+                dialog.data.personPayload = payload;
             } },
             { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
                 dialog.data.audienceJsTreeSelect.setSelected(payload);

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -1122,10 +1122,13 @@
         },
         when: [
             { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
-                console.log("!!roomsSelected!! -- " + dialog.dialogId, payload)
+                console.log("{{discriminator}} got a message!", payload);
+                // console.log("!!roomsSelected!! -- " + dialog.dialogId, payload)
                 let wrapper = dialog.$( '#roomChips' );
                 wrapper.empty();
-
+                
+                console.log("wrapper before", wrapper);
+                
                 payload.viewables.forEach((room) => {
                     wrapper.append(
                         $(`<selected-pill name='${room.text}'
@@ -1135,6 +1138,8 @@
                            </selected-pill>`)  
                     )
                 });
+
+                console.log("wrapper after", wrapper);
 
                 dialog.data.selectedRoomIds = new Map();
                 dialog.data.roomPresets = new Map();

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -1122,12 +1122,8 @@
         },
         when: [
             { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
-                console.log("{{discriminator}} got a message!", payload);
-                // console.log("!!roomsSelected!! -- " + dialog.dialogId, payload)
                 let wrapper = dialog.$( '#roomChips' );
                 wrapper.empty();
-                
-                console.log("wrapper before", wrapper);
                 
                 payload.viewables.forEach((room) => {
                     wrapper.append(
@@ -1138,8 +1134,6 @@
                            </selected-pill>`)  
                     )
                 });
-
-                console.log("wrapper after", wrapper);
 
                 dialog.data.selectedRoomIds = new Map();
                 dialog.data.roomPresets = new Map();
@@ -1167,7 +1161,7 @@
                 payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedPeopleIds.set(x.id, true) );
                 payload.selectedPresets.forEach( (presetId) => dialog.data.personPresets.set(presetId, payload.allPresets.get(presetId)) );
 
-                dialog.data.personPayload = payload;
+                dialog.data.peoplePayload = payload;
             } },
             { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
                 dialog.data.audienceJsTreeSelect.setSelected(payload);

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -456,6 +456,8 @@
                     meeting_place_en:           dialog.interior.id_meeting_place_en.value,
                     responsible:                dialog.interior.id_responsible.value,
                     display_text:               dialog.plugins.showIfSelected.isInShowState() ? dialog.interior.id_display_text.value : '',
+                    room_payload:               dialog.data.roomPayload,
+                    people_payload:             dialog.data.peoplePayload,
                 };
 
                 console.log("qualifiedEvent", qualifiedEvent);
@@ -503,7 +505,6 @@
                 }
 
                 if (id.startsWith("preset_")) {
-                    debugger;
                     const preset = appropriatePresetMap.get(id.split("_")[1]);
                     preset.ids.forEach((id) => appropriateIdMap.delete(id));
                 }
@@ -545,6 +546,8 @@
                 dialog.data.roomPresets = new Map();
                 payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );
                 payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
+
+                dialog.data.roomPayload = payload;
             } },
             { eventKnownAs: "peopleSelected", do: (dialog, payload) => {
                 let wrapper = dialog.$('#selectedPeopleWrapper');
@@ -563,6 +566,8 @@
                 dialog.data.personPresets = new Map();
                 payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedPeopleIds.set(x.id, true) );
                 payload.selectedPresets.forEach( (presetId) => dialog.data.personPresets.set(presetId, payload.allPresets.get(presetId)) );
+
+                dialog.data.peoplePayload = payload;
             } },
             { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
                 dialog.data.audienceJsTreeSelect.setSelected(payload);

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -396,6 +396,11 @@
       <script type="module">
         import dialogApi from "{% static 'modules/planner/dialog_manager/dialogApi.js' %}";
         import { Popover } from "{% static 'js/popover.js' %}";
+        import { MessagesFacility } from "{% static 'modules/planner/broadcast.js' %}";
+
+        $(document).ready(function () {
+          window.MessagesFacility = new MessagesFacility();
+        });
 
         const othersPopover = new Popover({
             triggerElement: document.getElementById('toggleOthersPopover'),


### PR DESCRIPTION
### Communication between dialogs

This PR introduces fixes and a new way of communicating between dialogs, primarily intended to fix the issue of not being able to remember selected rooms and people when editing an existing serie. This proved to be a rather more intricate problem than initially thought, as race conditions were present when sending messages between dialogs through the old way.
The way I solved this is to add a simple message handler class, that is global in scope, and should thus always be present to receive messages. If a dialog is created after messages to it has been sent, then it will be able to find these before-itself messages in window.MessagesFacility, and dialogs will also hook themselves up to MessagesFacility, allowing directly sending messages to MessagesFacility and triggering WHEN events.
It's not entirely ideal, but it is a working solution that seems to guarantee that dialogs receive messages regardless of timing.
