### PR TITLE
refactor location rooms table to use vue tablecomponent

### DIFF
--- a/webook/arrangement/urls/location_urls.py
+++ b/webook/arrangement/urls/location_urls.py
@@ -5,6 +5,7 @@ from webook.arrangement.views import (
     location_delete_view,
     location_detail_view,
     location_list_view,
+    location_rooms_json_list_view,
     location_update_view,
     locations_calendar_resources_list_view,
     locations_tree_json_view,
@@ -39,11 +40,16 @@ location_urls = [
     path(
         route="location/delete/<slug:slug>/",
         view=location_delete_view,
-        name="location_delete"
+        name="location_delete",
     ),
     path(
         route="location/calendar_resources",
         view=locations_calendar_resources_list_view,
         name="location_calendar_resources",
-    )
+    ),
+    path(
+        route="location/location_rooms_json/<slug:slug>",
+        view=location_rooms_json_list_view,
+        name="location_rooms_json",
+    ),
 ]

--- a/webook/arrangement/views/__init__.py
+++ b/webook/arrangement/views/__init__.py
@@ -82,6 +82,7 @@ from .location_views import (
     location_delete_view,
     location_detail_view,
     location_list_view,
+    location_rooms_json_list_view,
     location_update_view,
     locations_calendar_resources_list_view,
     locations_tree_json_view,

--- a/webook/arrangement/views/calendar_views.py
+++ b/webook/arrangement/views/calendar_views.py
@@ -130,7 +130,7 @@ class EventSourceViewMixin(ListView):
             "start": event.start,
             "end": event.end,
             "resourceIds": [room.slug for room in event.rooms.all()]
-            + [person.slug for person in event.people.all()],
+            + [person.slug for person in event.people],
         }
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:

--- a/webook/arrangement/views/location_views.py
+++ b/webook/arrangement/views/location_views.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http.response import HttpResponse
+from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
@@ -217,3 +218,30 @@ class LocationsCalendarResourcesListView(LoginRequiredMixin, ListView):
 
 
 locations_calendar_resources_list_view = LocationsCalendarResourcesListView.as_view()
+
+
+class LocationRoomsJsonListView(LoginRequiredMixin, JsonListView):
+    slug_field = "slug"
+    slug_url_kwarg = "slug"
+
+    def get_queryset(self):
+        location = get_object_or_404(Location, slug=self.kwargs["slug"])
+
+        converted_rooms = []
+
+        for room in location.rooms.all():
+            converted_rooms.append(
+                {
+                    "slug": room.slug,
+                    "id": room.id,
+                    "title": room.name,
+                    "max_capacity": room.max_capacity,
+                    "is_exclusive": room.is_exclusive,
+                    "has_screen": room.has_screen,
+                }
+            )
+
+        return converted_rooms
+
+
+location_rooms_json_list_view = LocationRoomsJsonListView.as_view()

--- a/webook/templates/arrangement/location/location_detail.html
+++ b/webook/templates/arrangement/location/location_detail.html
@@ -8,11 +8,11 @@
 {% block beneath_breadcrumbs_block %}
     <a class="btn wb-btn-main"
         href="{% url 'arrangement:location_delete' object.slug %}">
-        <i class="fa fa-trash"></i>&nbsp; {% trans "Delete" %}
+        <i class="fa fa-trash"></i>&nbsp; Slett
     </a>
     <a class="btn wb-btn-main"
         href="{% url 'arrangement:location_edit' object.slug %}">
-        <i class="fa fa-edit"></i>&nbsp; {% trans "Edit" %}
+        <i class="fa fa-edit"></i>&nbsp; Rediger
     </a>
 {% endblock %}
 
@@ -46,94 +46,28 @@
         <div id="location_calendar" class="mb-4"></div>
     </div>
     <div class="tab-pane fade" id="tab-rooms" role="tabpanel">
-        <div class="clearfix">
-            <button class="btn btn-lg btn-webook float-end"
-            data-mdb-toggle="modal"
-            data-mdb-target="#createRoomModal">
-                <i class="fa fa-plus"></i>&nbsp; {% trans "New Room" %}
-            </button>
-        </div>
-        
         <span id="roomsTableLoaderWrapper">
         </span>
     </div>
 </div>
 
 
-<div
-  class="modal fade"
-  id="createRoomModal"
-  tabindex="-1"
-  aria-labelledby="exampleModalLabel"
-  aria-hidden="true"
-    >
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">
-            <span class="badge badge-success">
-                <i class="fas fa-plus"></i>
-            </span>
-            {% trans "New room" %}
-        </h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-mdb-dismiss="modal"
-          aria-label="Close"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <form id="createNewRoomDialogForm">
-            <input type="hidden" name="location" value="{{ object.id }}" />
-            <div class="form-group">
-                <label>{% trans "Location" %}</label>
-                <input type="text" class="form-control" value="{{ object.name }}" disabled/>
-            </div>
-
-            <div class="form-group mt-3">
-                <label>{% trans "Maximum Occupancy" %}</label>
-                <input type="number" name="max_capacity" class="form-control" value="0" />
-            </div>
-
-            <div class="form-group mt-3">
-                <label>{% trans "Room Name" %}</label>
-                <input type="text" class="form-control" name="name" id="roomNameInput"/>
-            </div>
-
-            <div class="form-group mt-3">
-                <label>{% trans "Room Name (English)" %}</label>
-                <input type="text" class="form-control" name="name_en" id="roomNameEnInput">
-            </div>
-
-            <div class="form-group mt-3">
-                <div class="form-check form-switch">
-                    <label>Is Exclusive?</label>
-                    <input class="form-check-input" name="is_exclusive" type="checkbox" role="switch" id="roomIsExclusive" />
-                </div>
-            </div>
-            <div class="form-group mt-3">
-                <div class="form-check form-switch">
-                    <label>Has Screen?</label>
-                    <input class="form-check-input" name="has_screen" type="checkbox" role="switch" id="roomHasScreen" />
-                </div>
-            </div>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn wb-btn-secondary" data-mdb-dismiss="modal">
-            <i class="fas fa-times"></i>&nbsp; 
-            {% trans "Cancel" %}
-        </button>
-        <button type="button" class="btn wb-btn-main" onclick="createNewRoom()"><i class="fas fa-check"></i>&nbsp; {% trans "Create room" %}</button>
-        <button type="button" class="btn wb-btn-main" onclick="createNewRoom(false /* dont close after save*/)">{% trans "Create and new" %}</button>
-      </div>
-    </div>
-  </div>
-</div>
 
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    $(document).ready(function() {
+        $('#roomsTableLoaderWrapper').load('{% url "arrangement:locationroomlist" object.id %}?location={{object.id }}')
+        renderLocationCalendar();
+    });
+
+    const tabEl = document.querySelector('a[href="#tab-calendar"]');
+    tabEl.addEventListener('shown.mdb.tab', (event) => {
+        // Render calendar when tab is shown, due to possible issues that may occur after pagination on rooms table
+        // Causes rendering issues - not sure why, but it is a recurrent issue with fullcalendar and tabs
+        console.log('Tab shown')
+        renderLocationCalendar(); 
+    })
+
+    function renderLocationCalendar() {
         var calendarEl = document.getElementById('location_calendar');
         var calendar = new FullCalendar.Calendar(calendarEl, {
             schedulerLicenseKey: '{{ FULLCALENDAR_LICENSE_KEY }}',
@@ -153,43 +87,7 @@
             }
         });
         calendar.render();
-        loadRoomsTableForLocation()
-    });
-
-    function loadRoomsTableForLocation () {
-        $('#roomsTableLoaderWrapper').load('{% url "arrangement:locationroomlist" object.id %}?location={{object.id }}')
     }
 
-    async function createNewRoom (closeModalOnDone=true) {
-        let dataForm = new FormData(document.getElementById("createNewRoomDialogForm"))
-        let url = "{% url 'arrangement:room_create' %}"
-
-        dataForm.append("csrfmiddlewaretoken", "{{ csrf_token }}");
-
-        fetch(url, {
-            method: 'POST',
-            body: dataForm,
-            headers: {
-                'X-CSRFToken': '{% csrf_token %}'
-            }
-        }).then(function(response) {
-            if (response.ok) {
-                loadRoomsTableForLocation() // refresh rooms table to include our newly created room
-            }
-            else {
-                throw "Response not OK."
-            }
-        }).catch(function(err) {
-            console.log(err)
-        }).then(function(response) {
-            if (closeModalOnDone) {
-                $('#createRoomModal').modal('hide');
-            }
-            else {
-                // if we don't want to close the modal, we know we want to empty the form
-                $('#createNewRoomDialogForm').trigger("reset");
-            }
-        })
-    }
 </script>
 {% endblock %}

--- a/webook/templates/arrangement/room/partials/_location_room_list.html
+++ b/webook/templates/arrangement/room/partials/_location_room_list.html
@@ -1,66 +1,254 @@
 {% load static i18n %}
 
-<div class="table-responsive">
-    <table class="table table-sm" id="roomList">
-        <thead>
-            <tr>
-                <th class="h5">{% trans "Name" %}</th>
-                <th class="h5">{% trans "Maximum Occupants" %}</th>
-                <th class="h5">{% trans "Is Exclusive?" %}</th>
-                <th class="h5">{% trans "Has Screen?" %}</th>
-                <th class="h5">{% trans "Options" %}</th>
-            </tr>
-        </thead>
+{% include "arrangement/vue/table_component.html" %}
 
-        <tbody>
-            {% for item in object_list %}
-                <tr>
-                    <td>{{ item.name }}</td>
-                    <td>{{ item.max_capacity }}</td>
-                    <td>
-                        {% if item.is_exclusive %}
-                            <i class="fas fa-check text-success"></i>
-                        {% else %}
-                            <i class="fas fa-times text-danger"></i>
-                        {% endif %}
-                    </td>
-                     <td>
-                        {% if item.has_screen %}
-                            <i class="fas fa-check text-success"></i>
-                        {% else %}
-                            <i class="fas fa-times text-danger"></i>
-                        {% endif %}
-                    </td>
-                    <td>
-                        <!-- <a
-                            class="btn wb-btn-main btn-sm"
-                            href="{% url 'arrangement:room_detail' item.slug %}">
-                            <i class="fas fa-eye"></i>&nbsp;
-                            {% trans "Show" %}
-                        </a> -->
-                        <a
-                            class="btn wb-btn-main btn-sm"
-                            href="">
-                            <i class="fas fa-trash"></i>&nbsp;
-                            {% trans "Delete" %}
-                        </a>
-                        <a
-                            class="btn wb-btn-main btn-sm"
-                            href="{% url 'arrangement:room_edit' item.slug %}">
-                            <i class="fas fa-edit"></i>&nbsp;
-                            {% trans "Edit" %}
-                        </a>
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+<div id="roomsTableApp">
+    <div class="clearfix">
+        <button class="btn wb-btn-main btn-sm mb-3 float-end"
+            @click="showCreateRoomModal()">
+            <i class="fas fa-plus"></i>&nbsp; Opprett nytt rom
+        </button>    
+    </div>
+    
+
+    <table-component
+        :data-source="roomsDataSourceFunc"
+        :can-search="true"
+        :rerender-toggle="renderToggle"
+        @row-clicked="whenRowIsClicked"
+        @edit="edit"
+        @delete-room="deleteRoom">
+    </table-component>
+
+    <div
+        class="modal fade"
+        id="createRoomModal"
+        tabindex="-1"
+        aria-labelledby="exampleModalLabel"
+        aria-hidden="true"
+            >
+        <div class="modal-dialog">
+            <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalLabel">
+                    <span class="badge badge-success">
+                        <i class="fas fa-plus"></i>
+                    </span>
+                    {% trans "New room" %}
+                </h5>
+                <button
+                type="button"
+                class="btn-close"
+                data-mdb-dismiss="modal"
+                aria-label="Close"
+                ></button>
+            </div>
+            <div class="modal-body">
+                <form id="createNewRoomDialogForm">
+                    <input type="hidden" name="location" value="{{ LOCATION.id }}" />
+                    <div class="form-group">
+                        <label>{% trans "Location" %}</label>
+                        <input type="text" class="form-control" value="{{ LOCATION.name }}" name="location_name" disabled/>
+                    </div>
+
+                    <div class="form-group mt-3">
+                        <label>{% trans "Maximum Occupancy" %}</label>
+                        <input type="number" name="max_capacity" class="form-control" value="0" />
+                    </div>
+
+                    <div class="form-group mt-3">
+                        <label>{% trans "Room Name" %}</label>
+                        <input type="text" class="form-control" name="name" id="roomNameInput"/>
+                    </div>
+
+                    <div class="form-group mt-3">
+                        <label>{% trans "Room Name (English)" %}</label>
+                        <input type="text" class="form-control" name="name_en" id="roomNameEnInput">
+                    </div>
+
+                    <div class="form-group mt-3">
+                        <div class="form-check form-switch">
+                            <label>Is Exclusive?</label>
+                            <input class="form-check-input" name="is_exclusive" type="checkbox" role="switch" id="roomIsExclusive" />
+                        </div>
+                    </div>
+                    <div class="form-group mt-3">
+                        <div class="form-check form-switch">
+                            <label>Has Screen?</label>
+                            <input class="form-check-input" name="has_screen" type="checkbox" role="switch" id="roomHasScreen" />
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn wb-btn-secondary" data-mdb-dismiss="modal">
+                    <i class="fas fa-times"></i>&nbsp; 
+                    {% trans "Cancel" %}
+                </button>
+                <button type="button" class="btn wb-btn-main" @click="createNewRoom()">{% trans "Create room" %}</button>
+                <button type="button" class="btn wb-btn-main" @click="createNewRoom(false)">{% trans "Create and new" %}</button>
+            </div>
+            </div>
+        </div>
+        </div>
 </div>
 
+
 <script>
-    $(document).ready(function () {
-        $('#roomList').DataTable({
-            dom: '',
-        });
-    });
+    $(document).ready(function() {
+        const roomsTableApp = Vue.createApp({
+            components: {
+                TableComponent
+            },
+            data() {
+                return {
+                    renderToggle: true
+                }
+            },
+            computed: {},
+            methods: {
+                async rerenderTable() {
+                    this.renderToggle = !this.renderToggle;
+                },
+                showCreateRoomModal() {
+                    $("#createRoomModal").modal("show")
+                },
+                edit(row) {
+                    location.href = "/arrangement/room/edit/" + row.slug
+                },
+                async deleteRoom(row) {
+                    Swal.fire({
+                        title: 'Er du sikker?',
+                        text: "Du kan ikke angre denne handlingen!\n Rommet '" + row.title + "' vil bli slettet permanent.",
+                        icon: 'warning',
+                        showCancelButton: true,
+                        confirmButtonColor: '#3085d6',
+                        cancelButtonColor: '#d33',
+                        cancelButtonText: 'Avbryt',
+                        confirmButtonText: 'Ja, slett!'
+                      }).then(async (result) => {
+                        if (result.isConfirmed) {
+                            const response = await fetch("/arrangement/room/delete/" + row.slug, {
+                                method: "DELETE",
+                                headers: {
+                                    "X-CSRFToken": "{{ csrf_token }}",
+                                }
+                            });
+
+                            if (response.status === 200) {
+                                Swal.fire(
+                                    'Slettet!',
+                                    'Rommet er slettet.',
+                                    'success'
+                                ).then(() => {
+                                    this.rerenderTable();
+                                })
+                            } else {
+
+                                console.error(response)
+                                Swal.fire(
+                                    'Feil!',
+                                    'Noe gikk galt.',
+                                    'error'
+                                )
+                            }
+                        }
+                      })
+                },
+                async roomsDataSourceFunc() {
+                    let data = await fetch('{% url "arrangement:location_rooms_json" slug=LOCATION.slug %}')
+                        .then( response => response.json() );
+                    
+                    data.forEach(function(item) {
+                        let boolConvert = (value) => {
+                            if (value === true) {
+                                return "<i class='fas text-success fa-check'></i>"
+                            } else {
+                                return "<i class='fas text-danger fa-times'></i>"
+                            }
+                        }
+
+                        item.is_exclusive = boolConvert(item.is_exclusive)
+                        item.has_screen = boolConvert(item.has_screen)
+                    })
+
+                    return {
+                        columns: {
+                            "title": {
+                                isHtml: true,
+                                friendlyName: "Navn",
+                                isSortable: true,
+                                isSearchable: true
+                            },
+                            "max_capacity": {
+                                friendlyName: "Maks antall",
+                                isSortable: true,
+                            },
+                            "is_exclusive": {
+                                friendlyName: "Eksklusivt?",
+                                isHtml: true, 
+                                isSortable: true,
+                            },
+                            "has_screen": {
+                                friendlyName: "Har skjerm?",
+                                isHtml: true, 
+                                isSortable: true,
+                            },
+                        },
+                        actions: {
+                            "edit": {
+                                type: "main",
+                                isContentHtml: true,
+                                content: "<i class='fas fa-edit'></i> Rediger",
+                            },
+                            "deleteRoom": {
+                                type: "main",
+                                isContentHtml: true,
+                                content: "<i class='fas fa-trash'></i> Slett",
+                            },
+                        },
+                        data: data
+                    }
+                },
+                resetModalForm() {
+                    $('#createNewRoomDialogForm input:not([name=location_name], [name=location])').val('')
+                    $('#createNewRoomDialogForm input[name=max_capacity]').val("0");
+                },
+                async createNewRoom (closeModalOnDone=true) {
+                    console.log("createNewRoom")
+
+                    let dataForm = new FormData(document.getElementById("createNewRoomDialogForm"))
+                    let url = "{% url 'arrangement:room_create' %}"
+
+                    dataForm.append("csrfmiddlewaretoken", "{{ csrf_token }}");
+
+                    fetch(url, {
+                        method: 'POST',
+                        body: dataForm,
+                        headers: {
+                            'X-CSRFToken': '{% csrf_token %}'
+                        }
+                    }).then( async (response) => {
+                        if (response.ok) {
+                            await this.rerenderTable() // refresh rooms table to include our newly created room
+                            toastr.success("Rom opprettet!");
+                        }
+                        else {
+                            throw "Response not OK."
+                        }
+                    }).catch(err => {
+                        console.log(err)
+                    }).then(response => {
+                        this.resetModalForm();
+
+                        if (closeModalOnDone) {
+                            $('#createRoomModal').modal('hide');
+                        }
+                    })
+                }
+            }
+        })
+
+        roomsTableApp.mount("#roomsTableApp")
+    })
 </script>

--- a/webook/templates/arrangement/room/room_form.html
+++ b/webook/templates/arrangement/room/room_form.html
@@ -56,11 +56,6 @@
         </div>
 
         <div class="form-group mt-2 pt-3 pb-2">
-            <label for="{{ form.max_capacity.id_for_label }}" class="h5 d-block">
-                {{ form.max_capacity.label }}
-            </label>
-
-
             <div class="form-check form-switch">
                 {% if object.is_exclusive %}
                     <input class="form-check-input" name="{{form.is_exclusive.name}}" type="checkbox" role="switch" id="{{form.is_exclusive.id_for_label}}" checked />
@@ -83,8 +78,6 @@
 
 
         <div class="mt-3">
-
-
             <button type="reset" class="btn wb-bg-secondary shadow-0">
                 <i class="fas fa-redo"></i>&nbsp; 
                 {% trans "Reset Form" %}

--- a/webook/templates/arrangement/service/service_detail.html
+++ b/webook/templates/arrangement/service/service_detail.html
@@ -246,7 +246,7 @@ contaner-fluid ps-5 pe-5
 
 <template id="vuec_service_order_popover_template">
     <fancy-popover :x="x" :y="y" :title="`Tjenestebestilling ${serviceOrder.id}`">
-        Hello there pardner
+        Fancy popover - not in use
     </fancy-popover>
 </template>
 
@@ -463,10 +463,8 @@ contaner-fluid ps-5 pe-5
                             },
                             onUpdatedCallback: async (dialogManager, context) => {
                                 await this.getPersonnell();
-
                             },
                             onSubmit: async (context, details) => {
-                                console.log("onsubmit has been triggerered")
                                 await this.getPersonnell();
                             }
                         })

--- a/webook/templates/arrangement/vue/table_component.html
+++ b/webook/templates/arrangement/vue/table_component.html
@@ -1,6 +1,6 @@
 <template
     id="vuec-table-component-template">
-
+    
     <div class="d-flex justify-content-between">
         <div class="input-group w-50" v-if="canSearch">
             <span class="input-group-text border-end-0">
@@ -12,20 +12,23 @@
                 placeholder="Søk..."
                 v-model="searchTerm">
         </div>
-
-        <div class="d-flex align-items-center">
-            <div class="input-group w-auto ms-3">
-                <div class="input-group-text">
-                    <i class="fas fa-table"></i>
+        
+        <div class="d-flex">
+            <slot></slot>
+            <div class="d-flex align-items-center">
+                <div class="input-group w-auto ms-3">
+                    <div class="input-group-text">
+                        <i class="fas fa-table"></i>
+                    </div>
+                    <select class="form-control" v-model="itemsPerPage">
+                        <option value="10">10</option>
+                        <option value="15">15</option>
+                        <option value="25">25</option>
+                        <option value="50">50</option>
+                        <option value="75">75</option>
+                        <option value="100">100</option>
+                    </select>
                 </div>
-                <select class="form-control" v-model="itemsPerPage">
-                    <option value="10">10</option>
-                    <option value="15">15</option>
-                    <option value="25">25</option>
-                    <option value="50">50</option>
-                    <option value="75">75</option>
-                    <option value="100">100</option>
-                </select>
             </div>
         </div>
     </div>
@@ -155,7 +158,7 @@
         props: {
             type: String,
             iconClass: String,
-            tooltip: String
+            tooltip: String,
         },
         data() {
             return {
@@ -192,7 +195,8 @@
             sort: Boolean,
             tableClasses: String,
             hiddenColumns: Array,
-            columnNames: Object
+            columnNames: Object,
+            rerenderToggle: Boolean
         },
         data() {
             return {
@@ -256,6 +260,14 @@
             itemsPerPage() {
                 if (this.page > this.totalPages)
                     this.page = this.totalPages;
+            },
+            totalPages() {
+                if (this.page > this.totalPages)
+                    this.page = this.totalPages;
+            },
+            rerenderToggle() {
+                console.log("Rerendering table")
+                this.refresh();
             }
         },
         created() {


### PR DESCRIPTION
Rewritten the table tab to use the new vue table component designed for the service stuff. Works well - and does a lot for free. Additionally done some QOL improvements such as adding toasts post actions, and sweetalert for deletion of a room. Editing a room is still its own page, though it may be worth considering using the modal for this purpose - work involved should be minimal to achieve this.