### PR TITLE
Add better indication of filter status

### DIFF
--- a/webook/arrangement/views/planner_views.py
+++ b/webook/arrangement/views/planner_views.py
@@ -359,7 +359,7 @@ class GetArrangementsInPeriod (LoginRequiredMixin, ListView):
                             (SELECT EXISTS(SELECT id from arrangement_event WHERE buffer_before_event_id = ev.id OR buffer_after_event_id = ev.id)) AS is_rigging,
                             GROUP_CONCAT( DISTINCT room.name) as room_names, 
                             GROUP_CONCAT( DISTINCT participants.first_name || " " || participants.last_name ) as people_names,
-                            (GROUP_CONCAT(DISTINCT room.slug ) || "," || GROUP_CONCAT(DISTINCT participants.slug) ) as slug_list
+                            GROUP_CONCAT(DISTINCT room.slug ) || "," || GROUP_CONCAT(DISTINCT participants.slug) as slug_list
                             from arrangement_arrangement as arr 
                             JOIN arrangement_arrangementtype as arrtype on arrtype.id = arr.arrangement_type_id
                             JOIN arrangement_location as loc on loc.id = arr.location_id

--- a/webook/static/js/advancedTreeFilter.js
+++ b/webook/static/js/advancedTreeFilter.js
@@ -29,6 +29,7 @@ export class AdvancedTreeFilter extends Popover {
         treeSrcUrl,
         cascadeBehaviour=NORMAL_CASCADE_BEHAVIOUR,
         isSearchable=false,
+        onChange=null,
         } = {} ) 
         { 
             super({
@@ -39,6 +40,8 @@ export class AdvancedTreeFilter extends Popover {
             this.title = title;
             this.isSearchable = isSearchable;
             this.cascadeBehaviour = cascadeBehaviour;
+
+            this.onChange = onChange;
 
             this._instanceDiscriminator = crypto.randomUUID();
 
@@ -56,12 +59,25 @@ export class AdvancedTreeFilter extends Popover {
             this._categorySearchMap = new Map();
 
             this._render();
+            this._bindOnChange();
         }
 
         async _loadTreeJson() {
             return fetch(this.treeSrcUrl, {
                 method: 'GET'
             }).then(response => response.json())
+        }
+        
+        _$getJsTreeElement() {
+            return $(this._jsTreeElement);
+        }
+
+        _bindOnChange() {
+            if (typeof this.onChange === "function") {
+                $(this._jsTreeElement).on("changed.jstree", (e, data) => {
+                    this.onChange( this, data );
+                });
+            }
         }
 
         getSelectedValues() {
@@ -107,7 +123,7 @@ export class AdvancedTreeFilter extends Popover {
                 const selectedNodes = $(this._jsTreeElement).jstree("get_selected", true);
                 const undeterminedNodes = $(this._jsTreeElement).jstree("get_undetermined", true);
 
-                this._onSubmit(selectedNodes, undeterminedNodes);
+                this._onSubmit(this, selectedNodes, undeterminedNodes);
             }
             popoverContentEl.appendChild(submitBtnElement)
 
@@ -119,7 +135,7 @@ export class AdvancedTreeFilter extends Popover {
                 .then(treeValidObj => {
                     this._jsTree = $(treeHolder).jstree({
                         'checkbox': getCascadeSettingsFromCascadeBehaviour(this.cascadeBehaviour),
-                        'plugins': [ 'checkbox', 'search' ], 
+                        'plugins': [ 'checkbox', 'search', 'changed' ], 
                         'core': {
                             "themes" : { "icons": false },
                             'data': treeValidObj,

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -277,15 +277,18 @@ export class ArrangementStore extends BaseStore {
                 isWithinFilter = false;
             }
 
+            console.log(arrangement.slug_list);
+
             if (filterMap.size > 0) {
                 let match = false;
                 for (let y = 0; y < arrangement.slug_list.length; y++) {
                     const slug = arrangement.slug_list[y];
-                    if (filterMap.has(slug) === true) {
+                    if (filterMap.has(slug)) {
                         match = true;
                         break;
                     }
                 }
+
                 isWithinFilter = match;
             }
 

--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -39,7 +39,7 @@ class Dialog {
         this._listenToEventLaneCommunication()
         
         this.oldMessages = window.MessagesFacility.addressedTo(this.dialogId)?._messages;
-        console.log("oldMessages", this.oldMessages);
+
         if (this.oldMessages) {
             for (let [key, value] of this.oldMessages)
             {
@@ -76,11 +76,9 @@ class Dialog {
                 this._whenMap.set(when.eventKnownAs, when.do);
             });
         }
-        console.log("doneMapped")
     }
 
     _listenToEventLaneCommunication() {
-        console.log("whens listen on ---> ", this.$dialogElement);
         this.$dialogElement.on("laneCommunication", (event) => {
             this._whenMap.get(event.detail.name)(this, event.detail.payload);
         });

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -258,13 +258,8 @@ container-fluid
         triggerElement: document.getElementById('location-and-rooms-popover-filter-trigger'),
         wrapperElement: document.getElementById('location-and-rooms-popover-filter-content'),
         onSubmit: function (selectedNodes, undeterminedNodes) {
-            let totalItemsCount = 0;
-
-            let locationSlugs = selectedNodes.filter( x => !!x.parents == false ).map( x => x.id );
-            let roomSlugs = selectedNodes.filter( x => !!x.parents ).map( x => { return { id: x.id }; } );
-            
-            console.log("roomSlugs", roomSlugs);
-            console.log("SelectedNodes;; ", selectedNodes);
+            let locationSlugs = selectedNodes.filter( x => x.parent === "#" ).map( x => x.id );
+            let roomSlugs = selectedNodes.filter( x => x.parent !== "#" ).map( x => { return { id: x.id }; } );
 
             calendarFilter.filterRooms(roomSlugs, false);
             calendarFilter.filterLocations(locationSlugs);
@@ -272,65 +267,7 @@ container-fluid
         treeSrcUrl: "{% url 'arrangement:location_tree' %}",
         cascadeBehaviour: NORMAL_CASCADE_BEHAVIOUR,
         isSearchable: true,
-    })
-
-    {% comment %} let locationAndRoomsPopFilter = new AdvancedCategoricalFilter({
-        triggerMode: AdvancedCategoricalFilter.TRIGGERMODE_ONUPDATE,
-        triggerElement: document.getElementById('location-and-rooms-popover-filter-trigger'),
-        wrapperElement: document.getElementById('location-and-rooms-popover-filter-content'),
-        onSubmit: function (data) {
-            let roomSlugs = [];
-            let locationSlugs = [];
-            let totalItemsCount = 0;
-
-            data.forEach(function (category) {
-                totalItemsCount += category.items.length;
-                let notSelectedRoomSlugs = category.items.filter(x => x.active === false).map(x => x.key);
-                if (category.items.length == notSelectedRoomSlugs.length) {
-                    locationSlugs.push(category.category);
-                }
-
-                roomSlugs = roomSlugs.concat(notSelectedRoomSlugs);
-            });
-
-            if (totalItemsCount === roomSlugs.length) {
-                roomSlugs = [];
-                locationSlugs = [];
-            }
-
-            calendarFilter.filterRooms(roomSlugs, false);
-            calendarFilter.filterLocations(locationSlugs);
-        },
-        data: [
-            {% for location in LOCATIONS %}
-                {
-                    "key": "{{location.slug}}",
-                    "category": "{{location}}",
-                    "items": [
-                        {% for room in location.rooms.all %}
-                            {
-                                "key": "{{ room.slug }}",
-                                "text": "{{ room.name }}",
-                                "active": false,
-                            },
-                        {% endfor %}
-                    ]
-                },
-            {% endfor %}
-        ],
-        selectionPresets: [
-            {% for preset in ROOM_PRESETS %}
-            {
-                "title": "{{ preset.name }}",
-                "activates": [
-                    {% for room in preset.rooms.all %}
-                        "{{room.slug}}",
-                    {% endfor %}
-                ]
-            },
-            {% endfor %}
-        ],
-    }); {% endcomment %}
+    });
 
     const colorSwatch = [
         "#63b598", "#ce7d78", "#ea9e70", "#a48a9e", "#c6e1e8", "#648177", "#0d5ac1",

--- a/webook/templates/arrangement/planner/planner_calendar.html
+++ b/webook/templates/arrangement/planner/planner_calendar.html
@@ -227,13 +227,29 @@ container-fluid
     let activeCalendar;
     let calendarFilter = new CalendarFilter( (filter) => { activeCalendar.init(); } );
 
+    function reflectFilterStateOnTriggerElement(filter, countOfSelectedItems=0) {
+        filter.triggerElement.classList.remove("border-dark");
+        filter.triggerElement.querySelectorAll('.count-badge').forEach( (el) => el.remove() );
+
+        if (countOfSelectedItems) {
+            let badge = document.createElement('span');
+            badge.classList.add("badge", "badge-primary", "count-badge");
+            badge.innerHTML = "<i class='fas fa-filter'></i> " + countOfSelectedItems;
+            filter.triggerElement.appendChild(badge);
+
+            filter.triggerElement.classList.add("border-dark");
+        }
+    }
+
     const arrangementTypeTreeFilter = new AdvancedTreeFilter({
         title: 'Arrangementstyper',
         triggerElement: document.getElementById('arrangement-type-popover-filter-trigger'),
         wrapperElement: document.getElementById('arrangement-type-popover-filter-content'),
-        onSubmit: function (selectedNodes) {
+        onSubmit: function (filter, selectedNodes) {
             const slugs = selectedNodes.map( (node) => node.data.slug );
             calendarFilter.filterArrangementTypes(slugs);
+
+            reflectFilterStateOnTriggerElement(filter, slugs.length);
         },
         treeSrcUrl: "{% url 'arrangement:arrangement_type_tree_list' %}",
         cascadeBehaviour: PARENT_INDEPENDENT_CASCADE_BEHAVIOUR,
@@ -244,9 +260,11 @@ container-fluid
         title: 'Målgrupper',
         triggerElement: document.getElementById('audience-popover-filter-trigger'),
         wrapperElement: document.getElementById('audience-popover-filter-content'),
-        onSubmit: function (selectedNodes) { 
+        onSubmit: function (filter, selectedNodes) { 
             const slugs = selectedNodes.map( (node) => node.data.slug );
             calendarFilter.filterAudiences(slugs);
+
+            reflectFilterStateOnTriggerElement(filter, slugs.length);
         },
         treeSrcUrl: "{% url 'arrangement:audience_tree' %}",
         cascadeBehaviour: PARENT_INDEPENDENT_CASCADE_BEHAVIOUR,
@@ -257,9 +275,11 @@ container-fluid
         title: 'Lokasjoner & Rom',
         triggerElement: document.getElementById('location-and-rooms-popover-filter-trigger'),
         wrapperElement: document.getElementById('location-and-rooms-popover-filter-content'),
-        onSubmit: function (selectedNodes, undeterminedNodes) {
+        onSubmit: function (filter, selectedNodes, undeterminedNodes) {
             let locationSlugs = selectedNodes.filter( x => x.parent === "#" ).map( x => x.id );
             let roomSlugs = selectedNodes.filter( x => x.parent !== "#" ).map( x => { return { id: x.id }; } );
+
+            reflectFilterStateOnTriggerElement(filter, roomSlugs.length);
 
             calendarFilter.filterRooms(roomSlugs, false);
             calendarFilter.filterLocations(locationSlugs);


### PR DESCRIPTION
### Add better indication of filter status

This PR contains some improvements and cleanups of the existing filter code, as well as implementing functionality for reflecting the state of a filter unto its triggering element. This is necessary due to the tree-filters being hidden in the dropdowns, thus one can not easily tell the filter state when not actively actually filtering. Now these buttons/dropdown triggerers will have special styling as well as a badge with a total-filtered count, which makes the state a lot better communicated.