### PR TITLE
Automatically cancel service order if all events are archived

### DIFF
--- a/webook/arrangement/facilities/service_ordering.py
+++ b/webook/arrangement/facilities/service_ordering.py
@@ -385,6 +385,10 @@ def add_event_to_service_order(service_order: ServiceOrder, event: Event):
 def remove_provision_from_service_order(service_order: ServiceOrder, provision: ServiceOrderProvision):
     provision.archive()
     
+    if service_order.provisions.count() == 0:
+        cancel_service_order(service_order)
+        return
+
     if service_order.state not in [States.CONFIRMED, States.CHANGED]:
         return # Only trigger the change process if the service order is confirmed
 

--- a/webook/arrangement/views/event_views.py
+++ b/webook/arrangement/views/event_views.py
@@ -209,6 +209,18 @@ class DeleteEventSerie(LoginRequiredMixin, PlannerAuthorizationMixin, JsonArchiv
     model = EventSerie
     pk_url_kwarg = "pk"
 
+    def delete(self, request: HttpRequest, *args: str, **kwargs: Any) -> HttpResponse:
+        for event in self.get_object().events.all():
+            provisions: List[ServiceOrderProvision]
+            if provisions := event.provisions.all():
+                for provision in provisions:
+                    remove_provision_from_service_order(
+                        service_order=provision.related_to_order,
+                        provision=provision,
+                    )
+
+        return super().delete(request, *args, **kwargs)
+
 
 delete_event_serie_view = DeleteEventSerie.as_view()
 


### PR DESCRIPTION
Automatically cancel a service order if all the events/provisions it is concerned with are deleted/archived.