### PR TITLE
Refactor set planner popover

### DIFF
--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -1044,6 +1044,8 @@ class Person(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
         )
 
     @property
+
+    @property
     def is_sso_capable(self):
         return (
             self.social_provider_id is not None

--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -1044,8 +1044,6 @@ class Person(TimeStampedModel, ModelNamingMetaMixin, ModelArchiveableMixin):
         )
 
     @property
-
-    @property
     def is_sso_capable(self):
         return (
             self.social_provider_id is not None

--- a/webook/arrangement/urls/person_urls.py
+++ b/webook/arrangement/urls/person_urls.py
@@ -7,30 +7,23 @@ from webook.arrangement.views import (
     person_delete_view,
     person_detail_view,
     person_list_view,
+    person_search_planners_ajax_view,
     person_update_view,
     search_people_ajax_view,
 )
 
 person_urls = [
-    path(
-        route="person/list/",
-        view=person_list_view,
-        name="person_list"
-    ),
+    path(route="person/list/", view=person_list_view, name="person_list"),
     path(
         route="person/create/",
         view=person_create_view,
         name="person_create",
     ),
-    path(
-        route="person/edit/<slug:slug>",
-        view=person_update_view,
-        name="person_edit"
-    ),
+    path(route="person/edit/<slug:slug>", view=person_update_view, name="person_edit"),
     path(
         route="person/<slug:slug>/associate_with_user",
         view=associate_person_with_user_form_view,
-        name="associate_person_with_user"
+        name="associate_person_with_user",
     ),
     path(
         route="person/<slug:slug>/",
@@ -48,8 +41,13 @@ person_urls = [
         name="search_people_ajax_view",
     ),
     path(
+        route="person/search_planners",
+        view=person_search_planners_ajax_view,
+        name="person_search_planners_ajax_view",
+    ),
+    path(
         route="person/calendar_resources",
         view=people_calendar_resources_list_view,
-        name="people_calendar_resources"
-    )
+        name="people_calendar_resources",
+    ),
 ]

--- a/webook/arrangement/views/__init__.py
+++ b/webook/arrangement/views/__init__.py
@@ -125,6 +125,7 @@ from .person_views import (
     person_list_view,
     person_update_view,
     search_people_ajax_view,
+    person_search_planners_ajax_view
 )
 from .planner_views import (
     arrangement_add_planner_dialog_view,

--- a/webook/arrangement/views/generic_views/search_view.py
+++ b/webook/arrangement/views/generic_views/search_view.py
@@ -49,7 +49,9 @@ class SearchView(ListView):
         if isinstance(results, QuerySet) and hasattr(results, "_meta"):
             response = serializers.serialize("json", results)
         else:
-            if isinstance(results, QuerySet):  # values has no _meta
+            # TODO: Look into why this is necessary. When we use qs.values() we get a queryset without _meta 
+            # -- likely because it's not a model queryset. Can Django serializer handle this with some configuration?
+            if isinstance(results, QuerySet):
                 results = list(results)
             response = json.dumps(results, default=json_serial)
 

--- a/webook/arrangement/views/generic_views/search_view.py
+++ b/webook/arrangement/views/generic_views/search_view.py
@@ -1,38 +1,37 @@
 import json
-from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import JsonResponse
-from django.urls import reverse
-from django.core import serializers
-from django.views.generic import (
-    DetailView,
-    RedirectView,
-    UpdateView,
-    ListView,
-    CreateView,
-)
 from enum import Enum
 
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core import serializers
+from django.http import JsonResponse
+from django.urls import reverse
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    ListView,
+    RedirectView,
+    UpdateView,
+)
 
-class SearchView (ListView):
 
+class SearchView(ListView):
     class SearchType(Enum):
         TermSearch = 1
         PkSearch = 2
 
     def post(self, request):
-        body_data = json.loads(request.body.decode('utf-8'))
-        search_type = body_data["search_type"] if "search_type" in body_data else None
-
-        if (search_type is None):
-            search_type = self.SearchType.TermSearch
-        else:
-            search_type = self.SearchType(search_type)
+        body_data = json.loads(request.body.decode("utf-8"))
+        search_type = (
+            self.SearchType(body_data["search_type"])
+            if "search_type" in body_data
+            else self.SearchType.TermSearch
+        )
 
         response = None
-        if (search_type == self.SearchType.TermSearch):
+        if search_type == self.SearchType.TermSearch:
             search_term = body_data["term"]
             response = serializers.serialize("json", self.search(search_term))
-        if (search_type == self.SearchType.PkSearch):
+        if search_type == self.SearchType.PkSearch:
             pks = body_data["pks"]
             response = serializers.serialize("json", self.pk_search(pks))
 

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -13,7 +13,14 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import CreateView, DetailView, FormView, ListView, RedirectView, UpdateView
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    FormView,
+    ListView,
+    RedirectView,
+    UpdateView,
+)
 from django.views.generic.base import View
 from django.views.generic.edit import DeleteView, FormMixin
 
@@ -266,8 +273,6 @@ people_calendar_resources_list_view = PeopleCalendarResourcesListView.as_view()
 
 class PersonSearchPlannersView(SearchPeopleAjax):
     def search(self, search_term):
-        show_only_planners: bool = self.request.GET.get("only_planners", False)
-
         if search_term == "":
             # If no search term is specified, we want to show all planners
             # We also allow searching through (and selecting) persons that are not formally planners (by group), so this
@@ -275,8 +280,6 @@ class PersonSearchPlannersView(SearchPeopleAjax):
             qs = Person.objects.all().filter(user__groups__name="planners")
         else:
             qs = super().search(search_term)
-            if show_only_planners:
-                qs = qs.filter(user__groups__name="planners")
 
         return qs.values("id", "first_name", "middle_name", "last_name")
 

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -209,7 +209,7 @@ class SearchPeopleAjax(LoginRequiredMixin, PlannerAuthorizationMixin, SearchView
         else:
             people = Person.objects.annotate(
                 afull_name=Concat("first_name", "middle_name", "last_name")
-            ).filter(afull_name__contains=search_term)
+            ).filter(afull_name__icontains=search_term)
 
         return people
 

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -13,7 +13,14 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import CreateView, DetailView, FormView, ListView, RedirectView, UpdateView
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    FormView,
+    ListView,
+    RedirectView,
+    UpdateView,
+)
 from django.views.generic.base import View
 from django.views.generic.edit import DeleteView, FormMixin
 
@@ -266,7 +273,7 @@ people_calendar_resources_list_view = PeopleCalendarResourcesListView.as_view()
 
 class PersonSearchPlannersView(SearchPeopleAjax):
     def search(self, search_term):
-        show_only_planners: bool = self.request.GET.get("only_planners", True)
+        show_only_planners: bool = self.request.GET.get("only_planners", False)
 
         if search_term == "":
             # If no search term is specified, we want to show all planners

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -13,14 +13,7 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import (
-    CreateView,
-    DetailView,
-    FormView,
-    ListView,
-    RedirectView,
-    UpdateView,
-)
+from django.views.generic import CreateView, DetailView, FormView, ListView, RedirectView, UpdateView
 from django.views.generic.base import View
 from django.views.generic.edit import DeleteView, FormMixin
 

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -286,5 +286,7 @@ class PersonSearchPlannersView(SearchPeopleAjax):
         if show_only_planners:
             qs = qs.filter(user__groups__name="planner")
 
+        return qs
+
 
 person_search_planners_ajax_view = PersonSearchPlannersView.as_view()

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -195,7 +195,6 @@ organization_person_member_list_view = OrganizationPersonMemberListView.as_view(
 
 
 class SearchPeopleAjax(LoginRequiredMixin, PlannerAuthorizationMixin, SearchView):
-
     model = Person
 
     def search(self, search_term):
@@ -270,3 +269,22 @@ class PeopleCalendarResourcesListView(LoginRequiredMixin, ListView):
 
 
 people_calendar_resources_list_view = PeopleCalendarResourcesListView.as_view()
+
+
+class PersonSearchPlannersView(SearchPeopleAjax):
+    def search(self, search_term):
+        show_only_planners: bool = self.request.GET.get("only_planners", True)
+
+        if search_term == "":
+            # If no search term is specified, we want to show all planners
+            # We also allow searching through (and selecting) persons that are not formally planners (by group), so this
+            # acts as a sane default that is shown when the user opens the search dialog/popover
+            return Person.objects.all().filter(user__groups__name="planner")
+
+        qs = super().search(search_term)
+
+        if show_only_planners:
+            qs = qs.filter(user__groups__name="planner")
+
+
+person_search_planners_ajax_view = PersonSearchPlannersView.as_view()

--- a/webook/arrangement/views/person_views.py
+++ b/webook/arrangement/views/person_views.py
@@ -13,14 +13,7 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import (
-    CreateView,
-    DetailView,
-    FormView,
-    ListView,
-    RedirectView,
-    UpdateView,
-)
+from django.views.generic import CreateView, DetailView, FormView, ListView, RedirectView, UpdateView
 from django.views.generic.base import View
 from django.views.generic.edit import DeleteView, FormMixin
 
@@ -279,14 +272,13 @@ class PersonSearchPlannersView(SearchPeopleAjax):
             # If no search term is specified, we want to show all planners
             # We also allow searching through (and selecting) persons that are not formally planners (by group), so this
             # acts as a sane default that is shown when the user opens the search dialog/popover
-            return Person.objects.all().filter(user__groups__name="planner")
+            qs = Person.objects.all().filter(user__groups__name="planners")
+        else:
+            qs = super().search(search_term)
+            if show_only_planners:
+                qs = qs.filter(user__groups__name="planners")
 
-        qs = super().search(search_term)
-
-        if show_only_planners:
-            qs = qs.filter(user__groups__name="planner")
-
-        return qs
+        return qs.values("id", "first_name", "middle_name", "last_name")
 
 
 person_search_planners_ajax_view = PersonSearchPlannersView.as_view()

--- a/webook/static/js/popover.js
+++ b/webook/static/js/popover.js
@@ -13,7 +13,7 @@ export class Popover {
         }
 
         this._listenToOutsideClicks();
-    }
+    }   
 
     _listenToTriggerElementClick() {
         this.triggerElement.addEventListener("click", function () {

--- a/webook/static/js/popover.js
+++ b/webook/static/js/popover.js
@@ -40,4 +40,11 @@ export class Popover {
         this.wrapperElement.classList.toggle("active");
         this.isShown = !this.isShown;
     }
+
+    fadeAndHide() {
+        $(this.wrapperElement).hide("fade", {}, 400, () => {
+            this.isShown = false;
+            this.wrapperElement.classList.remove("active");
+        });
+    }
 }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -22,83 +22,6 @@
                 <input type="submit" style="display:none;" />
 
                 <fieldset>
-
-                    <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
-                        <input type="hidden" 
-                            name="{{ form.responsible.name }}" 
-                            id="{{ form.responsible.id_for_label }}"
-                            v-model="mainPlanner.id">
-    
-                        <label for="" class="d-block form-label">
-                            <i class="fas fa-star"></i>
-                            Hovedplanlegger
-                        </label>
-    
-                        <div class="text-danger" style="display: none;"
-                            id="mainPlanner_validationText">
-                            Vennligst velg en hovedplanlegger
-                        </div>
-    
-                        <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
-                        <button class="wb-btn-main"
-                            id="setMainPlannerButton"
-                            type="button">
-                            Velg hovedplanlegger
-                        </button>
-    
-                        <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
-                            <div class="popover_content" style="width: 50em!important;">
-                                <h5>Velg hovedplanlegger</h5>
-                                
-                                
-                                <input type="search" name="" id="" class="form-control form-control-lg"
-                                    v-model="mainPlannerSearchTerm"
-                                    placeholder="Søk etter planlegger... (minst 3 tegn)">       
-
-                                <div class="mt-3">
-                                    <div v-if="mainPlannerSearchResults.length">
-                                        <div v-if="mainPlannerSearchTerm.length == 0"
-                                            class="alert alert-info">
-                                            <div class="d-flex align-items-center">
-                                                <h2 class="mb-0"><i class="fas fa-info"></i></h2>
-                                                
-                                                <div class="ms-3">
-                                                    Uten søkeord vises alle personer med gruppe planlegger
-                                                    <br>
-                                                    Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
-                                            <tbody>
-                                                <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
-                                                    <td>
-                                                        <a>
-                                                            [[ [result.first_name, result.middle_name, result.last_name].join(" ") ]]
-                                                        </a>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                        
-                                        <div class="clearfix">
-                                            <small class="text-muted float-end fw-bold">
-                                                <i class="fas fa-info"></i>&nbsp;
-                                                Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
-                                            </small>
-                                        </div>
-                                    </div>
-                                    <div 
-                                        class="alert alert-info"
-                                        v-else>
-                                        Ingen resultater
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
                     <div class="form-group mb-2">
                         <label>
                             Tittel <i>(Norsk)</i>
@@ -239,6 +162,82 @@
         <div id="step-2">
             <form id="arrangementDetailsForm">
                 <input type="submit" value="" style="display: none;">
+
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                    <input type="hidden" 
+                        name="{{ form.responsible.name }}" 
+                        id="{{ form.responsible.id_for_label }}"
+                        v-model="mainPlanner.id">
+
+                    <label for="" class="d-block form-label">
+                        <i class="fas fa-star"></i>
+                        Hovedplanlegger
+                    </label>
+
+                    <div class="text-danger" style="display: none;"
+                        id="mainPlanner_validationText">
+                        Vennligst velg en hovedplanlegger
+                    </div>
+
+                    <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
+                    <button class="wb-btn-main"
+                        id="setMainPlannerButton"
+                        type="button">
+                        Velg hovedplanlegger
+                    </button>
+
+                    <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
+                        <div class="popover_content" style="width: 50em!important;">
+                            <h5>Velg hovedplanlegger</h5>
+                            
+                            
+                            <input type="search" name="" id="" class="form-control form-control-lg"
+                                v-model="mainPlannerSearchTerm"
+                                placeholder="Søk etter planlegger... (minst 3 tegn)">       
+
+                            <div class="mt-3">
+                                <div v-if="mainPlannerSearchResults.length">
+                                    <div v-if="mainPlannerSearchTerm.length == 0"
+                                        class="alert alert-info">
+                                        <div class="d-flex align-items-center">
+                                            <h2 class="mb-0"><i class="fas fa-info"></i></h2>
+                                            
+                                            <div class="ms-3">
+                                                Uten søkeord vises alle personer med gruppe planlegger
+                                                <br>
+                                                Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
+                                        <tbody>
+                                            <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
+                                                <td>
+                                                    <a>
+                                                        [[ [result.first_name, result.middle_name, result.last_name].join(" ") ]]
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    
+                                    <div class="clearfix">
+                                        <small class="text-muted float-end fw-bold">
+                                            <i class="fas fa-info"></i>&nbsp;
+                                            Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
+                                        </small>
+                                    </div>
+                                </div>
+                                <div 
+                                    class="alert alert-info"
+                                    v-else>
+                                    Ingen resultater
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
                 <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
                     <label for="" class="form-label">

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -49,30 +49,33 @@
                         <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
                             <div class="popover_content" style="width: 50em!important;">
                                 <h5>Velg hovedplanlegger</h5>
-                                <input type="search" name="" id="" class="form-control"
+                                
+                                
+                                <input type="search" name="" id="" class="form-control form-control-lg"
                                     v-model="mainPlannerSearchTerm"
                                     placeholder="Søk etter planlegger... (minst 3 tegn)">       
 
                                 <div class="mt-3">
                                     <div v-if="mainPlannerSearchResults.length">
-                                        <table class="table table-bordered table-sm" v-if="mainPlannerSearchResults.length">
-                                            <thead>
-                                                <tr>
-                                                    <th class="d-flex wb-bg-secondary justify-content-between align-items-center">
-                                                        <h5 class="fw-bolder mb-0">
-                                                            Resultater
-                                                        </h5>
-                                                        <span class="badge badge-light fw-bold">
-                                                            [[ mainPlannerSearchResults.length ]] resultater
-                                                        </span>
-                                                    </th>
-                                                </tr>
-                                            </thead>
+                                        <div v-if="mainPlannerSearchTerm.length == 0"
+                                            class="alert alert-info">
+                                            <div class="d-flex align-items-center">
+                                                <h2 class="mb-0"><i class="fas fa-info"></i></h2>
+                                                
+                                                <div class="ms-3">
+                                                    Uten søkeord vises alle personer med gruppe planlegger
+                                                    <br>
+                                                    Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
                                             <tbody>
-                                                <tr>
-                                                    <td v-for="result in mainPlannerSearchResults">
+                                                <tr v-for="result in mainPlannerSearchResults" class="secondary-hover">
+                                                    <td>
                                                         <a @click="setMainPlanner(result)">
-                                                            [[ result.name ]]
+                                                            [[ [result.first_name, result.middle_name, result.last_name].join(" ") ]]
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -80,9 +83,9 @@
                                         </table>
                                         
                                         <div class="clearfix">
-                                            <small class="text-muted float-end">
+                                            <small class="text-muted float-end fw-bold">
                                                 <i class="fas fa-info"></i>&nbsp;
-                                                Trykk på navnet til planleggeren du ønsker å velge
+                                                Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
                                             </small>
                                         </div>
                                     </div>
@@ -596,8 +599,8 @@
                     rooms: [],
                     planners: [],
                     mainPlanner: { id: null, name: null },
-                    mainPlannerSearchTerm: "",
-                    mainPlannerSearchResults: [ { "id": 1, "name": "A Sample Planner" } ],
+                    mainPlannerSearchTerm: null,
+                    mainPlannerSearchResults: [],
                 }
             },
             computed: {},
@@ -659,10 +662,33 @@
                         preselectedMainPlanner: this.dialog.data.mainPlannerPayload,
                         preselectedRooms: this.dialog.data.roomPayload,
                     });
+                },
+            },
+            watch: {
+                mainPlannerSearchTerm: async function (val) {
+                    if (val.length > 2 || val.length == 0) {
+                        await fetch("{% url 'arrangement:person_search_planners_ajax_view' %}?term=" + val, {
+                            method: "GET",
+                            headers: {
+                                "X-CSRFToken": "{{ csrf_token }}",
+                            },
+                        }).then((response) => {
+                            if (response.ok) {
+                                response.json().then((data) => {
+                                    this.mainPlannerSearchResults = JSON.parse(data);
+                                });
+                            }
+                            else {
+                                console.log("HTTP-Error: " + response.status);
+                            }
+                        })
+                    }
                 }
             },
             delimiters: ['[[', ']]'],
             mounted() {
+                this.mainPlannerSearchTerm = "";
+
                 this.dialog = new Dialog({
                     vueApp: this,
                     managerName: '{{managerName}}',

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -215,7 +215,7 @@
                                             <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
                                                 <td>
                                                     <a>
-                                                        [[ [result.first_name, result.middle_name, result.last_name].join(" ") ]]
+                                                        [[ result.full_name ]]
                                                     </a>
                                                 </td>
                                             </tr>
@@ -666,13 +666,12 @@
 
                 setMainPlanner(planner) {
                     console.log("setMainPlanner", planner)
-                    const fullName = [ planner.first_name, planner.middle_name, planner.last_name ].join(" ");
 
-                    this.mainPlanner = { id: planner.id, text: fullName };
+                    this.mainPlanner = { id: planner.id, text: planner.full_name };
 
                     this.dialog.data.mainPlannerPayload = {
                         allPresets: new Map(),
-                        allSelectedEntityIds: [ { id: planner.id, text: fullName } ],
+                        allSelectedEntityIds: [ { id: planner.id, text: planner.full_name } ],
                         selectedPresets: [],
                         viewables: [ { id: planner.id, text: fullName } ]
                     }
@@ -692,6 +691,10 @@
                             if (response.ok) {
                                 response.json().then((data) => {
                                     this.mainPlannerSearchResults = JSON.parse(data);
+
+                                    this.mainPlannerSearchResults.forEach((planner) => {
+                                        planner.full_name = [ planner.first_name, planner.middle_name, planner.last_name ].join(" ");
+                                    });
                                 });
                             }
                             else {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -22,6 +22,37 @@
                 <input type="submit" style="display:none;" />
 
                 <fieldset>
+
+                    <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                        <input type="hidden" 
+                            name="{{ form.responsible.name }}" 
+                            id="{{ form.responsible.id_for_label }}"
+                            v-model="mainPlanner.id">
+    
+                        <label for="" class="d-block form-label">
+                            <i class="fas fa-star"></i>
+                            Hovedplanlegger
+                        </label>
+    
+                        <div class="text-danger" style="display: none;"
+                            id="mainPlanner_validationText">
+                            Vennligst velg en hovedplanlegger
+                        </div>
+    
+                        <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
+                        <button class="wb-btn-main"
+                            id="setMainPlannerButton"
+                            type="button">
+                            Velg hovedplanlegger
+                        </button>
+    
+                        <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none">
+                            <div class="popover_content">
+                                This is popover content                                
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="form-group mb-2">
                         <label>
                             Tittel <i>(Norsk)</i>
@@ -162,31 +193,6 @@
         <div id="step-2">
             <form id="arrangementDetailsForm">
                 <input type="submit" value="" style="display: none;">
-
-                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
-                    <input type="hidden" 
-                        name="{{ form.responsible.name }}" 
-                        id="{{ form.responsible.id_for_label }}"
-                        v-model="mainPlanner.id">
-
-                    <label for="" class="d-block form-label">
-                        <i class="fas fa-star"></i>
-                        Hovedplanlegger
-                    </label>
-
-                    <div class="text-danger" style="display: none;"
-                        id="mainPlanner_validationText">
-                        Vennligst velg en hovedplanlegger
-                    </div>
-
-                    <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
-                    <button class="wb-btn-main"
-                        id="setMainPlannerButton"
-                        type="button"
-                        @click="openSetMainPlannerDialog()">
-                        Velg hovedplanlegger
-                    </button>
-                </div>
 
                 <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
                     <label for="" class="form-label">
@@ -533,6 +539,7 @@
 
 <script type="module">
     import { JSTreeSelect } from "{% static 'js/jsTreeSelect.js' %}";
+    import { Popover } from "{% static 'js/popover.js' %}"
 
     $(document).ready(function () {
         let createArrangementDialogApp = Vue.createApp({
@@ -611,8 +618,6 @@
             },
             delimiters: ['[[', ']]'],
             mounted() {
-                console.log("Mounted", this)
-
                 this.dialog = new Dialog({
                     vueApp: this,
                     managerName: '{{managerName}}',
@@ -622,6 +627,11 @@
                         dialog.querySelectorAll('.form-outline').forEach((formOutline) => {
                             new mdb.Input(formOutline).init();
                         });
+                        const mainPlannerPopover = new Popover({
+                            triggerElement: dialog.dialogElement.querySelector('#setMainPlannerButton'),
+                            wrapperElement: dialog.dialogElement.querySelector('#select-main-planner-popover'),
+                        });
+        
 
                         [
                             {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -72,9 +72,9 @@
 
                                         <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
                                             <tbody>
-                                                <tr v-for="result in mainPlannerSearchResults" class="secondary-hover">
+                                                <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
                                                     <td>
-                                                        <a @click="setMainPlanner(result)">
+                                                        <a>
                                                             [[ [result.first_name, result.middle_name, result.last_name].join(" ") ]]
                                                         </a>
                                                     </td>
@@ -598,9 +598,10 @@
                     serviceOrders: [],
                     rooms: [],
                     planners: [],
-                    mainPlanner: { id: null, name: null },
+                    mainPlanner: { id: null, text: null },
                     mainPlannerSearchTerm: null,
                     mainPlannerSearchResults: [],
+                    mainPlannerPopover: null
                 }
             },
             computed: {},
@@ -663,6 +664,22 @@
                         preselectedRooms: this.dialog.data.roomPayload,
                     });
                 },
+
+                setMainPlanner(planner) {
+                    console.log("setMainPlanner", planner)
+                    const fullName = [ planner.first_name, planner.middle_name, planner.last_name ].join(" ");
+
+                    this.mainPlanner = { id: planner.id, text: fullName };
+
+                    this.dialog.data.mainPlannerPayload = {
+                        allPresets: new Map(),
+                        allSelectedEntityIds: [ { id: planner.id, text: fullName } ],
+                        selectedPresets: [],
+                        viewables: [ { id: planner.id, text: fullName } ]
+                    }
+
+                    this.mainPlannerPopover.hide();
+                }
             },
             watch: {
                 mainPlannerSearchTerm: async function (val) {
@@ -702,6 +719,7 @@
                             triggerElement: dialog.dialogElement.querySelector('#setMainPlannerButton'),
                             wrapperElement: dialog.dialogElement.querySelector('#select-main-planner-popover'),
                         });
+                        dialog.vueApp.mainPlannerPopover = mainPlannerPopover;
         
 
                         [
@@ -1094,6 +1112,7 @@
                             payload.selectedPresets.forEach( (presetId) => dialog.data.plannerPresets.set(presetId, payload.allPresets.get(presetId)));
             
                             dialog.data.plannerPayload = payload;
+                            console.log(dialog.data.plannerPayload);
 
                             dialog.vueApp.planners = payload.viewables;
                         } },

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -678,7 +678,7 @@
                         viewables: [ { id: planner.id, text: fullName } ]
                     }
 
-                    this.mainPlannerPopover.hide();
+                    this.mainPlannerPopover.fadeAndHide();
                 }
             },
             watch: {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -46,9 +46,52 @@
                             Velg hovedplanlegger
                         </button>
     
-                        <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none">
-                            <div class="popover_content">
-                                This is popover content                                
+                        <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
+                            <div class="popover_content" style="width: 50em!important;">
+                                <h5>Velg hovedplanlegger</h5>
+                                <input type="search" name="" id="" class="form-control"
+                                    v-model="mainPlannerSearchTerm"
+                                    placeholder="Søk etter planlegger... (minst 3 tegn)">       
+
+                                <div class="mt-3">
+                                    <div v-if="mainPlannerSearchResults.length">
+                                        <table class="table table-bordered table-sm" v-if="mainPlannerSearchResults.length">
+                                            <thead>
+                                                <tr>
+                                                    <th class="d-flex wb-bg-secondary justify-content-between align-items-center">
+                                                        <h5 class="fw-bolder mb-0">
+                                                            Resultater
+                                                        </h5>
+                                                        <span class="badge badge-light fw-bold">
+                                                            [[ mainPlannerSearchResults.length ]] resultater
+                                                        </span>
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td v-for="result in mainPlannerSearchResults">
+                                                        <a @click="setMainPlanner(result)">
+                                                            [[ result.name ]]
+                                                        </a>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        
+                                        <div class="clearfix">
+                                            <small class="text-muted float-end">
+                                                <i class="fas fa-info"></i>&nbsp;
+                                                Trykk på navnet til planleggeren du ønsker å velge
+                                            </small>
+                                        </div>
+                                    </div>
+                                    <div 
+                                        class="alert alert-info"
+                                        v-else>
+                                        Ingen resultater
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -553,6 +596,8 @@
                     rooms: [],
                     planners: [],
                     mainPlanner: { id: null, name: null },
+                    mainPlannerSearchTerm: "",
+                    mainPlannerSearchResults: [ { "id": 1, "name": "A Sample Planner" } ],
                 }
             },
             computed: {},


### PR DESCRIPTION
Refactor the set main planner mechanism. The current dialog approach is heavy, and has some pesky bugs that it is not worth the time to get to the bottom of. Better to rewrite it leveraging Vue and Popovers to end up at what is, I think, a better result all together. Many flies, one PR.