### PR TITLE
Fix jstree staging malfunction

### DIFF
--- a/webook/static/js/jsTreeSelect.js
+++ b/webook/static/js/jsTreeSelect.js
@@ -38,7 +38,6 @@ export class JSTreeSelect {
 
         this.onValueSet = onValueSet;
         this.selected = initialSelected;
-        console.log(">>initialSelected", this.selected);
 
         this.invalidFeedbackText = invalidFeedbackText;
 
@@ -103,14 +102,22 @@ export class JSTreeSelect {
 
     setSelected(id) {
         const jsTree = $(this._jsTreeElement).jstree(true);
-
-        if (!jsTree) { // if jsTree is false, then jsTree is not initialized yet, so we stage the set value.
-            console.log("STAGED");
+        if (jsTree === false) { // if jsTree is false, then jsTree is not initialized yet, so we stage the set value.
             this.selected={ id: id };
             return;
         }
 
+        /** 
+         * It is possible for JSTREE to be initialized, but not having finished loading the tree json from the endpoint yet
+         * We ascertain this state by get_node being False -- and again we default to staging the value.
+        */
         const selected = $(this._jsTreeElement).jstree(true).get_node(id);
+        if (selected === false)
+        {
+            this.selected={ id: id };
+            return;
+        }
+
         this._setSelectedValue(selected.id, selected.text, selected.parent);
     }
     


### PR DESCRIPTION
### Fix jstree staging malfunction

This PR introduces a fix to a race condition bug in the JSTREE select utility / component. 
Normally in a JsTree utility we might be attempting to set the value before the tree itself is even initialized. In these cases we "stage" the values on the instance, which will be then set when the JsTree is done initializing. However in some cases this would fail. The core issue was that in the set/stage function there was the possible scenario of the JsTree being initialized, but the JsTree source JSON content not having loaded (thus the tree was not popualted). This messed up, and caused undefined to be set, as there was no node in the tree by the respective id (yet!).  I have altered the behaviour to be such that if the tree exists, but get_node returns false, then the value should be staged, which results in it being correctly picked up **after** the JSON content has been loaded and the tree populated.