### PR TITLE
Cloak notification bell render

### DIFF
--- a/webook/arrangement/views/event_views.py
+++ b/webook/arrangement/views/event_views.py
@@ -211,13 +211,12 @@ class DeleteEventSerie(LoginRequiredMixin, PlannerAuthorizationMixin, JsonArchiv
 
     def delete(self, request: HttpRequest, *args: str, **kwargs: Any) -> HttpResponse:
         for event in self.get_object().events.all():
-            provisions: List[ServiceOrderProvision]
-            if provisions := event.provisions.all():
-                for provision in provisions:
-                    remove_provision_from_service_order(
-                        service_order=provision.related_to_order,
-                        provision=provision,
-                    )
+            provisions: List[ServiceOrderProvision] = event.provisions.all()
+            for provision in provisions:
+                remove_provision_from_service_order(
+                    service_order=provision.related_to_order,
+                    provision=provision,
+                )
 
         return super().delete(request, *args, **kwargs)
 

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -299,7 +299,7 @@
               </ul>
               {% if request.user.is_authenticated %}
 
-                <div id="notificationsApp">
+                <div id="notificationsApp" v-cloak>
                   <a
                     href="#" :class="[  noOfUnreadNotifications > 0  ?'bg-warning p-1 rounded-3 shadow-5 text-white' : 'text-dark', 'h4 me-2 ms-4' ]"
                     id="toggleNotificationsPopover">

--- a/webook/templates/base.html
+++ b/webook/templates/base.html
@@ -656,6 +656,9 @@
             this.$nextTick(async function () {
               if (this.myNotifications.length === 0)
                 $( "#toggle" ).effect( "shake" );
+
+              await this.refreshNotifications();
+
               window.setInterval(async () => {
                 const initialCount = this.myNotifications.length;
                 await this.refreshNotifications();


### PR DESCRIPTION
Cloak the notification bell vue app to avoid visible code before
Additionally run refreshNotifications once before the refresh timer to avoid waiting before first get