### PR TITLE
Adjustments to dialog behaviour and refresh

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -447,6 +447,12 @@ class Arrangement(
         return self.event_set.filter(start__gte=datetime.datetime.now()).first()
 
     @property
+    def timedelta_to_next_event(self):
+        return self.next_event.start - datetime.datetime.now(
+            pytz.timezone(str(dj_timezone.get_current_timezone()))
+        )
+
+    @property
     def start(self) -> Optional[datetime.datetime]:
         """Get the datetime of when the earliest event in this arrangement starts -- ergo the start of the arrangement"""
         return self.event_set.order_by("start").first()

--- a/webook/static/modules/planner/arrangementInspector.js
+++ b/webook/static/modules/planner/arrangementInspector.js
@@ -129,10 +129,11 @@ export class ArrangementInspector {
                                 this.dialogManager.reloadDialog("mainDialog");
                             });
                         },
-                        onUpdatedCallback: () => {  },
+                        onUpdatedCallback: () => { },
                         dialogOptions: { 
                             width: "90%", 
-                            maxHeight: 100,
+                            height: "100%",
+                            // maxHeight: "",
                             modal: true,
                             dialogClass: 'no-titlebar',
                             // position: "center center",
@@ -200,9 +201,10 @@ export class ArrangementInspector {
                             });
                         },
                         onRenderedCallback: () => {},
-                        onUpdatedCallback: () => { 
-                            this.dialogManager.reloadDialog("mainDialog"); 
+                        onUpdatedCallback: async () => { 
                             this.dialogManager.closeDialog("uploadFilesToArrangementDialog"); 
+                            await this.dialogManager.reloadDialog("mainDialog"); 
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_files" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             details.formData.append("slug", context.arrangement.slug);
@@ -234,9 +236,11 @@ export class ArrangementInspector {
                             });
                         },
                         onRenderedCallback: () => { console.info("Upload files to event serie dialog rendered") },
-                        onUpdatedCallback: () => { 
-                            this.dialogManager.reloadDialog("mainDialog"); 
-                            this.dialogManager.closeDialog("uploadFilesToEventSerieDialog"); 
+                        onUpdatedCallback: async () => { 
+                            this.dialogManager.closeDialog("uploadFilesToEventSerieDialog");
+                            await this.dialogManager.reloadDialog("mainDialog");
+
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_files" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             details.formData.append("pk", context.lastTriggererDetails.event_serie_pk);
@@ -293,8 +297,6 @@ export class ArrangementInspector {
                                 $newTimePlanDialog.find( mapping.targetSelector ).val( mapping.value );
                             } );
 
-                            // console.log("info", info);
-
                             window.MessagesFacility.send("newTimePlanDialog", info.arrangement_type_id, "setArrangementTypeFromParent")
                             window.MessagesFacility.send("newTimePlanDialog", info.audience_id, "setAudienceFromParent");
                             window.MessagesFacility.send("newTimePlanDialog", info.status_id, "setStatusFromParent");
@@ -309,9 +311,11 @@ export class ArrangementInspector {
                                 new mdb.Input(formOutline).init();
                             });
                         },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("mainDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("newTimePlanDialog");
+
+                            await this.dialogManager.reloadDialog("mainDialog");
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_timeslots" }, "moveToTab" );
                         },
                         dialogOptions: { 
                             width: 700,
@@ -515,9 +519,11 @@ export class ArrangementInspector {
                                 new mdb.Input(formOutline).init();
                             });
                         },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("mainDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("newSimpleActivityDialog");
+
+                            await this.dialogManager.reloadDialog("mainDialog");
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_timeslots" }, "moveToTab" );
                         },
                         dialogOptions: { width: "30%", dialogClass: 'no-titlebar', modal: true },
                         onSubmit: async (context, details) => {
@@ -571,9 +577,11 @@ export class ArrangementInspector {
                                 new mdb.Input(formOutline).init();
                             });
                         },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("mainDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("editEventSerieDialog");
+
+                            await this.dialogManager.reloadDialog("mainDialog");
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_timeslots" }, "moveToTab" );                            
                         },
                         onSubmit: async (context, details) => {
                             details.serie.event_serie_pk = context.editing_serie_pk;
@@ -673,9 +681,11 @@ export class ArrangementInspector {
                             )
                         },
                         onRenderedCallback: () => { console.info("Rendered") },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("mainDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("newNoteDialog");
+                            await this.dialogManager.reloadDialog("mainDialog");
+                            
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_notes" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             await fetch('/arrangement/note/post', {
@@ -704,9 +714,11 @@ export class ArrangementInspector {
                             });
                         },
                         onRenderedCallback: () => { console.info("Rendered"); },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("mainDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("editNoteDialog");
+                            await this.dialogManager.reloadDialog("mainDialog");
+                            
+                            window.MessagesFacility.send( "mainDialog", { tab: "arrangementInfoDialog_tabs_notes" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             await fetch('/arrangement/planner/dialogs/edit_note/' + details.id, {

--- a/webook/static/modules/planner/eventInspector.js
+++ b/webook/static/modules/planner/eventInspector.js
@@ -101,7 +101,7 @@ export class EventInspector {
                         },
                         onSubmit: (context, details, dialogManager, dialog) => {
                             const eventName = dialog.data.whenEventName || "peopleSelected";
-                            dialogManager._dialogRepository.get(details.recipientDialog)
+                            this.dialogManager._dialogRepository.get(details.recipientDialog)
                                 .communicationLane.send(eventName, details.selectedBundle);
                         }
                     })
@@ -155,9 +155,11 @@ export class EventInspector {
                             width: 600, 
                             dialogClass: 'no-titlebar',
                         },
-                        onUpdatedCallback: () => { 
+                        onUpdatedCallback: async () => { 
                             this.dialogManager.closeDialog("uploadFilesDialog"); 
-                            this.dialogManager.reloadDialog("inspectEventDialog"); 
+                            await this.dialogManager.reloadDialog("inspectEventDialog");
+
+                            window.MessagesFacility.send( "inspectEventDialog", { tab: "files-tab" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             details.formData.append("pk", context.event.pk);
@@ -191,9 +193,11 @@ export class EventInspector {
                             );
                         },
                         onRenderedCallback: () => { console.info("Rendered") },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("inspectEventDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("newNoteDialog");
+                            await this.dialogManager.reloadDialog("inspectEventDialog");
+
+                            window.MessagesFacility.send( "inspectEventDialog", { tab: "notes-tab" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             await fetch('/arrangement/note/post', {
@@ -227,9 +231,11 @@ export class EventInspector {
                             );
                         },
                         onRenderedCallback: () => { console.info("Rendered"); },
-                        onUpdatedCallback: () => {
-                            this.dialogManager.reloadDialog("inspectEventDialog");
+                        onUpdatedCallback: async () => {
                             this.dialogManager.closeDialog("editNoteDialog");
+                            await this.dialogManager.reloadDialog("inspectEventDialog");
+
+                            window.MessagesFacility.send( "inspectEventDialog", { tab: "notes-tab" }, "moveToTab" );
                         },
                         onSubmit: async (context, details) => {
                             await fetch('/arrangement/planner/dialogs/edit_note/' + details.id, {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/arrangementInfoDialog.html
@@ -56,6 +56,7 @@
         <!-- Information/General -->
         <li class="nav-item" role="presentation">
             <a  href="#arrangementInfoDialog_tabs_information"
+                id="arrangementInfoDialog_tabs_information-link"
                 class="nav-link active"
                 role="tab"
                 data-mdb-toggle="tab">
@@ -65,6 +66,7 @@
         <!-- Timeslots -->
         <li class="nav-item" role="presentation">
             <a href="#arrangementInfoDialog_tabs_timeslots"
+                id="arrangementInfoDialog_tabs_timeslots-link"
                 class="nav-link"
                 role="tab"
                 data-mdb-toggle="tab">
@@ -74,6 +76,7 @@
         <!-- Notes -->
         <li class="nav-item" role="presentation">
             <a href="#arrangementInfoDialog_tabs_notes"
+                id="arrangementInfoDialog_tabs_notes-link"
                 class="nav-link"
                 role="tab"
                 data-mdb-toggle="tab">
@@ -83,6 +86,7 @@
         <!-- Files -->
         <li class="nav-item" role="presentation">
             <a href="#arrangementInfoDialog_tabs_files"
+                id="arrangementInfoDialog_tabs_files-link"
                 class="nav-link"
                 role="tab"
                 data-mdb-toggle="tab">
@@ -596,37 +600,39 @@
                 </div>
             {% endif %}
 
-            {% for note in object.notes.all %}
-            <div class="p-3 border rounded-6 shadow-3 mt-2" id="note_{{note.pk}}">
-                {{note.content|safe}}
-
-                <hr>
-
-                <div class="clearfix">
-                    <div class="float-start">
+            <div style="overflow-y: scroll; max-height: 30em;">
+                {% for note in object.notes.all %}
+                <div class="p-3 border rounded-6 shadow-3 mt-2" id="note_{{note.pk}}">
+                    {{note.content|safe}}
+    
+                    <hr>
+    
+                    <div class="clearfix">
                         <div class="float-start">
-                            {% if note.has_personal_information %}
-                                <i class="fas fa-shield-alt text-warning h3"></i> <strong>Inneholder <abbr class="me-3" title="Personlig identifiserende informasjon">PII</abbr></strong>
-                            {% endif %}
-                            <em class="text-muted small float-end">Opprettet av {{note.author}} den {{ note.created|date:'d.m.Y H:i' }}</em>
+                            <div class="float-start">
+                                {% if note.has_personal_information %}
+                                    <i class="fas fa-shield-alt text-warning h3"></i> <strong>Inneholder <abbr class="me-3" title="Personlig identifiserende informasjon">PII</abbr></strong>
+                                {% endif %}
+                                <em class="text-muted small float-end">Opprettet av {{note.author}} den {{ note.created|date:'d.m.Y H:i' }}</em>
+                            </div>
+                        </div>
+                        <div class="float-end">
+                            <a href="#" class="btn wb-btn-main"
+                                d-trigger="deleteNote"
+                                d-arg-note_pk="{{ note.pk }}">
+                                <i class="fas fa-trash"></i>
+                            </a>
+    
+                            <a href="#" class="btn wb-btn-main"
+                                d-trigger="triggerUpdateNoteDialog"
+                                d-arg-note_pk="{{ note.pk }}">
+                            <i class="fas fa-edit"></i>
+                        </a>
                         </div>
                     </div>
-                    <div class="float-end">
-                        <a href="#" class="btn wb-btn-main"
-                            d-trigger="deleteNote"
-                            d-arg-note_pk="{{ note.pk }}">
-                            <i class="fas fa-trash"></i>
-                        </a>
-
-                        <a href="#" class="btn wb-btn-main"
-                            d-trigger="triggerUpdateNoteDialog"
-                            d-arg-note_pk="{{ note.pk }}">
-                        <i class="fas fa-edit"></i>
-                    </a>
-                    </div>
                 </div>
+                {% endfor %}
             </div>
-            {% endfor %}
         </div>
 
         <!-- Receipts Tab -->
@@ -1068,6 +1074,11 @@
             },
         },
         data: {},
+        when: [
+            { eventKnownAs: "moveToTab", do: (dialog, payload) => {
+                dialog.querySelector("#" + payload.tab + "-link").click()
+            } },
+        ],
         plugins: [
             {
                 name: 'showIfSelected',

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/inspectEventDialog.html
@@ -81,9 +81,9 @@
         <li class="nav-item" role="presentation">
             <a
                 class="nav-link"
-                id="ex1-tab-2"
+                id="files-tab-link"
                 data-mdb-toggle="tab"
-                href="#ex1-tabs-2"
+                href="#files-tab"
                 role="tab"
                 aria-controls="ex1-tabs-2"
                 aria-selected="false">
@@ -93,9 +93,9 @@
         <li class="nav-item" role="presentation">
             <a
                 class="nav-link"
-                id="ex1-tab-3"
+                id="notes-tab-link"
                 data-mdb-toggle="tab"
-                href="#ex1-tabs-3"
+                href="#notes-tab"
                 role="tab"
                 aria-controls="ex1-tabs-3"
                 aria-selected="false">
@@ -114,7 +114,7 @@
                 data-mdb-toggle="tab"
                 href="#ex1-tabs-4"
                 role="tab"
-                aria-controls="ex1-tabs-3"
+                aria-controls="ex1-tabs-4"
                 aria-selected="false"
                 >Opprigg & Nedrigg
             </a>
@@ -326,7 +326,7 @@
             </div>
         </form>
         </div>
-        <div class="tab-pane fade" id="ex1-tabs-2" role="tabpanel" aria-labelledby="ex1-tab-2">
+        <div class="tab-pane fade" id="files-tab" role="tabpanel" aria-labelledby="ex1-tab-2">
             {% if object.arrangement.files.exists or object.files.exists %}
             <div class="clearfix">
                 <div class="float-end">
@@ -334,36 +334,14 @@
                 </div>
             </div>
 
-            {% for file in object.arrangement.files.all %}
-                <div class="wb-bg-extra p-3 mt-2 rounded-pill" id="fileRow_{{file.pk}}">
-                    <span><i class="fas fa-arrow-down"></i> <small class="me-2 fw-bold">Fra arrangement</small>&nbsp; {{file.filename}}</span>
-                    <span class="float-end">
-                        <a href="#" class="text-muted"
-                            data-mdb-toggle="tooltip"
-                            title="Denne filen kommer fra arrangementet og kan dermed bare slettes der">
-                            <i class="fas fa-trash"></i>
-                        </a>
-
-                        <a data-mdb-toggle="tooltip"
-                                class="ms-2 me-3"
-                                title="{% trans 'Download this file' %}"
-                                href="/media/{{file.file}}"
-                                download>
-                            <i class="fas fa-download"></i>
-                        </a>
-                    </span>
-                </div>
-            {% endfor %}
-
-            <div class="mb-2">
-                {% for file in object.files.all %}
+            <div data-mdb-perfect-scrollbar="true" data-mdb-handlers="click-rail" style="position: relative; max-height: 30em; overflow-y: scroll;">
+                {% for file in object.arrangement.files.all %}
                     <div class="wb-bg-extra p-3 mt-2 rounded-pill" id="fileRow_{{file.pk}}">
-                        <span>{{file.filename}}</span>
+                        <span><i class="fas fa-arrow-down"></i> <small class="me-2 fw-bold">Fra arrangement</small>&nbsp; {{file.filename}}</span>
                         <span class="float-end">
-                            <a href="#"
-                                    d-trigger="deleteFile"
-                                    d-arg-type_discriminator="event_serie"
-                                    d-arg-file_id="{{file.pk}}">
+                            <a href="#" class="text-muted"
+                                data-mdb-toggle="tooltip"
+                                title="Denne filen kommer fra arrangementet og kan dermed bare slettes der">
                                 <i class="fas fa-trash"></i>
                             </a>
 
@@ -377,6 +355,31 @@
                         </span>
                     </div>
                 {% endfor %}
+
+
+                <div class="mb-2">
+                    {% for file in object.files.all %}
+                        <div class="wb-bg-extra p-3 mt-2 rounded-pill" id="fileRow_{{file.pk}}">
+                            <span>{{file.filename}}</span>
+                            <span class="float-end">
+                                <a href="#"
+                                        d-trigger="deleteFile"
+                                        d-arg-type_discriminator="event_serie"
+                                        d-arg-file_id="{{file.pk}}">
+                                    <i class="fas fa-trash"></i>
+                                </a>
+
+                                <a data-mdb-toggle="tooltip"
+                                        class="ms-2 me-3"
+                                        title="{% trans 'Download this file' %}"
+                                        href="/media/{{file.file}}"
+                                        download>
+                                    <i class="fas fa-download"></i>
+                                </a>
+                            </span>
+                        </div>
+                    {% endfor %}
+                </div>
             </div>
             {% else %}
             <div class="alert wb-bg-secondary">
@@ -480,7 +483,7 @@
             {% endif %}
         </div>
 
-        <div class="tab-pane fade" id="ex1-tabs-3" role="tabpanel" aria-labelledby="ex1-tabs-3">
+        <div class="tab-pane fade" id="notes-tab" role="tabpanel" aria-labelledby="notes-tab">
             {% if object.arrangement.notes.exists or object.notes.exists %}
                 <div class="clearfix">
                     <a class="btn wb-btn-main shadow-0 mb-2 float-end"
@@ -490,56 +493,59 @@
                     </a>
                 </div>
 
-                {% for note in object.arrangement.notes.all %}
-                <div class="p-3 border rounded-6 shadow-3 mt-2 wb-bg-secondary " id="note_{{note.pk}}">
-                    {{note.content|safe}}
+                <div style="overflow-y: scroll; max-height: 30em;">
+                    {% for note in object.arrangement.notes.all %}
+                    <div class="p-3 border rounded-6 shadow-3 mt-2 wb-bg-secondary " id="note_{{note.pk}}">
+                        {{note.content|safe}}
 
-                    <hr>
+                        <hr>
 
-                    <div class="clearfix">
-                        <div class="float-start">
-                            <i class="fas fa-arrow-down me-3 h3"></i>
-                            {% if note.has_personal_information %}
-                                <i class="fas fa-shield-alt text-warning h3"></i> <strong>Inneholder <abbr class="me-3" title="Personlig identifiserende informasjon">PII</abbr></strong>
-                            {% endif %}
-                            <em class="text-muted small float-end">Opprettet av {{note.author}} den {{ note.created|date:'d.m.Y H:i' }}</em>
-                        </div>
-                        <div class="float-end">
-                            <em><small> <i class="far fa-question-circle"></i> Notatet kommer fra arrangementet og kan bare redigeres/slettes der</small></em>
-                        </div>
-                    </div>
-                </div>
-                {% endfor %}
-
-                {% for note in object.notes.all %}
-                <div class="p-3 border rounded-6 shadow-3 mt-2" id="note_{{note.pk}}">
-                    {{note.content|safe}}
-
-                    <hr>
-
-                    <div class="clearfix">
-                        <div class="float-start">
-                            {% if note.has_personal_information %}
-                                <i class="fas fa-shield-alt text-warning h3"></i> <strong>Inneholder <abbr class="me-3" title="Personlig identifiserende informasjon">PII</abbr></strong>
-                            {% endif %}
-                            <em class="text-muted small float-end">Opprettet av {{note.author}} den {{ note.created|date:'d.m.Y H:i' }}</em>
-                        </div>
-                        <div class="float-end">
-                            <a href="#" class="btn wb-btn-secondary"
-                                d-trigger="deleteNote"
-                                d-arg-note_pk="{{ note.pk }}">
-                                <i class="fas fa-trash"></i>
-                            </a>
-
-                            <a href="#" class="btn wb-btn-secondary"
-                                d-trigger="updateNoteDialog"
-                                d-arg-note_pk="{{note.pk}}">
-                                <i class="fas fa-edit"></i>
-                            </a>
+                        <div class="clearfix">
+                            <div class="float-start">
+                                <i class="fas fa-arrow-down me-3 h3"></i>
+                                {% if note.has_personal_information %}
+                                    <i class="fas fa-shield-alt text-warning h3"></i> <strong>Inneholder <abbr class="me-3" title="Personlig identifiserende informasjon">PII</abbr></strong>
+                                {% endif %}
+                                <em class="text-muted small float-end">Opprettet av {{note.author}} den {{ note.created|date:'d.m.Y H:i' }}</em>
+                            </div>
+                            <div class="float-end">
+                                <em><small> <i class="far fa-question-circle"></i> Notatet kommer fra arrangementet og kan bare redigeres/slettes der</small></em>
+                            </div>
                         </div>
                     </div>
+                    {% endfor %}
+
+                    {% for note in object.notes.all %}
+                    <div class="p-3 border rounded-6 shadow-3 mt-2" id="note_{{note.pk}}">
+                        {{note.content|safe}}
+
+                        <hr>
+
+                        <div class="clearfix">
+                            <div class="float-start">
+                                {% if note.has_personal_information %}
+                                    <i class="fas fa-shield-alt text-warning h3"></i> <strong>Inneholder <abbr class="me-3" title="Personlig identifiserende informasjon">PII</abbr></strong>
+                                {% endif %}
+                                <em class="text-muted small float-end">Opprettet av {{note.author}} den {{ note.created|date:'d.m.Y H:i' }}</em>
+                            </div>
+                            <div class="float-end">
+                                <a href="#" class="btn wb-btn-secondary"
+                                    d-trigger="deleteNote"
+                                    d-arg-note_pk="{{ note.pk }}">
+                                    <i class="fas fa-trash"></i>
+                                </a>
+
+                                <a href="#" class="btn wb-btn-secondary"
+                                    d-trigger="updateNoteDialog"
+                                    d-arg-note_pk="{{note.pk}}">
+                                    <i class="fas fa-edit"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
                 </div>
-                {% endfor %}
+
             {% else %}
                 <div class="alert wb-bg-secondary">
                     <h4 class="text-center">Ingen notater skrevet ennå!</h4>
@@ -711,6 +717,10 @@
         dialogId: '{{dialogId}}',
         discriminator: '{{discriminator}}',
         postInit: function (dialog) {
+            console.log("postInit.dialog", dialog);
+            if (dialog.data.stagedMoveTo)
+                dialog.moveToTab({ "tab": dialog.data.stagedMoveTo })
+
             new mdb.Datetimepicker(dialog.getElementById('startDateTime', {
                 container: "[id='{{dialogId}}'][class='{{discriminator}}']",
                 datepicker: { format: 'dd.mm.yyyy' },
@@ -1004,6 +1014,7 @@
                 });
             },
             triggerUploadFilesDialog(dialog, {}={}, triggeredByElement) {
+                console.log("triggerUploadFilesDialog");
                 dialog.raiseTriggerEvent(dialog.managerName, "uploadFilesDialog", { $parent: dialog.dialogElement });
             },
             triggerAddRooms(dialog, {} = {}, triggeredByElement) {
@@ -1015,10 +1026,14 @@
             triggerSetPlanner(dialog, {} = {}, triggeredByElement) {
                 dialog.raiseTriggerEvent(dialog.managerName, "orderPersonDialog", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "setPlanner" } })
             },
+            moveToTab(dialog, { tab } = {}, triggeredByElement) {
+                $( document.querySelector("#" + tab + "-link") )[0].click()
+            }
         },
         data: {
             peopleMap: new Map(),
             roomsMap: new Map(),
+            stagedMoveTo: null
         },
         when: [
             { eventKnownAs: "setPlanner", do: (dialog, payload) => {
@@ -1029,6 +1044,9 @@
                 
                 dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
                 dialog.getElementById('mainPlannerName').innerText = person.text;
+            } },
+            { eventKnownAs: "moveToTab", do: (dialog, payload) => {
+                dialog.querySelector("#" + payload.tab + "-link").click()
             } },
             { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
                 dialog.data.roomsMap = new Map(
@@ -1061,8 +1079,6 @@
     })
 
     $(document).ready(function () {
-
-
         const personAsyncFilter = async (query) => {
         const url = `{% url "arrangement:search_people_ajax_view" %}?term=${encodeURI(query)}`;
         const response = await fetch(url);
@@ -1072,7 +1088,7 @@
         for (let i = 0; i < data.length; i++) {
           let entry = data[i]
           entry.fields.id = entry.pk;
-          if (peopleMap.has(entry.fields.id) !== true) {
+          if (!peopleMap.has(entry.fields.id)) {
             people.push(entry.fields)
           }
         }


### PR DESCRIPTION
# Adjustments to dialog behaviour and refresh

This PR introduces changes to the dialog refresh behaviour. Instead of re-initializing the dialog the inner html of the dialog is replaced in-place, thus yielding a smoother user experience. Also added specific handling to re-navigate to the users active tabs on inspect event/inspect arrangement dialogs -- but it remains to be seen if this is good enough,