### PR TITLE
Fix intermittent errors on loading order service dialog

### DIFF
--- a/webook/static/modules/planner/dialog_manager/dialog.js
+++ b/webook/static/modules/planner/dialog_manager/dialog.js
@@ -43,7 +43,7 @@ class Dialog {
         this._listenToGlobalBroadcasts();
 
 
-        if (this.oldMessages) {
+        if (this.oldMessages && this.oldMessages.size > 0) {
             console.log("There are old messages")
             debugger;
             for (let [key, value] of this.oldMessages)
@@ -65,7 +65,7 @@ class Dialog {
     }
 
     _handleMessage(messageKey, message) {
-        if (this === undefined || this._whenMap === undefined)
+        if (this === undefined || this._whenMap === undefined || this._getDialogElement().length == 0)
             return null;
         
         console.log(window.MessagesFacility)

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createSerieDialog.html
@@ -1231,7 +1231,7 @@
                 dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', renderInChain: true, multiple: false, data: { whenEventName: "setPlanner" } });
             },
             triggerNewServiceOrder(dialog, {} = {}, triggeredByElement) {
-                    dialog.raiseTriggerEvent("{{managerName}}", "orderServiceDialog", { $parent:dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "newServiceOrder"}, event_type: "serie", entity_id: "0" })
+                    dialog.raiseTriggerEvent("{{managerName}}", "orderServiceDialog", { $parent:dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "newServiceOrder"}, entity_type: "serie", entity_id: "0" })
             },  
             removeAssociation(dialog, {} = {}, triggeredByElement) {
                 let $triggeredByElement = $(triggeredByElement);


### PR DESCRIPTION
Fix some intermittent errors affecting the loading of the "ORder service" dialog, and create serie dialog.
Fix a race condition causing messages to be picked up by the earlier dead dialogs listener, added a check to make sure that the dialog is still "alive", otherwise the message will be put on queue/wait for the new correct dialog listener to come pick it up.