### PR TITLE
Fix selects bug -- through rewiring the flow

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -278,6 +278,14 @@ class StatusType(
     name = models.CharField(verbose_name=_("Name"), max_length=255)
     slug = AutoSlugField(populate_from="name", unique=True, manager_name="all_objects")
 
+    def as_node(self):
+        return {
+            "id": self.pk,
+            "text": self.name,
+            "children": [],
+            "data": {"slug": self.slug},
+        }
+
     def get_absolute_url(self):
         pass
 

--- a/webook/arrangement/urls/status_type_urls.py
+++ b/webook/arrangement/urls/status_type_urls.py
@@ -4,6 +4,7 @@ from webook.arrangement.views import (
     status_type_create_view,
     status_type_delete_view,
     status_type_list_view,
+    status_type_tree_json_view,
     status_type_update_view,
 )
 
@@ -27,5 +28,8 @@ status_type_urls = [
         route="statustype/delete/<slug:slug>",
         view=status_type_delete_view,
         name="statustype_delete",
+    ),
+    path(
+        route="statustype/tree", view=status_type_tree_json_view, name="statustype_tree"
     ),
 ]

--- a/webook/arrangement/views/__init__.py
+++ b/webook/arrangement/views/__init__.py
@@ -1,9 +1,9 @@
 # Arrangement Views
 
 # Example:
-#from .arrangement_views import (
+# from .arrangement_views import (
 #   arrangement_create_view
-#)
+# )
 
 
 from .analysis_views import (
@@ -83,7 +83,12 @@ from .location_views import (
     locations_calendar_resources_list_view,
     locations_tree_json_view,
 )
-from .note_views import delete_note_view, get_notes_view, notes_on_entity_view, post_note_view
+from .note_views import (
+    delete_note_view,
+    get_notes_view,
+    notes_on_entity_view,
+    post_note_view,
+)
 from .organization_views import (
     organization_create_view,
     organization_delete_view,
@@ -190,5 +195,6 @@ from .status_type_views import (
     status_type_create_view,
     status_type_delete_view,
     status_type_list_view,
+    status_type_tree_json_view,
     status_type_update_view,
 )

--- a/webook/arrangement/views/event_views.py
+++ b/webook/arrangement/views/event_views.py
@@ -38,65 +38,83 @@ from webook.utils.serie_calculator import calculate_serie
 
 
 class CreateEventSerieJsonFormView(LoginRequiredMixin, JsonFormView):
-    """ Create a new event serie / schedule """
+    """Create a new event serie / schedule"""
+
     form_class = CreateSerieForm
 
     def form_valid(self, form) -> JsonResponse:
         form.save(form, user=self.request.user)
         return super().form_valid(form)
 
+
 create_event_serie_json_view = CreateEventSerieJsonFormView.as_view()
 
 
 class CreateEventJsonFormView(LoginRequiredMixin, CreateView, JsonModelFormMixin):
-    """ View for event creation """
+    """View for event creation"""
+
     form_class = CreateEventForm
     model = Event
+
 
 create_event_json_view = CreateEventJsonFormView.as_view()
 
 
 class UpdateEventJsonFormView(LoginRequiredMixin, UpdateView, JsonModelFormMixin):
-    """ Update event """
+    """Update event"""
+
     model = Event
     form_class = UpdateEventForm
+
 
 update_event_json_view = UpdateEventJsonFormView.as_view()
 
 
 class DeleteEventJsonView(LoginRequiredMixin, JsonArchiveView):
-    """ Delete event """
+    """Delete event"""
+
     model = Event
+
 
 delete_event_json_view = DeleteEventJsonView.as_view()
 
 
 class UploadFilesToEventJsonFormView(LoginRequiredMixin, UploadFilesStandardFormView):
     """FormView that handles file uploads to an event"""
+
     model = Event
     file_relationship_model = EventFile
+
 
 upload_files_to_event_json_form_view = UploadFilesToEventJsonFormView.as_view()
 
 
 class DeleteFileFromEventView(LoginRequiredMixin, JsonDeleteView):
     """View that provides functionality for deleting a file from an event"""
+
     model = EventFile
     pk_url_kwarg = "pk"
+
 
 delete_file_from_event_view = DeleteFileFromEventView.as_view()
 
 
-class UploadFilesToEventSerieJsonFormView(LoginRequiredMixin, UploadFilesStandardFormView):
+class UploadFilesToEventSerieJsonFormView(
+    LoginRequiredMixin, UploadFilesStandardFormView
+):
     model = EventSerie
     file_relationship_model = EventSerieFile
 
-upload_files_to_event_serie_json_form_view = UploadFilesToEventSerieJsonFormView.as_view()
+
+upload_files_to_event_serie_json_form_view = (
+    UploadFilesToEventSerieJsonFormView.as_view()
+)
 
 
 class EventSerieDeleteFileView(LoginRequiredMixin, JsonDeleteView):
     model = EventSerieFile
     pk_url_kwarg = "pk"
+
 
 event_serie_delete_file_view = EventSerieDeleteFileView.as_view()
 
@@ -104,6 +122,7 @@ event_serie_delete_file_view = EventSerieDeleteFileView.as_view()
 class DeleteEventSerie(LoginRequiredMixin, JsonArchiveView):
     model = EventSerie
     pk_url_kwarg = "pk"
+
 
 delete_event_serie_view = DeleteEventSerie.as_view()
 
@@ -115,10 +134,10 @@ class CalculateEventSerieView(LoginRequiredMixin, DetailView, JSONResponseMixin)
     def get_object(self):
         serie_pk = self.kwargs.get(self.pk_url_kwarg)
         event_serie = EventSerie.objects.filter(pk=serie_pk).first()
-        
-        if (event_serie is None):
+
+        if event_serie is None:
             raise Http404("No event_serie found matching the query")
-        
+
         return calculate_serie(event_serie.serie_plan_manifest)
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
@@ -131,31 +150,37 @@ class CalculateEventSerieView(LoginRequiredMixin, DetailView, JSONResponseMixin)
 
         converted_events = []
         for event in events:
-            converted_events.append({
-                "title": event.title,
-                "start": event.start,
-                "end": event.end,
-            })
+            converted_events.append(
+                {
+                    "title": event.title,
+                    "start": event.start,
+                    "end": event.end,
+                }
+            )
 
         return converted_events
+
 
 calculate_event_serie_view = CalculateEventSerieView.as_view()
 
 
 class CalculateEventSeriePreviewView(LoginRequiredMixin, DetailView):
-    """ Preview calendar primarily used for testing and debugging the results of a calculation """
+    """Preview calendar primarily used for testing and debugging the results of a calculation"""
+
     model = PlanManifest
     pk_url_kwarg = "pk"
     template_name = "arrangement/eventserie/preview_calendar.html"
+
 
 calculate_event_serie_preview_view = CalculateEventSeriePreviewView.as_view()
 
 
 class EventSerieManifestView(LoginRequiredMixin, DetailView, JSONResponseMixin):
     """
-        EventSerieManifestView takes a given EventSerie, and serves the manifest used to generate
-        that serie out in JSON format.
+    EventSerieManifestView takes a given EventSerie, and serves the manifest used to generate
+    that serie out in JSON format.
     """
+
     model = PlanManifest
     pk_url_kwarg = "pk"
 
@@ -163,7 +188,7 @@ class EventSerieManifestView(LoginRequiredMixin, DetailView, JSONResponseMixin):
         serie_pk = self.kwargs.get(self.pk_url_kwarg)
         event_serie = EventSerie.objects.filter(pk=serie_pk).first()
 
-        if (event_serie is None):
+        if event_serie is None:
             raise Http404("No event_serie found matching the query")
 
         return event_serie.serie_plan_manifest
@@ -181,42 +206,65 @@ class EventSerieManifestView(LoginRequiredMixin, DetailView, JSONResponseMixin):
         display_layouts = []
 
         for display_layout in manifest.display_layouts.all():
-            display_layouts.append({
-                "id": display_layout.id,
-                "name": display_layout.name
-            })
-        
+            display_layouts.append(
+                {"id": display_layout.id, "name": display_layout.name}
+            )
+
         room_presets = RoomPreset.objects.all()
-        selected_rooms =  {
-            "allPresets": { room_preset.slug: room_preset.name for room_preset in room_presets },
+        selected_rooms = {
+            "allPresets": {
+                room_preset.slug: room_preset.name for room_preset in room_presets
+            },
             "allSelectedEntityIds": [],
             "viewables": [],
             "selectedPresets": [],
-            "eventPk": "", 
+            "eventPk": "",
         }
 
-        rooms = { room.id: room.name for room in manifest.rooms.all() }
-        viewables = { **rooms }
-        room_ids = set([ room for room in rooms.keys() ])
+        rooms = {room.id: room.name for room in manifest.rooms.all()}
+        viewables = {**rooms}
+        room_ids = set([room for room in rooms.keys()])
 
         for a_room_preset in room_presets:
-            room_preset_member_rooms = set([ room.id for room in a_room_preset.rooms.all() ])
-            if (room_preset_member_rooms.issubset(room_ids)):
+            room_preset_member_rooms = set(
+                [room.id for room in a_room_preset.rooms.all()]
+            )
+            if room_preset_member_rooms.issubset(room_ids):
                 selected_rooms["selectedPresets"].append(a_room_preset.slug)
                 viewables[a_room_preset.slug] = a_room_preset.name
                 for room_id in room_preset_member_rooms:
                     del viewables[room_id]
 
-        selected_rooms["viewables"] = [ { "id": key, "text": value } for (key, value) in viewables.items() ]
-        selected_rooms["allSelectedEntityIds"] = [ { "id": key, "text": value } for (key, value) in rooms.items() ]
+        selected_rooms["viewables"] = [
+            {"id": key, "text": value} for (key, value) in viewables.items()
+        ]
+        selected_rooms["allSelectedEntityIds"] = [
+            {"id": key, "text": value} for (key, value) in rooms.items()
+        ]
 
-        people = [ { "id": person.id, "text": person.full_name } for person in manifest.people.all() ]
-        selected_people = { 
+        people = [
+            {"id": person.id, "text": person.full_name}
+            for person in manifest.people.all()
+        ]
+        selected_people = {
             "allPresets": [],
             "allSelectedEntityIds": people,
             "viewables": people,
             "selectedPresets": [],
-            "eventPk": "", 
+            "eventPk": "",
+        }
+
+        responsible_list = (
+            [{"id": manifest.responsible.id, "text": manifest.responsible.full_name}]
+            if manifest.responsible
+            else []
+        )
+        responsible = {
+            "allPresets": [],
+            "allSelectedEntityIds": responsible_list,
+            "viewables": responsible_list,
+            "selectedPresets": [],
+            "eventPk": "",
         }
 
         return {
@@ -259,9 +307,11 @@ class EventSerieManifestView(LoginRequiredMixin, DetailView, JSONResponseMixin):
             "meeting_place_en": manifest.meeting_place_en,
             "status": manifest.status.pk if manifest.status else None,
             "audience": manifest.audience.pk if manifest.audience else None,
-            "arrangement_type": manifest.arrangement_type.pk if manifest.arrangement_type else None,
-            "responsible": manifest.responsible.pk if manifest.responsible else None
+            "arrangement_type": manifest.arrangement_type.pk
+            if manifest.arrangement_type
+            else None,
+            "responsible": responsible,
         }
 
+
 event_serie_manifest_view = EventSerieManifestView.as_view()
-        

--- a/webook/arrangement/views/generic_views/jstree_list_view.py
+++ b/webook/arrangement/views/generic_views/jstree_list_view.py
@@ -29,4 +29,3 @@ class JSTreeListView(JsonListView):
                     item["data"][attr_name] = reverse(url, kwargs={ "slug": item["data"]["slug"] })
             if "children" in item:
                 self._process_urls(item["children"])
-    

--- a/webook/arrangement/views/status_type_views.py
+++ b/webook/arrangement/views/status_type_views.py
@@ -2,21 +2,38 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import CreateView, DetailView, ListView, RedirectView, TemplateView, UpdateView
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    ListView,
+    RedirectView,
+    TemplateView,
+    UpdateView,
+)
 from django.views.generic.edit import DeleteView, ModelFormMixin
 
-from webook.arrangement.forms.arrangement_type_forms import CreateArrangementTypeForm, UpdateArrangementTypeForm
-from webook.arrangement.forms.status_type_forms import CreateStatusTypeForm, UpdateStatusTypeForm
+from webook.arrangement.forms.arrangement_type_forms import (
+    CreateArrangementTypeForm,
+    UpdateArrangementTypeForm,
+)
+from webook.arrangement.forms.status_type_forms import (
+    CreateStatusTypeForm,
+    UpdateStatusTypeForm,
+)
 from webook.arrangement.models import Arrangement, ArrangementType, StatusType
 from webook.arrangement.views.generic_views.archive_view import ArchiveView
 from webook.arrangement.views.generic_views.dialog_views import DialogView
+from webook.arrangement.views.generic_views.json_list_view import JsonListView
 from webook.arrangement.views.generic_views.jstree_list_view import JSTreeListView
 from webook.arrangement.views.generic_views.search_view import SearchView
 from webook.arrangement.views.mixins.json_response_mixin import JSONResponseMixin
 from webook.arrangement.views.mixins.multi_redirect_mixin import MultiRedirectMixin
 from webook.crumbinator.crumb_node import CrumbNode
 from webook.utils import crumbs
-from webook.utils.crudl_utils.view_mixins import GenericListTemplateMixin, GenericTreeListTemplateMixin
+from webook.utils.crudl_utils.view_mixins import (
+    GenericListTemplateMixin,
+    GenericTreeListTemplateMixin,
+)
 from webook.utils.meta_utils import SectionCrudlPathMap, SectionManifest, ViewMeta
 from webook.utils.meta_utils.meta_mixin import MetaMixin
 
@@ -32,7 +49,7 @@ def get_section_manifest():
             edit_url="arrangement:statustype_update",
             delete_url="arrangement:statustype_delete",
             list_url="arrangement:statustype_list",
-        )
+        ),
     )
 
 
@@ -47,15 +64,30 @@ class StatusTypeSectionManifestMixin:
         return context
 
 
-class StatusTypeListView(LoginRequiredMixin, StatusTypeSectionManifestMixin, GenericListTemplateMixin, MetaMixin, ListView):
+class StatusTypeListView(
+    LoginRequiredMixin,
+    StatusTypeSectionManifestMixin,
+    GenericListTemplateMixin,
+    MetaMixin,
+    ListView,
+):
     queryset = StatusType.objects.all()
     template_name = "common/dialog_list_view.html"
     model = StatusType
     view_meta = ViewMeta.Preset.table(StatusType)
 
+
 status_type_list_view = StatusTypeListView.as_view()
 
-class StatusTypeCreateView(LoginRequiredMixin, StatusTypeSectionManifestMixin, MetaMixin, CreateView, ModelFormMixin, DialogView):
+
+class StatusTypeCreateView(
+    LoginRequiredMixin,
+    StatusTypeSectionManifestMixin,
+    MetaMixin,
+    CreateView,
+    ModelFormMixin,
+    DialogView,
+):
     form_class = CreateStatusTypeForm
     model = StatusType
     template_name = "arrangement/statustype/statustype_form.html"
@@ -64,28 +96,49 @@ class StatusTypeCreateView(LoginRequiredMixin, StatusTypeSectionManifestMixin, M
     def get_success_url(self) -> str:
         return reverse("arrangement:statustype_list")
 
+
 status_type_create_view = StatusTypeCreateView.as_view()
 
-class StatusTypeUpdateView(LoginRequiredMixin, StatusTypeSectionManifestMixin, MetaMixin, UpdateView, ModelFormMixin, DialogView):
+
+class StatusTypeUpdateView(
+    LoginRequiredMixin,
+    StatusTypeSectionManifestMixin,
+    MetaMixin,
+    UpdateView,
+    ModelFormMixin,
+    DialogView,
+):
     form_class = UpdateStatusTypeForm
     model = StatusType
     template_name = "arrangement/statustype/statustype_form.html"
     view_meta = ViewMeta.Preset.edit(StatusType)
-    
+
     def get_success_url(self) -> str:
         return reverse("arrangement:statustype_list")
+
 
 status_type_update_view = StatusTypeUpdateView.as_view()
 
 
-class StatusTypeDeleteView(LoginRequiredMixin, StatusTypeSectionManifestMixin, DialogView, ArchiveView):
+class StatusTypeDeleteView(
+    LoginRequiredMixin, StatusTypeSectionManifestMixin, DialogView, ArchiveView
+):
     model = StatusType
     view_meta = ViewMeta.Preset.delete(StatusType)
     template_name = "common/dialog_delete_view.html"
 
     def get_success_url(self) -> str:
-        return reverse(
-            "arrangement:statustype_list"
-        )
+        return reverse("arrangement:statustype_list")
+
 
 status_type_delete_view = StatusTypeDeleteView.as_view()
+
+
+class StatusTypeTreeJsonView(
+    LoginRequiredMixin, StatusTypeSectionManifestMixin, JsonListView
+):
+    def get_queryset(self):
+        return [item.as_node() for item in StatusType.objects.all()]
+
+
+status_type_tree_json_view = StatusTypeTreeJsonView.as_view()

--- a/webook/static/css/base.css
+++ b/webook/static/css/base.css
@@ -17,6 +17,11 @@
     --DIALOG-BORDER-COLOR: #DEDFE3;
 }
 
+.chipsList {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 .event-title-text{
     text-overflow: ellipsis;
     overflow: hidden;

--- a/webook/static/js/components.js
+++ b/webook/static/js/components.js
@@ -27,7 +27,6 @@ class SelectedPill extends LinkedHTMLElement {
         super()
     
         const wrapper = document.createElement("span");
-        wrapper.classList.add("wb-bg-secondary", "rounded-pill", "p-3",);
 
         const textSpan = document.createElement("span");
         textSpan.innerText = this.getAttribute("name"); 

--- a/webook/static/js/jsTreeSelect.js
+++ b/webook/static/js/jsTreeSelect.js
@@ -105,6 +105,7 @@ export class JSTreeSelect {
         const jsTree = $(this._jsTreeElement).jstree(true);
 
         if (!jsTree) { // if jsTree is false, then jsTree is not initialized yet, so we stage the set value.
+            console.log("STAGED");
             this.selected={ id: id };
             return;
         }

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -112,6 +112,9 @@ export class ArrangementCreator {
                                 if (context.lastTriggererDetails.preselectedRooms) {
                                     window.MessagesFacility.send("newTimePlanDialog", context.lastTriggererDetails.preselectedRooms, "roomsSelected");
                                 }
+                                if (context.lastTriggererDetails.preselectedMainPlanner) {
+                                    window.MessagesFacility.send("newTimePlanDialog", context.lastTriggererDetails.preselectedMainPlanner, "setPlanner");
+                                }
 
                                 [
                                     { from: '#id_ticket_code', to: '#serie_ticket_code' },
@@ -120,12 +123,11 @@ export class ArrangementCreator {
                                     { from: '#id_expected_visitors', to: '#serie_expected_visitors'},
                                     { from: '#id_meeting_place', to: '#id_meeting_place' },
                                     { from: '#id_meeting_place_en', to: '#id_meeting_place_en' },
-                                    { from: '#id_responsible', to: '#id_responsible' },
-                                    { from: '#id_status', to: '#id_status' },
                                     { from: '#_audienceId', to: '#_backingAudienceId' },
                                     { from: '#_arrangementTypeId', to: '#_backingArrangementTypeId' },
+                                    { from: '#_statusTypeId', to: '#_statusTypeId' },
                                     { from: '#id_display_text', to: '#id_display_text' },
-                                ].forEach( (mapping) => { 
+                                ].forEach( (mapping) => {
                                     $thisDialog.find( mapping.to ).val( $mainDialog.find( mapping.from )[0].value );
                                 });
 
@@ -346,16 +348,18 @@ export class ArrangementCreator {
                                 if (context.lastTriggererDetails.preselectedRooms) {
                                     window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preselectedRooms, "roomsSelected");
                                 }
+                                if (context.lastTriggererDetails.preselectedMainPlanner) {
+                                    window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preselectedMainPlanner, "setPlanner");
+                                }
 
                                 [
                                     { from: '#id_ticket_code', to: '#ticket_code' },
                                     { from: '#id_name', to: '#title' },
                                     { from: '#id_name_en', to: '#title_en' },
                                     { from: '#id_expected_visitors', to: '#expected_visitors'},
-                                    { from: '#id_status', to: '#id_status' },
                                     { from: '#id_meeting_place', to: '#id_meeting_place' },
                                     { from: '#id_meeting_place_en', to: '#id_meeting_place_en' },
-                                    { from: '#id_responsible', to: '#id_responsible' },
+                                    { from: '#_statusTypeId', to: '#_statusTypeId' },
                                     { from: '#id_display_text', to: '#id_display_text' },
                                     { from: '#_audienceId', to: '#_backingAudienceId' },
                                     { from: '#_arrangementTypeId', to: '#_backingArrangementTypeId'},
@@ -459,7 +463,11 @@ export class ArrangementCreator {
                         dialogElementId: "orderPersonDialog",
                         triggerElementId: undefined,
                         triggerByEvent: true,
-                        htmlFabricator: async (context) => {
+                        htmlFabricator: async (context, dialog) => {
+                            let multiple = context.lastTriggererDetails.multiple;
+                            if (multiple === undefined)
+                                multiple = true
+
                             return this.dialogManager.loadDialogHtml({
                                 url: '/arrangement/planner/dialogs/order_person',
                                 managerName: 'arrangementCreator',
@@ -467,6 +475,7 @@ export class ArrangementCreator {
                                 customParameters: {
                                     event_pk: 0,
                                     recipientDialogId: context.lastTriggererDetails.sendTo,
+                                    multiple: multiple,
                                 }
                             });
                         },
@@ -474,15 +483,16 @@ export class ArrangementCreator {
                         dialogOptions: { 
                             width: 500,
                             dialogClass: 'no-titlebar',
-                         },
+                        },
                         onUpdatedCallback: () => {
                             $(this.dialogManager.$getDialogElement("orderPersonDialog")).toggle("slide", () => {
                                 this.dialogManager.closeDialog("orderPersonDialog");
                             });
                         },
-                        onSubmit: (context, details, dialogManager) => {
+                        onSubmit: (context, details, dialogManager, dialog) => {
+                            const eventName = dialog.data.whenEventName || "peopleSelected";
                             dialogManager._dialogRepository.get(details.recipientDialog)
-                                .communicationLane.send("peopleSelected", details.selectedBundle);
+                                .communicationLane.send(eventName, details.selectedBundle);
                         }
                     })
                 ]

--- a/webook/static/modules/planner/broadcast.js
+++ b/webook/static/modules/planner/broadcast.js
@@ -42,7 +42,6 @@ export class MessagesFacility {
                 const result = subscriptionsOnRecipient[i](key, payload)
                 if (result === null)
                 {
-                    debugger;
                     /**
                      * If a subscription function returns null we read this as if the
                      * subscription instance has perished, and should therefore be removed.

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -261,8 +261,6 @@ export class ArrangementStore extends BaseStore {
         let arrangements = this._getStoreAsArray();
         let filteredArrangements = [];
 
-        console.log("filterSet", filterSet);
-
         let filterMap = new Map(filterSet.map( (slug) => [ slug.id, true ]));
 
         let arrangementTypesMap =   arrangement_types !== undefined && arrangement_types.length > 0 ? new Map(arrangement_types.map(i => [i, true])) : undefined;
@@ -276,8 +274,6 @@ export class ArrangementStore extends BaseStore {
             if (filterSet.showOnlyEventsWithNoRooms === true && arrangement.room_names.length > 0 && arrangement.room_names[0] !== null) {
                 isWithinFilter = false;
             }
-
-            console.log(arrangement.slug_list);
 
             if (filterMap.size > 0) {
                 let match = false;

--- a/webook/static/modules/planner/dialog_manager/dialogManager.js
+++ b/webook/static/modules/planner/dialog_manager/dialogManager.js
@@ -27,6 +27,8 @@
         this._isRendering = false;
         this.title = title;
 
+        this.data = {};
+
         this.formUrl = formUrl;
 
         this.renderer = renderer;
@@ -44,6 +46,9 @@
     }
 
     async render(context, html) {
+        if (context.lastTriggererDetails?.data !== undefined)
+            this.data = context.lastTriggererDetails.data;
+
         let result = await this.renderer.render(context, this, html);
         
         $(this.renderer.$dialogElement).on("dialogclose", (event) => {
@@ -64,9 +69,9 @@
             if (this.onPreRefresh !== undefined) {
                 await this.onPreRefresh(this);
             }
-
+            
             if (html === undefined) {
-                html = await this.htmlFabricator(context);
+                html = await this.htmlFabricator(context, this);
             }
             else { console.log(html); }
 
@@ -273,7 +278,7 @@ export class DialogComplexDiscriminativeRenderer extends DialogBaseRenderer {
             this._isRendering = true;
             if (dialog.isOpen() === false) {
                 if (!html)
-                    html = await dialog.htmlFabricator(context);
+                    html = await dialog.htmlFabricator(context, dialog);
 
                 let span = document.createElement("span");
                 span.innerHTML = html;
@@ -422,7 +427,7 @@ export class DialogManager {
     _listenForSubmitEvent() {
         document.addEventListener(`${this.managerName}.submit`, async (e) => {
             let dialog = this._dialogRepository.get(e.detail.dialog);
-            let submitResult = await dialog.onSubmit(this.context, e.detail, this);  // Trigger the dialogs onSubmit handling
+            let submitResult = await dialog.onSubmit(this.context, e.detail, this, dialog);  // Trigger the dialogs onSubmit handling
             if (submitResult !== false) {
                 dialog.onUpdatedCallback(this.context);  // Trigger the dialogs on update handling
             }

--- a/webook/static/modules/planner/dialog_manager/presetSelectManagerPlugin.js
+++ b/webook/static/modules/planner/dialog_manager/presetSelectManagerPlugin.js
@@ -1,7 +1,7 @@
 class DialogPresetSelectManager extends DialogPluginBase {
     constructor(dialog, args) {
         super(dialog, args);
-        
+
         this._setup();
 
         this.selectedItemsMap = new Map();
@@ -102,8 +102,6 @@ class DialogPresetSelectManager extends DialogPluginBase {
     getSelected() {
         let viewables = [];
 
-        console.log(Array.from(this.selectedItemsMap.values()));
-
         let results = {
             allPresets: this.presets,
             selectedPresets: Array.from(this.activePresets.keys()),
@@ -119,8 +117,6 @@ class DialogPresetSelectManager extends DialogPluginBase {
         viewables = viewables.concat(Array.from(selectedItemsMapExcludingPresetSubjects, ([name, value]) => ({id: name, text: value})));
 
         results.viewables = viewables;
-
-        console.log("Results", results);
 
         return results;
     }

--- a/webook/static/modules/planner/form_populating_routines.js
+++ b/webook/static/modules/planner/form_populating_routines.js
@@ -22,10 +22,9 @@ export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialog
         { target: '#buffer_after_date_offset', value: serie.buffer.after?.date_offset },
         { target: '#buffer_after_start', value: serie.buffer.after?.start },
         { target: '#buffer_after_end', value: serie.buffer.after?.end },
-        { target: '#id_status', value: serie.time.status },
+        { target: '#_statusTypeId', value: serie.time.status },
         { target: '#_backingArrangementTypeId', value: serie.time.arrangement_type },
         { target: '#_backingAudienceId', value: serie.time.audience },
-        { target: '#id_responsible', value: serie.time.responsible },
         { target: '#id_meeting_place', value: serie.time.meeting_place },
         { target: '#id_meeting_place_en', value: serie.time.meeting_place_en },
         { target: '#id_display_text', value: serie.time.display_text },
@@ -36,6 +35,9 @@ export function PopulateCreateSerieDialogFromSerie(serie, $dialogElement, dialog
 
     console.log("serie", serie);
 
+    if (serie.planner_payload) {
+        window.MessagesFacility.send(dialogId, serie.planner_payload, "setPlanner");
+    }
     if (serie.room_payload) {
         window.MessagesFacility.send(dialogId, serie.room_payload, "roomsSelected");
     }
@@ -161,14 +163,14 @@ export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dia
         { to: "#area_start_date", value: manifest.start_date },
         { to: "#id_meeting_place", value: manifest.meeting_place },
         { to: "#id_meeting_place_en", value: manifest.meeting_place_en },
-        { to: "#id_responsible", value: manifest.responsible },
-        { to: '#id_status', value: manifest.status },
+        { to: '#_statusTypeId', value: manifest.status },
         { to: '#id_display_text', value: manifest.display_text },
         { to: '#id_display_text_en', value: manifest.display_text_en },
     ].forEach( (mapping) => { $dialogElement.find(mapping.to).val(mapping.value ).trigger('change'); } );
 
     window.MessagesFacility.send(dialogId, manifest.audience, "setAudienceFromParent");
     window.MessagesFacility.send(dialogId, manifest.arrangement_type, "setArrangementTypeFromParent");
+    window.MessagesFacility.send(dialogId, manifest.status, "setStatusFromParent");
 
     if (manifest.rooms) {
         manifest.rooms.allPresets = new Map([
@@ -180,7 +182,9 @@ export function PopulateCreateSerieDialogFromManifest(manifest, serie_uuid, $dia
     if (manifest.people) {
         window.MessagesFacility.send(dialogId, manifest.people, "peopleSelected");
     }
-
+    if (manifest.responsible)
+        window.MessagesFacility.send(dialogId, manifest.responsible, "setPlanner");
+    
     manifest.display_layouts.forEach(display_layout => {
         $dialogElement.find('#id_display_layouts_serie_planner_' + display_layout.id).prop( "checked", true );
     })
@@ -318,14 +322,12 @@ export function PopulateCreateEventDialog(event, $dialogElement, dialogId) {
         { target: '#_backingArrangementTypeId', value: event.arrangement_type },
         { target: '#id_meeting_place', value: event.meeting_place },
         { target: '#id_meeting_place_en', value: event.meeting_place_en },
-        { target: '#id_status', value: event.status },
-        { target: '#id_responsible', value: event.responsible },
+        { target: '#_statusTypeId', value: event.status },
         { target: '#id_display_text', value: event.display_text },
         { target: '#id_display_text_en', value: event.display_text_en },
     ].forEach( (mapping) => {
         $dialogElement.find( mapping.target ).val( mapping.value );
     } )
-
 
     if (Array.isArray(event.display_layouts)) {
         event.display_layouts.forEach(element => {
@@ -338,7 +340,8 @@ export function PopulateCreateEventDialog(event, $dialogElement, dialogId) {
 
     if (event.people_payload)
         window.MessagesFacility.send(dialogId, event.people_payload, "peopleSelected");
-    if (event.room_payload) {
+    if (event.room_payload)
         window.MessagesFacility.send(dialogId, event.room_payload, "roomsSelected");
-    }
+    if (event.planner_payload)
+        window.MessagesFacility.send(dialogId, event.planner_payload, "setPlanner");
 }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -251,9 +251,9 @@
 
                         <div>
                             <a href='#' class='shadow-0 btn wb-btn-secondary btn-block mb-2 btn-sm'
-                                    d-trigger="triggerAddPlannerDialog">
+                                    d-trigger="triggerAddPlannersDialog">
                                 <i class='fas fa-plus'></i>
-                                Legg til planlegger
+                                Legg til planlegger(e)
                             </a>
                         </div>
                         <div>
@@ -798,6 +798,9 @@
             },
             triggerEditSerie(dialog, { eventSeriePk } = {}, triggeredByElement) {
                 dialog.raiseTriggerEvent("arrangementInspector", "editEventSerieDialog", { event_serie_pk: eventSeriePk, $parent: dialog.dialogElement });
+            },
+            triggerAddPlannersDialog(dialog, {} = {}, triggeredByElement) {
+                dialog.raiseTriggerEvent("arrangementInspector", "selectPlannersDialog", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: true, data: { whenEventName: "addPlanners", arrangementSlug: "{{object.slug}}" } });
             },
             triggerAddPlannerDialog(dialog, {} = {}, triggeredByElement) {
                 dialog.raiseTriggerEvent("arrangementInspector", "addPlannerDialog", { $parent: dialog.dialogElement });

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -5,6 +5,7 @@
 <div id="{{dialogId}}" class="{{discriminator}}" style="overflow-x: visible;">
     <input type="hidden" name="" id="_audienceId">
     <input type="hidden" name="" id="_arrangementTypeId">
+    <input type="hidden" name="" id="_statusTypeId">
 
     <div class="clearfix">
         <div class="float-start">
@@ -89,13 +90,20 @@
                             Status
                         </label>
 
-                        {{ form.status }}
+                        <div id="status_type_jstree_select" class="dialog-popover-left-fix"></div>
+                        {% if form.status_type.errors|length > 0 %}
+                        <div class="alert alert-danger">
+                            {{ form.status_type.errors }}
+                        </div>
+                        {% endif %}
+
+                        {% comment %} {{ form.status }}
 
                         {% if form.status.errors|length > 0 %}
                         <div class="alert alert-danger">
                             {{ form.status.errors }}
                         </div>
-                        {% endif %}
+                        {% endif %} {% endcomment %}
                     </div>
 
                     <div class="mb-2">
@@ -117,20 +125,53 @@
             <form id="arrangementDetailsForm">
                 <input type="submit" value="" style="display: none;">
 
-                <div class="mb-2">
-                    <label>
-                        <i class="fas fa-star"></i>&nbsp;
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                    <input type="hidden" name="{{ form.responsible.name }}" id="{{ form.responsible.id_for_label }}">
+
+                    <label for="" class="d-block form-label">
+                        <i class="fas fa-star"></i>
                         Hovedplanlegger
                     </label>
-                    {{ form.responsible }}
+                    <h5 class="mb-2" id="mainPlannerName"></h5>
+                    <button class="wb-btn-main"
+                        id="setMainPlannerButton"
+                        type="button"
+                        d-trigger="triggerSetPlanner">
+                        Velg hovedplanlegger
+                    </button>
                 </div>
-                {% if form.responsible.errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        {{ form.responsible.errors }}
-                    </div>
-                {% endif %}
 
-                <div class="mb-2 form-group">
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4">
+                    <label for="{{form.responsible.id_for_label}}" class="form-label">
+                        <i class="fas fa-users"></i>&nbsp;
+                        Personer
+                    </label>
+                    <div>
+                        <button class="wb-btn-main"
+                                type="button"
+                                d-trigger="triggerAddPeople">
+                            Velg personer
+                        </button>
+                    </div>
+                    <div id="peopleChips" class="chipsList"></div>
+                </div>
+
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
+                    <label for="" class="form-label">
+                        <i class="fas fa-building"></i>&nbsp;
+                        Rom
+                    </label>
+                    <div>
+                        <button class="wb-btn-main"
+                            type="button"
+                            d-trigger="triggerAddRooms">
+                            Velg rom
+                        </button>
+                    </div>
+                    <div id="roomChips" class="chipsList"></div>
+                </div>
+
+                <div class="mb-2 mt-4 form-group">
                     <label>
                         <i class="fas fa-receipt"></i>&nbsp;
                         Billetkode
@@ -165,38 +206,6 @@
                         {{ form.expected_visitors.errors }}
                     </div>
                 {% endif %}
-
-                <div class="form-group">
-                    <label for="{{form.responsible.id_for_label}}"
-                            class="form-label">
-                        <i class="fas fa-users"></i>&nbsp;
-                        Personer
-                    </label>
-                    <div>
-                        <button class="btn wb-btn-secondary border mb-1"
-                                d-trigger="triggerAddPeople">
-                            Velg personer
-                        </button>
-                    </div>
-                    <br>
-                    <div id="peopleChips" class="mb-1 mt-1"></div>
-                    <br>
-                </div>
-                
-                <div class="form-group">
-                    <label for="" class="form-label">
-                        <i class="fas fa-building"></i>&nbsp;
-                        Rom
-                    </label>
-                    <div>
-                        <button class="btn wb-btn-secondary border"
-                            d-trigger="triggerAddRooms">
-                            Velg rom
-                        </button>
-                    </div>
-                    <br>
-                    <div id="roomChips" class="mb-1 mt-1"></div>
-                </div>
             </form>
         </div>
         <div id="step-3">
@@ -330,18 +339,18 @@
                     element: dialog.querySelector('#{{ form.location.id_for_label }}'),
                     invalidFeedback: "Vennligst velg en lokasjon",
                 },
-                {
+                {% comment %} {
                     element: dialog.querySelector('#{{ form.responsible.id_for_label }}'),
                     invalidFeedback: "Vennligst velg en hovedplanlegger",
-                },
-                {
+                }, {% endcomment %}
+                {% comment %} {
                     element: dialog.querySelector('#{{ form.status.id_for_label }}'),
                     invalidFeedback: 'Vennligst velg en status',
-                },
+                }, {% endcomment %}
             ].forEach((select) => {
                 const mdbSelect = new mdb.Select(select.element, {
-                    filter: true,
-                    container: "[class='{{discriminator}}']",
+                    {% comment %} filter: true, {% endcomment %}
+                    {% comment %} container: "[class='{{discriminator}}']", {% endcomment %}
                     validation: true,
                     noResultText: "Ingen resultater",
                     invalidFeedback: select.invalidFeedback,
@@ -395,6 +404,27 @@
                 changeSelectedValueButtonText: 'Endre arrangementstype',
                 popoverSaveChoicesButtonText: 'Lagre valg',
             });
+            dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
+                element: dialog.querySelector('#status_type_jstree_select'),
+                treeJsonSrcUrl: "/arrangement/statustype/tree",
+                onValueSet: ( data ) => {
+                    dialog.getElementById('_statusTypeId').value = data.selected[0];
+                },
+                valueSelectedLabelText: ( selected ) => {
+                    let labelText = '';
+
+                    if (selected.parent && selected.parent.text)
+                        labelText += (selected.parent.text + " | ");
+
+                    labelText += selected.text;
+                    
+                    return labelText;
+                },
+                noneSelectedLabelText: "Ingen status valgt ennå",
+                selectFirstTimeButtonText: 'Velg status',
+                changeSelectedValueButtonText: 'Endre status',
+                popoverSaveChoicesButtonText: 'Lagre valg',
+            });
 
             document.addEventListener("{{managerName}}.contextUpdated", (e) => {
                 if (e.detail.context.series !== undefined) {
@@ -413,6 +443,8 @@
                     title: 'Generelt',
                     stepIn: () => {},
                     stepOut: () => {
+                        return true;
+
                         let field_elements = dialog.$('#step-1').find("input, select");
                         [
                             mdb.Select.getInstance(dialog.querySelector('#{{ form.location.id_for_label }}')),
@@ -504,7 +536,10 @@
                 dialog.raiseTriggerEvent("{{managerName}}", "{{orderRoomDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}' });
             },
             triggerAddPeople(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}' });
+                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: true, data: { whenEventName: "peopleSelected" } });
+            },
+            triggerSetPlanner(dialog, {} = {}, triggeredByElement) {
+                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "setPlanner" } })
             },
             submit(dialog, {} = {}, triggeredByElement) {
                 if (dialog.validate() === false) {
@@ -526,7 +561,7 @@
                 formData.append("meeting_place",    dialog.interior.id_meeting_place.value);
                 formData.append("meeting_place_en", dialog.interior.id_meeting_place_en.value);
                 formData.append("expected_visitors",dialog.interior.id_expected_visitors.value);
-                formData.append("status",           dialog.interior.id_status.value);
+                formData.append("status",           dialog.data.statusTypeJsTreeSelect.getSelectedValue());
                 formData.append("display_text",     dialog.plugins.showIfSelected.isInShowState() ? dialog.interior.id_display_text.value : '');
 
                 let displayLayouts = [];
@@ -681,6 +716,35 @@
                     )
                 });
             },
+            removeAssociation(dialog, {} = {}, triggeredByElement) {
+                const itemId = triggeredByElement.id;
+                const type = triggeredByElement.getAttribute("select-type");
+
+                let mapOfSelectedItemIds = null;
+                let appropriatePresetMap = null;
+
+                if (type === "room") {
+                    mapOfSelectedItemIds = dialog.data.selectedRoomIds;
+                    appropriatePresetMap = dialog.data.roomPresets;
+                }
+                else if (type === "person") {
+                    mapOfSelectedItemIds = dialog.data.selectedPeopleIds;
+                    appropriatePresetMap = dialog.data.personPresets;
+                }
+                else {
+                    throw Error("Type not recognized")
+                }
+
+                if (itemId.startsWith("preset_")) {
+                    const preset = appropriatePresetMap.get(id.split("_")[1]);
+                    preset.ids.forEach((id) => mapOfSelectedItemIds.delete(id));
+                }
+                else {
+                    mapOfSelectedItemIds.delete(id);
+                }
+                
+                triggeredByElement.remove();
+            },
             removeSerie(dialog, { uuid } = {}, triggeredByElement) {
                 dialog.$(`#${uuid}`).remove();
                 dialog.data.seriesMap.delete(uuid);
@@ -693,7 +757,16 @@
                 dialog.raiseTriggerEvent("arrangementCreator", "newSimpleActivityDialog", { event_uuid: uuid, $parent: dialog.dialogElement });
             },
             createSimpleActivity(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("arrangementCreator", "newSimpleActivityDialog", { preselectedRooms: dialog.data.roomPayload, preselectedPeople: dialog.data.peoplePayload, $parent: dialog.dialogElement })
+                dialog.raiseTriggerEvent(
+                    "arrangementCreator", 
+                    "newSimpleActivityDialog", 
+                    { 
+                        preselectedMainPlanner: dialog.data.mainPlannerPayload,
+                        preselectedRooms: dialog.data.roomPayload, 
+                        preselectedPeople: dialog.data.peoplePayload, 
+                        $parent: dialog.dialogElement,
+                    }
+                )
             },
             breakOutEvent(dialog, { serieUuid, collisionIndex } = {}, triggeredByElement) {
                 dialog.raiseTriggerEvent("arrangementCreator", "breakOutActivityDialog", {
@@ -702,10 +775,26 @@
                 });
             },
             editSerie(dialog, { uuid } = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("arrangementCreator", "newTimePlanDialog", { serie_uuid: uuid, $parent: dialog.dialogElement });
+                dialog.raiseTriggerEvent(
+                    "arrangementCreator", 
+                    "newTimePlanDialog", 
+                    { 
+                        serie_uuid: uuid, 
+                        $parent: dialog.dialogElement 
+                    }
+                );
             },
             createSerie(dialog, {}={}, triggeredByElement) {
-                dialog.raiseTriggerEvent("arrangementCreator", "newTimePlanDialog", {  preselectedRooms: dialog.data.roomPayload, preselectedPeople: dialog.data.peoplePayload, $parent: dialog.dialogElement })
+                dialog.raiseTriggerEvent(
+                    "arrangementCreator", 
+                    "newTimePlanDialog", 
+                    { 
+                        preselectedMainPlanner: dialog.data.mainPlannerPayload,
+                        preselectedRooms: dialog.data.roomPayload, 
+                        preselectedPeople: dialog.data.peoplePayload, 
+                        $parent: dialog.dialogElement 
+                    }
+                );
             },
         },
         when: [
@@ -718,6 +807,7 @@
                         $(`<selected-pill name='${room.text}'
                                           id='${room.id}'
                                           select-type='room'
+                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
                                           d-trigger='removeAssociation'>
                            </selected-pill>`)  
                     )
@@ -739,6 +829,7 @@
                         $(`<selected-pill name='${person.text}'
                                           id='${person.id}'
                                           select-type='person'
+                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
                                           d-trigger='removeAssociation'>
                            </selected-pill>`)
                     )
@@ -751,6 +842,19 @@
 
                 dialog.data.peoplePayload = payload;
             } },
+            { eventKnownAs: "setPlanner", do: (dialog, payload) => {
+                if (payload.allSelectedEntityIds.length == 0)
+                    return;
+
+                // save the payload so that it can be re-used / re-applied to child activities / series
+                dialog.data.mainPlannerPayload = payload;
+
+                const person = payload.viewables[0];
+                
+                dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
+                dialog.getElementById('mainPlannerName').innerText = person.text;
+                dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
+            } }
         ],
         data: {
             roomPresets: new Map(),

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -6,6 +6,7 @@
 
     <input type="hidden" id="_backingAudienceId" />
     <input type="hidden" id="_backingArrangementTypeId" />
+    <input type="hidden" id="_statusTypeId">
 
     <div class="clearfix">
         <div class="float-start">
@@ -91,8 +92,16 @@
                 </div>
 
                 <div class="form-group mb-2">
-                    <label for="{{form.status.id_for_label}}" class="form-label">Status</label>
-                    {{ form.status }}
+                    <label>
+                        <i class="fas fa-cog"></i>&nbsp;
+                        Status
+                    </label>
+                    <div id="status_type_jstree_select" class="dialog-popover-left-fix"></div>
+                    {% if form.status_type.errors|length > 0 %}
+                    <div class="alert alert-danger">
+                        {{ form.status_type.errors }}
+                    </div>
+                    {% endif %}
                 </div>
             </form>
         </div>
@@ -215,45 +224,50 @@
         </div>
 
         <div id="step-3">
-            <div class="form-group mb-2">
-                <label for="{{form.responsible.id_for_label}}"
-                        class="form-label">
-                    <i class="fas fa-star"></i>&nbsp;
+            <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                <input type="hidden" name="{{ form.responsible.name }}" id="{{ form.responsible.id_for_label }}">
+
+                <label for="" class="d-block form-label">
+                    <i class="fas fa-star"></i>
                     Hovedplanlegger
                 </label>
-                {{ form.responsible }}
+                <h5 class="mb-2" id="mainPlannerName"></h5>
+                <button class="wb-btn-main"
+                    id="setMainPlannerButton"
+                    type="button"
+                    d-trigger="triggerSetPlanner">
+                    Velg hovedplanlegger
+                </button>
             </div>
 
-            <div class="form-group">
-                <label for="{{form.responsible.id_for_label}}"
-                        class="form-label">
+            <div class="border rounded box-shadow-2 wb-bg-secondary p-4">
+                <label for="{{form.responsible.id_for_label}}" class="form-label">
                     <i class="fas fa-users"></i>&nbsp;
                     Personer
                 </label>
                 <div>
-                    <button class="btn wb-btn-secondary border mb-1"
+                    <button class="wb-btn-main"
+                            type="button"
                             d-trigger="triggerAddPeople">
                         Velg personer
                     </button>
                 </div>
-                <br>
-                <div id="peopleChips" class="mb-1 mt-1"></div>
-                <br>
+                <div id="peopleChips" class="chipsList"></div>
             </div>
-            
-            <div class="form-group">
+
+            <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
                 <label for="" class="form-label">
                     <i class="fas fa-building"></i>&nbsp;
                     Rom
                 </label>
                 <div>
-                    <button class="btn wb-btn-secondary border"
+                    <button class="wb-btn-main"
+                        type="button"
                         d-trigger="triggerAddRooms">
                         Velg rom
                     </button>
                 </div>
-                <br>
-                <div id="roomChips" class="mb-1 mt-1"></div>
+                <div id="roomChips" class="chipsList"></div>
             </div>
         </div>
 
@@ -596,9 +610,6 @@
         managerName: '{{ managerName }}',
         discriminator: '{{ discriminator }}',
         postInit: function (dialog) {
-
-            console.log(dialog.oldMessages);
-
             dialog.data.audienceJsTreeSelect = new JSTreeSelect({
                 element: dialog.querySelector('#audience_jstree_select'),
                 treeJsonSrcUrl: "/arrangement/audience/tree",
@@ -636,6 +647,29 @@
                 noneSelectedLabelText: "Ingen arrangementstype valgt ennå",
                 selectFirstTimeButtonText: 'Velg arrangementstype',
                 changeSelectedValueButtonText: 'Endre arrangementstype',
+                popoverSaveChoicesButtonText: 'Lagre valg',
+            });
+
+            dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
+                element: dialog.querySelector('#status_type_jstree_select'),
+                treeJsonSrcUrl: "/arrangement/statustype/tree",
+                initialSelected: dialog.getElementById('_statusTypeId').value ? { id: dialog.getElementById('_statusTypeId').value } : undefined,
+                onValueSet: ( data ) => {
+                    dialog.getElementById('_statusTypeId').value = data.selected[0];
+                },
+                valueSelectedLabelText: ( selected ) => {
+                    let labelText = '';
+
+                    if (selected.parent && selected.parent.text)
+                        labelText += (selected.parent.text + " | ");
+
+                    labelText += selected.text;
+                    
+                    return labelText;
+                },
+                noneSelectedLabelText: "Ingen status valgt ennå",
+                selectFirstTimeButtonText: 'Velg status',
+                changeSelectedValueButtonText: 'Endre status',
                 popoverSaveChoicesButtonText: 'Lagre valg',
             });
 
@@ -894,7 +928,7 @@
                     end: dialog.interior.serie_end.value,
                     ticket_code: dialog.interior.serie_ticket_code.value,
                     expected_visitors: dialog.interior.serie_expected_visitors.value,
-                    status: dialog.interior.id_status.value,
+                    status: dialog.data.statusTypeJsTreeSelect.getSelectedValue(),
                     audience: dialog.data.audienceJsTreeSelect.getSelectedValue(),
                     arrangement_type: dialog.data.arrangementTypeJsTreeSelect.getSelectedValue(),
                     meeting_place: dialog.interior.id_meeting_place.value,
@@ -1017,6 +1051,7 @@
                 serie.room_payload = dialog.data.roomPayload;
                 serie.people_name_map = dialog.data.peopleNameMap;
                 serie.people_payload = dialog.data.peoplePayload;
+                serie.planner_payload = dialog.data.mainPlannerPayload;
                 serie.display_layouts = display_layouts.join(",");
 
                 dialog.raiseSubmitEvent({
@@ -1087,7 +1122,10 @@
                 dialog.raiseTriggerEvent("{{managerName}}", "{{orderRoomDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}' });
             },
             triggerAddPeople(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}' });
+                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: true, data: { whenEventName: "peopleSelected" } });
+            },
+            triggerSetPlanner(dialog, {} = {}, triggeredByElement) {
+                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "setPlanner" } });
             },
             removeAssociation(dialog, {} = {}, triggeredByElement) {
                 let $triggeredByElement = $(triggeredByElement);
@@ -1133,6 +1171,7 @@
                         $(`<selected-pill name='${room.text}'
                                           id='${room.id}'
                                           select-type='room'
+                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
                                           d-trigger='removeAssociation'>
                            </selected-pill>`)  
                     )
@@ -1154,6 +1193,7 @@
                         $(`<selected-pill name='${person.text}'
                                           id='${person.id}'
                                           select-type='person'
+                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
                                           d-trigger='removeAssociation'>
                            </selected-pill>`)
                     )
@@ -1166,18 +1206,37 @@
 
                 dialog.data.peoplePayload = payload;
             } },
+            { eventKnownAs: "setPlanner", do: (dialog, payload) => {
+                if (payload.allSelectedEntityIds.length == 0)
+                    return;
+
+                const person = payload.viewables[0];
+                dialog.data.mainPlannerPayload = payload;
+                
+                dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
+                dialog.getElementById('mainPlannerName').innerText = person.text;
+                dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
+            } },
             { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
                 if (dialog.data.audienceJsTreeSelect)
-                    dialog.data.audienceJsTreeSelect.setSelected(payload);
+                    dialog.data.audienceJsTreeSelect.setSelected(String(payload));
                 else
                     dialog.$('#_backingAudienceId').val(payload);
             } },
             { eventKnownAs: "setArrangementTypeFromParent", do: (dialog, payload) => {
                 if (dialog.data.arrangementTypeJsTreeSelect)
-                    dialog.data.arrangementTypeJsTreeSelect.setSelected(payload)
+                    dialog.data.arrangementTypeJsTreeSelect.setSelected(String(payload));
                 else
                     dialog.$('#_backingArrangementTypeId').val(payload);
             } },
+            { eventKnownAs: "setStatusFromParent", do: (dialog, payload) => {
+                if (dialog.data.statusTypeJsTreeSelect) {
+                    dialog.data.statusTypeJsTreeSelect.setSelected(String(payload));
+                }
+                else {
+                    dialog.$('#_statusTypeId').val(payload);
+                }
+            } }
         ],
         plugins: [
             {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -5,6 +5,7 @@
 
     <input type="hidden" id="_backingAudienceId" />
     <input type="hidden" id="_backingArrangementTypeId" />
+    <input type="hidden" id="_statusTypeId" />
 
     <div class="clearfix">
         <div class="float-start">
@@ -35,22 +36,6 @@
                     <label class="form-label" for="title_en">Tittel <i>(Engelsk)</i></label>
                     <input type="text" id="title_en" name="title_en" class="form-control form-control-lg" />
                 </div>
-    
-                <div class="form-group mb-2">
-                    <label class="form-label" for="ticket_code">
-                        <i class="fas fa-receipt"></i>&nbsp;
-                        Billettkode
-                    </label>
-                    <input type="text" id="ticket_code" name="ticket_code" class="form-control form-control-lg" />
-                </div>
-    
-                <div class="form-group mb-2">
-                    <label class="form-label" for="expected_visitors">
-                        <i class="fas fa-users"></i>
-                        Forventet besøkende
-                    </label>
-                    <input type="text" id="expected_visitors" name="expected_visitors" class="form-control form-control-lg" required />
-                </div>
 
                 <div class="form-group mb-2">
                     <label>
@@ -80,8 +65,16 @@
                 </div>
 
                 <div class="form-group mb-2">
-                    <label for="{{form.status.id_for_label}}" class="form-label"><i class="fas fa-cog"></i>&nbsp; Status</label>
-                    {{ form.status }}
+                    <label>
+                        <i class="fas fa-cog"></i>&nbsp;
+                        Status
+                    </label>
+                    <div id="status_type_jstree_select" class="dialog-popover-left-fix"></div>
+                    {% if form.status_type.errors|length > 0 %}
+                    <div class="alert alert-danger">
+                        {{ form.status_type.errors }}
+                    </div>
+                    {% endif %}
                 </div>
     
                 <div class="form-group mt-2">
@@ -118,45 +111,74 @@
             </form>
         </div>
         <div id="step-2">
-            <div class="form-group mb-2">
+            <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                <input type="hidden" name="{{ form.responsible.name }}" id="{{ form.responsible.id_for_label }}">
+
+                <label for="" class="d-block form-label">
+                    <i class="fas fa-star"></i>
+                    Hovedplanlegger
+                </label>
+                <h5 class="mb-2" id="mainPlannerName"></h5>
+                <button class="wb-btn-main"
+                    id="setMainPlannerButton"
+                    type="button"
+                    d-trigger="triggerSetPlanner">
+                    Velg hovedplanlegger
+                </button>
+            </div>
+            {% comment %} <div class="form-group mb-2">
                 <label for="{{form.responsible.id_for_label}}"
                         class="form-label">
                         <i class="fas fa-star"></i>&nbsp;
                         Hovedplanlegger
                 </label>
                 {{ form.responsible }}
-            </div>
+            </div> {% endcomment %}
 
-            <div class="form-group">
-                <label for="{{form.responsible.id_for_label}}"
-                        class="form-label">
+            <div class="border rounded box-shadow-2 wb-bg-secondary p-4">
+                <label for="{{form.responsible.id_for_label}}" class="form-label">
                     <i class="fas fa-users"></i>&nbsp;
                     Personer
                 </label>
                 <div>
-                    <button class="btn wb-btn-secondary border mb-1"
+                    <button class="wb-btn-main"
+                            type="button"
                             d-trigger="triggerAddPeople">
                         Velg personer
                     </button>
-                </div>
-                <br>
-                <div id="selectedPeopleWrapper" class="mb-1 mt-1"></div>
-                <br>
+                </div>  
+                <div id="selectedPeopleWrapper" class="chipsList"></div>
             </div>
             
-            <div class="form-group">
+            <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
                 <label for="" class="form-label">
                     <i class="fas fa-building"></i>&nbsp;
                     Rom
                 </label>
                 <div>
-                    <button class="btn wb-btn-secondary border"
+                    <button class="wb-btn-main"
+                        type="button"
                         d-trigger="triggerAddRooms">
                         Velg rom
                     </button>
                 </div>
-                <br>
-                <div id="selectedRoomsWrapper" class="mb-1 mt-1"></div>
+                <div id="selectedRoomsWrapper" class="chipsList"></div>
+            </div>
+
+            <div class="form-group mb-2">
+                <label class="form-label" for="ticket_code">
+                    <i class="fas fa-receipt"></i>&nbsp;
+                    Billettkode
+                </label>
+                <input type="text" id="ticket_code" name="ticket_code" class="form-control form-control-lg" />
+            </div>
+
+            <div class="form-group mb-2">
+                <label class="form-label" for="expected_visitors">
+                    <i class="fas fa-users"></i>
+                    Forventet besøkende
+                </label>
+                <input type="text" id="expected_visitors" name="expected_visitors" class="form-control form-control-lg" required />
             </div>
         </div>
         <div id="step-3">
@@ -368,6 +390,28 @@
                 changeSelectedValueButtonText: 'Endre arrangementstype',
                 popoverSaveChoicesButtonText: 'Lagre valg',
             });
+            dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
+                element: dialog.querySelector('#status_type_jstree_select'),
+                treeJsonSrcUrl: "/arrangement/statustype/tree",
+                initialSelected: dialog.getElementById('_statusTypeId').value ? { id: dialog.getElementById('_statusTypeId').value } : undefined,
+                onValueSet: ( data ) => {
+                    dialog.getElementById('_statusTypeId').value = data.selected[0];
+                },
+                valueSelectedLabelText: ( selected ) => {
+                    let labelText = '';
+
+                    if (selected.parent && selected.parent.text)
+                        labelText += (selected.parent.text + " | ");
+
+                    labelText += selected.text;
+                    
+                    return labelText;
+                },
+                noneSelectedLabelText: "Ingen status valgt ennå",
+                selectFirstTimeButtonText: 'Velg status',
+                changeSelectedValueButtonText: 'Endre status',
+                popoverSaveChoicesButtonText: 'Lagre valg',
+            });
 
             dialog.$("#fromTime").on("change", (event) => {
                 dialog.$("#buffer_before_end").val(event.target.value);
@@ -454,7 +498,7 @@
                     title_en:                   dialog.interior.title_en.value,
                     ticket_code:                dialog.interior.ticket_code.value,
                     expected_visitors:          dialog.interior.expected_visitors.value,
-                    status:                     dialog.interior.id_status.value,
+                    status:                     dialog.data.statusTypeJsTreeSelect.getSelectedValue(),
                     audience:                   dialog.data.audienceJsTreeSelect.getSelectedValue(),
                     arrangement_type:           dialog.data.arrangementTypeJsTreeSelect.getSelectedValue(),
                     start:                      new Date( dialog.interior.fromDate.value   + "T" + dialog.interior.fromTime.value ),
@@ -478,6 +522,7 @@
                     display_text:               dialog.plugins.showIfSelected.isInShowState() ? dialog.interior.id_display_text.value : '',
                     room_payload:               dialog.data.roomPayload,
                     people_payload:             dialog.data.peoplePayload,
+                    planner_payload:            dialog.data.mainPlannerPayload,
                 };
 
                 console.log("qualifiedEvent", qualifiedEvent);
@@ -538,7 +583,10 @@
                 dialog.raiseTriggerEvent("{{managerName}}", "{{orderRoomDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}'  });
             },
             triggerAddPeople(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}' });
+                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: true, data: { whenEventName: "peopleSelected" } });
+            },
+            triggerSetPlanner(dialog, {} = {}, triggeredByElement) {
+                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "setPlanner" } })
             },
         },
         data: {
@@ -557,6 +605,7 @@
                     wrapper.append(
                         $(`<selected-pill name='${room.text}'
                                           id='${room.id}'
+                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
                                           d-trigger='removeAssociation'>
                            </selected-pill>`)    
                     );
@@ -577,6 +626,7 @@
                     wrapper.append(
                         $(`<selected-pill name='${person.text}'
                                           id='${person.id}'
+                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
                                           d-trigger='removeAssociation'>
                            </selected-pill>`)    
                     );
@@ -588,6 +638,18 @@
                 payload.selectedPresets.forEach( (presetId) => dialog.data.personPresets.set(presetId, payload.allPresets.get(presetId)) );
 
                 dialog.data.peoplePayload = payload;
+            } },
+            { eventKnownAs: "setPlanner", do: (dialog, payload) => {
+                if (payload.allSelectedEntityIds.length == 0)
+                    return;
+
+                const person = payload.viewables[0];
+
+                dialog.data.mainPlannerPayload = payload;
+                
+                dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
+                dialog.getElementById('mainPlannerName').innerText = person.text;
+                dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
             } },
             { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
                 dialog.data.audienceJsTreeSelect.setSelected(payload);

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
@@ -103,12 +103,31 @@
             <div>
                 <div>
                     <div class="row mb-2">
-                        <div class="col-12">
+                        {% comment %} <div class="col-12">
                             <label for="{{form.responsible.id_for_label}}" class="form-label">
                                 <i class="fas fa-star"></i>&nbsp;
                                 Ansvarlig
                             </label>
                             {{form.responsible}}
+                        </div> {% endcomment %}
+                        <div class="col-12">
+                            <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                                <input type="hidden" name="{{ form.responsible.name }}" id="{{ form.responsible.id_for_label }}">
+    
+                                <label for="" class="d-block form-label">
+                                    <i class="fas fa-star"></i>
+                                    Hovedplanlegger
+                                </label>
+                                <h5 class="mb-2" id="mainPlannerName">
+                                    {{ object.responsible }}
+                                </h5>
+                                <button class="wb-btn-main"
+                                    id="setMainPlannerButton"
+                                    type="button"
+                                    d-trigger="triggerSetPlanner">
+                                    Endre hovedplanlegger
+                                </button>
+                            </div>
                         </div>
 
                         <div class="col-6  mt-3">
@@ -236,12 +255,17 @@
 
                         <div class="row mt-2">
                             <div class="col-6">
-                                <div class="form-group">
-                                    <label for="{{ form.status.id_for_label }}" class="form-label">
+                                <div class="form-group mb-2">
+                                    <label>
                                         <i class="fas fa-cog"></i>&nbsp;
-                                        {{ form.status.label }}
+                                        Status
                                     </label>
-                                    {{form.status}}
+                                    <div id="status_type_jstree_select" class="dialog-popover-left-fix"></div>
+                                    {% if form.status_type.errors|length > 0 %}
+                                    <div class="alert alert-danger">
+                                        {{ form.status_type.errors }}
+                                    </div>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -253,7 +277,7 @@
                                 <label class="d-block form-label">Vises på skjerm:</label>
                                 {{form.display_layouts}}
                             </div>
-                            <div class="col-lg-8 col-sm-12 mt-sm-2">
+                            <div class="col-lg-8 col-sm-12">
                                 <div 
                                     class="form-group"
                                     id="display-layout-text-group"
@@ -649,6 +673,25 @@
                 changeSelectedValueButtonText: 'Endre arrangementstype',
                 popoverSaveChoicesButtonText: 'Lagre valg',
             });
+            dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
+                element: dialog.querySelector('#status_type_jstree_select'),
+                initialSelected: { id: '{{ object.status.id }}', text: '{{ object.status.name }}' },
+                treeJsonSrcUrl: "/arrangement/statustype/tree",
+                valueSelectedLabelText: ( selected ) => {
+                    let labelText = '';
+
+                    if (selected.parent && selected.parent.text)
+                        labelText += (selected.parent.text + " | ");
+
+                    labelText += selected.text;
+                    
+                    return labelText;
+                },
+                noneSelectedLabelText: "Ingen status valgt ennå",
+                selectFirstTimeButtonText: 'Velg status',
+                changeSelectedValueButtonText: 'Endre status',
+                popoverSaveChoicesButtonText: 'Lagre valg',
+            });
 
             document.addEventListener("eventInspector.roomsUpdated", (e) => {
                 dialog.data.roomsMap = e.detail.context.room_name_map;
@@ -848,7 +891,7 @@
                     arrangement:        '{{object.arrangement.pk}}',
                     people:             dialog.getSelectedPeopleIds(),
                     rooms:              dialog.getSelectedRoomIds(),    
-                    status:             dialog.interior.id_status.value,
+                    status:             dialog.data.statusTypeJsTreeSelect.getSelectedValue(),
                     display_layouts:    [...dialog.querySelectorAll("input[name='display_layouts'][type='checkbox']:checked")]
                                             .map(element => element.value),
                                             
@@ -880,13 +923,39 @@
                 dialog.raiseTriggerEvent(dialog.managerName, "orderRoomDialog", { $parent: dialog.dialogElement, sendTo: '{{ dialogId }}' });
             },
             triggerAddPeople(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent(dialog.managerName, "orderPersonDialog", { $parent: dialog.dialogElement, sendTo: '{{ dialogId }}' });
+                dialog.raiseTriggerEvent(dialog.managerName, "orderPersonDialog", { $parent: dialog.dialogElement, sendTo: '{{ dialogId }}', multiple: true, data: { whenEventName: "peopleSelected" } });
+            },
+            triggerSetPlanner(dialog, {} = {}, triggeredByElement) {
+                dialog.raiseTriggerEvent(dialog.managerName, "orderPersonDialog", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "setPlanner" } })
             },
         },
         data: {
             peopleMap: new Map(),
             roomsMap: new Map(),
         },
+        when: [
+            { eventKnownAs: "setPlanner", do: (dialog, payload) => {
+                if (payload.allSelectedEntityIds.length == 0)
+                    return;
+
+                const person = payload.viewables[0];
+                
+                dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
+                dialog.getElementById('mainPlannerName').innerText = person.text;
+            } },
+            { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
+                dialog.data.roomsMap = new Map(
+                    payload.allSelectedEntityIds.map(x => [x.id, x.text])
+                );
+                dialog.setRooms(payload.allSelectedEntityIds.map(x => x.id).join(","));
+            } },
+            { eventKnownAs: "peopleSelected", do: (dialog, payload) => {
+                dialog.data.peopleMap = new Map(
+                    payload.allSelectedEntityIds.map(x => [x.id, x.text])
+                );
+                dialog.setPeople(payload.allSelectedEntityIds.map(x => x.id).join(","));
+            } },
+        ],
         plugins: [
             {
                 name: 'showIfSelected',

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderPersonDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/orderPersonDialog.html
@@ -3,7 +3,9 @@
     
     <div class="clearfix">
         <div class="float-start">
-            <h5 class="fw-bold">Velg personer</h5>
+            <h5 class="fw-bold">
+                {% if multiple %}Velg personer{% else %}Velg person{% endif %}
+            </h5>
         </div>
         <div id="rail" class="float-end stepper-rail"></div>
     </div>
@@ -29,13 +31,13 @@
                         <td>
                             {% if person.is_selected %}
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" person_name="{{person.full_name}}" id="{{person.pk}}" 
+                                <input class="form-check-input" type="{% if multiple %}checkbox{% else %}radio{% endif %}" person_name="{{person.full_name}}" id="{{person.pk}}" 
                                     name="orderPersonDialog__checkboxArray" checked/>
                                 <label class="form-check-label" for="{{person.pk}}">{{person}}</label>
                             </div>
                             {% else %}
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox"  person_name="{{person.full_name}}" id="{{person.pk}}" 
+                                <input class="form-check-input" type="{% if multiple %}checkbox{% else %}radio{% endif %}"  person_name="{{person.full_name}}" id="{{person.pk}}" 
                                     name="orderPersonDialog__checkboxArray"/>
                                 <label class="form-check-label" for="{{person.pk}}">{{person}}</label>
                             </div>
@@ -57,7 +59,9 @@
                     Avbryt
                 </a>
 
-                <a class="btn wb-btn-main shadow-0 float-end" d-trigger="order"><i class="fas fa-check"></i>&nbsp; Legg til valgte personer</a>
+                <a class="btn wb-btn-main shadow-0 float-end" d-trigger="order">
+                    <i class="fas fa-check"></i>&nbsp; Legg til {% if multiple %}valgte personer{% else %}valgt person{% endif %}
+                </a>
             </div>
         </div>
     </div>
@@ -92,7 +96,11 @@
                 name: "presetSelectManager",
                 pluginClass: DialogPresetSelectManager,
                 args: {
+                    {% if multiple %}
                     checkboxes: document.querySelectorAll("input[type='checkbox'][name='orderPersonDialog__checkboxArray']"),
+                    {% else %}
+                    checkboxes: document.querySelectorAll("input[type='radio'][name='orderPersonDialog__checkboxArray']"),
+                    {% endif%}
                     presets: new Map(),
                     checkboxIdPrefix: "personCheck",
                 }

--- a/webook/utils/utc_to_current.py
+++ b/webook/utils/utc_to_current.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
-from django.utils import timezone as dj_timezone
 
 import pytz
+from django.utils import timezone as dj_timezone
+
 
 def utc_to_current(utc_dt):
-    current_tz = pytz.timezone(dj_timezone.get_current_timezone().key)
+    current_tz = pytz.timezone(dj_timezone.get_current_timezone().zone)
     return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=current_tz)


### PR DESCRIPTION
### Fix selects bug

There has been a particular nasty bug with the selects in-dialog, that has caused a lot of headache. The issue is that the dropdown part of the dropdown menu is rendered way down, and not where it should be, when its container is the parent dialog. If one uses body as the parent of the dropdown then searching in dropdown will not work (though placement will be correct). Interestingly this does not seem to be an issue on Firefox, but is one on Chrome, which is not good. It is either caused by a bug in mdbootstrap or perhaps there is some nuance I am not aware of that affects transform and what not in this very specific context. Hard to say.

Instead of figuring out what it was, as it would be quite time consuming, I elected to do a larger rewrite of the flow. There are already components and utilities we could use in-place anyways. So for now I use the OrderPersonDialog for selecting a Main Planner (had to add a singular/multiple mode where we switch radio/checkbox depending on state), and JsTreeSelect for status.
It seems to feel a bit better visually as well.
