### PR TITLE
Rewrite create activity dialog to vue

### DIFF
--- a/webook/arrangement/forms/event_forms.py
+++ b/webook/arrangement/forms/event_forms.py
@@ -257,6 +257,7 @@ class BaseEventForm(forms.ModelForm):
                 attrs={
                     "id": "display_layouts_create_event",
                     "name": "display_layouts_create_event",
+                    "v-model": "activity.display_layouts",
                 }
             ),
         }
@@ -281,6 +282,7 @@ class UpdateEventForm(BaseEventForm):
                 attrs={
                     "id": "display_layouts_create_event",
                     "name": "display_layouts_create_event",
+                    "v-model": "activity.display_layouts",
                 }
             ),
             "status": forms.Select(attrs={"class": "form-control form-control-lg"}),

--- a/webook/arrangement/forms/planner/planner_create_arrangement_form.py
+++ b/webook/arrangement/forms/planner/planner_create_arrangement_form.py
@@ -5,7 +5,6 @@ from webook.arrangement.models import Arrangement, Person, RoomPreset
 
 
 class PlannerCreateArrangementModelForm(forms.ModelForm):
-
     display_text = forms.CharField(required=False)
     display_text_en = forms.CharField(required=False)
     responsible = forms.ModelChoiceField(queryset=Person.objects.all(), required=False)
@@ -29,11 +28,17 @@ class PlannerCreateArrangementModelForm(forms.ModelForm):
             "planners",
         )
         widgets = {
-            "display_layouts": CheckboxSelectMultiple(),
+            "display_layouts": CheckboxSelectMultiple(
+                attrs={"v-model": "arrangement.display_layouts"}
+            ),
+            "display_text": forms.TextInput(
+                attrs={"v-model": "arrangement.display_text"}
+            ),
             "location": forms.Select(
                 attrs={
                     "class": "form-control form-control-md",
                     "data-mdb-validation": "true",
+                    "v-model": "arrangement.location",
                 }
             ),
             "audience": forms.Select(

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -325,32 +325,21 @@ export class ArrangementCreator {
                                 const $mainDialog = this.dialogManager.$getDialogElement("createArrangementDialog");
                                 this.dialogManager.setTitle("newSimpleActivityDialog", "Opprett aktivitet");
 
-                                if (context.lastTriggererDetails.preselectedPeople) {
-                                    window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preselectedPeople, "peopleSelected");
+                                const arrangementData = context.lastTriggererDetails.data;
+
+                                if (arrangementData.roomPayload) {
+                                    window.MessagesFacility.send("newSimpleActivityDialog", arrangementData.roomPayload, "roomsSelected");
                                 }
-                                if (context.lastTriggererDetails.preselectedRooms) {
-                                    window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preselectedRooms, "roomsSelected");
+                                if (arrangementData.mainPlannerPayload) {
+                                    window.MessagesFacility.send("newSimpleActivityDialog", arrangementData.mainPlannerPayload, "setPlanner");
                                 }
-                                if (context.lastTriggererDetails.preselectedMainPlanner) {
-                                    window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preselectedMainPlanner, "setPlanner");
-                                }
-                                if (context.lastTriggererDetails.preorderedServices) {
-                                    window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preorderedServices, "newServiceOrder");
+                                if (arrangementData.servicePresets) {
+                                    window.MessagesFacility.send("newSimpleActivityDialog", Array.from(arrangementData.servicePresets.values()), "newServiceOrder");
                                 }
 
                                 window.MessagesFacility.send(
                                     "newSimpleActivityDialog",
-                                    {
-                                        title: $mainDialog.find('#title').val(),
-                                        title_en: $mainDialog.find('#title_en').val(),
-                                        expected_visitors: $mainDialog.find('#expected_visitors').val(),
-                                        meeting_place: $mainDialog.find('#id_meeting_place').val(),
-                                        meeting_place_en: $mainDialog.find('#id_meeting_place_en').val(),
-                                        display_text: $mainDialog.find('#id_display_text').val(),
-                                        audienceId: $mainDialog.find('#_backingAudienceId').val(),
-                                        arrangementTypeId: $mainDialog.find('#_backingArrangementTypeId').val(),
-                                        statusTypeId: $mainDialog.find('#_statusTypeId').val(),
-                                    },
+                                    arrangementData,
                                     "populateDialogWithEvent"
                                 )
 

--- a/webook/static/modules/planner/arrangementCreator.js
+++ b/webook/static/modules/planner/arrangementCreator.js
@@ -338,20 +338,21 @@ export class ArrangementCreator {
                                     window.MessagesFacility.send("newSimpleActivityDialog", context.lastTriggererDetails.preorderedServices, "newServiceOrder");
                                 }
 
-                                [
-                                    { from: '#id_ticket_code', to: '#ticket_code' },
-                                    { from: '#id_name', to: '#title' },
-                                    { from: '#id_name_en', to: '#title_en' },
-                                    { from: '#id_expected_visitors', to: '#expected_visitors'},
-                                    { from: '#id_meeting_place', to: '#id_meeting_place' },
-                                    { from: '#id_meeting_place_en', to: '#id_meeting_place_en' },
-                                    { from: '#id_display_text', to: '#id_display_text' },
-                                    { from: '#_audienceId', to: '#_backingAudienceId' },
-                                    { from: '#_arrangementTypeId', to: '#_backingArrangementTypeId'},
-                                    { from: '#_statusTypeId', to: '#_statusTypeId' },
-                                ].forEach( (mapping) => { 
-                                    $simpleActivityDialog.find( mapping.to ).val( $mainDialog.find( mapping.from )[0].value );
-                                });
+                                window.MessagesFacility.send(
+                                    "newSimpleActivityDialog",
+                                    {
+                                        title: $mainDialog.find('#title').val(),
+                                        title_en: $mainDialog.find('#title_en').val(),
+                                        expected_visitors: $mainDialog.find('#expected_visitors').val(),
+                                        meeting_place: $mainDialog.find('#id_meeting_place').val(),
+                                        meeting_place_en: $mainDialog.find('#id_meeting_place_en').val(),
+                                        display_text: $mainDialog.find('#id_display_text').val(),
+                                        audienceId: $mainDialog.find('#_backingAudienceId').val(),
+                                        arrangementTypeId: $mainDialog.find('#_backingArrangementTypeId').val(),
+                                        statusTypeId: $mainDialog.find('#_statusTypeId').val(),
+                                    },
+                                    "populateDialogWithEvent"
+                                )
 
                                 $simpleActivityDialog.find('#event_uuid').val(crypto.randomUUID());
                                 $mainDialog[0].querySelectorAll("input[name='display_layouts']:checked")

--- a/webook/static/modules/planner/form_populating_routines.js
+++ b/webook/static/modules/planner/form_populating_routines.js
@@ -372,6 +372,8 @@ export function PopulateCreateEventDialog(event, $dialogElement, dialogId) {
     let [fromDate, fromTime]    = parseDateOrStringToArtifacts(event.start);
     let [toDate, toTime]        = parseDateOrStringToArtifacts(event.end);
 
+    console.log("PopulateCreateEventDialog", event);
+
     [
         { target: "#event_uuid", value: event._uuid },
         { target: "#title", value: event.title },

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -622,13 +622,10 @@
                         {% endfor %}
                     ]);
 
-                    console.log("displayLayoutsWithRequisiteText", displayLayoutsWithRequisiteText)
-
                     let showDisplayText = false;
 
                     this.arrangement.display_layouts.forEach((displayLayout) => {
                         if (displayLayoutsWithRequisiteText.has(displayLayout)) {
-                            console.log("is trueeeee")
                             showDisplayText = true;
                         }
                     });

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -1,6 +1,9 @@
 {% load static i18n %}
 {% load crispy_forms_tags %}
 
+<!-- {% include "arrangement/vue/popover_component.html" %} -->
+{% include "arrangement/vue/js_tree_select_component.html" %}
+
 
 <div id="{{dialogId}}" class="{{discriminator}}" style="overflow-x: visible;">
     <input type="hidden" name="" id="_audienceId">
@@ -20,7 +23,7 @@
         <div id="step-1">
             <form id="arrangementInfoForm">
                 <input type="submit" style="display:none;" />
-
+                
                 <fieldset>
                     <div class="form-group mb-2">
                         <label>
@@ -61,55 +64,36 @@
                         </div>
                     {% endif %}
 
-                    <div class="mb-2">
-                        <label>
-                            <i class="fas fa-users"></i>&nbsp;
-                            Målgruppe
-                            <span class="fw-bold">&nbsp;*</span>
-                        </label>
-                        <div id="audience_jstree_select" class="dialog-popover-left-fix"></div>
 
-                        {% if form.audience.errors|length > 0 %}
-                        <div class="alert alert-danger">
-                            {{ form.audience.errors }}
-                        </div>
-                        {% endif %}
-                    </div>
+                    <tree-select-component
+                        class="mb-2"
+                        label="Målgruppe *"
+                        json-url="/arrangement/audience/tree"
+                        icon="fas fa-users"
+                        button-label="Velg målgruppe"
+                        :selected="arrangement.audience"
+                        @input="(id) => arrangement.audience = id">
+                    </tree-select-component>
 
-                    <div class="mb-2">
-                        <label>
-                            <i class="fas fa-cog"></i>&nbsp;
-                            Arrangementstype
-                            <span class="fw-bold">&nbsp;*</span>
-                        </label>
-                        <div id="arrangement_type_jstree_select" class="dialog-popover-left-fix"></div>
-                        {% if form.arrangement_type.errors|length > 0 %}
-                        <div class="alert alert-danger">
-                            {{ form.arrangement_type.errors }}
-                        </div>
-                        {% endif %}
-                    </div>
+                    <tree-select-component
+                        class="mb-2"
+                        label="Arrangementstype *"
+                        json-url="/arrangement/arrangementtype/treelist"
+                        icon="fas fa-users"
+                        button-label="Velg arrangementstype"
+                        :selected="arrangement.arrangement_type"
+                        @input="(id) => arrangement.arrangement_type = id">
+                    </tree-select-component>
 
-                    <div class="mb-2">
-                        <label>
-                            Status
-                        </label>
-
-                        <div id="status_type_jstree_select" class="dialog-popover-left-fix"></div>
-                        {% if form.status_type.errors|length > 0 %}
-                        <div class="alert alert-danger">
-                            {{ form.status_type.errors }}
-                        </div>
-                        {% endif %}
-
-                        {% comment %} {{ form.status }}
-
-                        {% if form.status.errors|length > 0 %}
-                        <div class="alert alert-danger">
-                            {{ form.status.errors }}
-                        </div>
-                        {% endif %} {% endcomment %}
-                    </div>
+                    <tree-select-component
+                        class="mb-2"
+                        label="Status"
+                        json-url="/arrangement/statustype/tree"
+                        icon="fas fa-cog"
+                        button-label="Velg status"
+                        :selected="arrangement.status"
+                        @input="(id) => arrangement.status = id">
+                    </tree-select-component>
 
                     <div class="mb-2">
                         <label>
@@ -173,7 +157,7 @@
                     <input type="hidden" 
                         name="{{ form.responsible.name }}" 
                         id="{{ form.responsible.id_for_label }}"
-                        v-model="mainPlanner.id">
+                        >
 
                     <label for="" class="d-block form-label">
                         <i class="fas fa-star"></i>
@@ -185,7 +169,7 @@
                         Vennligst velg en hovedplanlegger
                     </div>
 
-                    <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
+                    <!-- <h5 class="mb-2">[[ mainPlanner.text ]]</h5> -->
                     <button class="wb-btn-main"
                         id="setMainPlannerButton"
                         type="button">
@@ -594,7 +578,7 @@
 
     $(document).ready(function () {
         let createArrangementDialogApp = Vue.createApp({
-            components: {},
+            components: { TreeSelectComponent },
             data() {
                 return {
                     dialog: null,
@@ -618,6 +602,11 @@
             },
             computed: {},
             methods: {
+
+                updateArrangementType(payload) {
+                    this.arrangement.arrangement_type = payload.id;
+                },
+
                 /**
                  * @summary Open a dialog, with the option to send data to the dialog 
                  * @param {string} dialogName
@@ -760,70 +749,6 @@
                             select.element.addEventListener("change", (event) => {
                                 $(mdbSelect._wrapper).find(".invalid-feedback").hide();
                             });
-                        });
-            
-                        dialog.data.audienceJsTreeSelect = new JSTreeSelect({
-                            element: dialog.querySelector('#audience_jstree_select'),
-                            treeJsonSrcUrl: "/arrangement/audience/tree",
-                            onValueSet: ( data ) => {
-                                dialog.getElementById('_audienceId').value = data.selected[0];
-                            },
-                            valueSelectedLabelText: ( selected) => {
-                                let labelText = '';
-            
-                                if (selected.parent && selected.parent.text)
-                                    labelText += (selected.parent.text + " | ");
-            
-                                labelText += selected.text;
-            
-                                return labelText;
-                            },
-                            noneSelectedLabelText: "Ingen målgruppe valgt ennå",
-                            selectFirstTimeButtonText: 'Velg målgruppe',
-                            changeSelectedValueButtonText: 'Endre målgruppe',
-                            popoverSaveChoicesButtonText: 'Lagre valg',
-                        });
-                        dialog.data.arrangementTypeJsTreeSelect = new JSTreeSelect({
-                            element: dialog.querySelector('#arrangement_type_jstree_select'),
-                            treeJsonSrcUrl: "/arrangement/arrangementtype/treelist",
-                            onValueSet: ( data ) => {
-                                dialog.getElementById('_arrangementTypeId').value = data.selected[0];
-                            },
-                            valueSelectedLabelText: ( selected ) => {
-                                let labelText = '';
-            
-                                if (selected.parent && selected.parent.text)
-                                    labelText += (selected.parent.text + " | ");
-            
-                                labelText += selected.text;
-            
-                                return labelText;
-                            },
-                            noneSelectedLabelText: "Ingen arrangementstype valgt ennå",
-                            selectFirstTimeButtonText: 'Velg arrangementstype',
-                            changeSelectedValueButtonText: 'Endre arrangementstype',
-                            popoverSaveChoicesButtonText: 'Lagre valg',
-                        });
-                        dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
-                            element: dialog.querySelector('#status_type_jstree_select'),
-                            treeJsonSrcUrl: "/arrangement/statustype/tree",
-                            onValueSet: ( data ) => {
-                                dialog.getElementById('_statusTypeId').value = data.selected[0];
-                            },
-                            valueSelectedLabelText: ( selected ) => {
-                                let labelText = '';
-            
-                                if (selected.parent && selected.parent.text)
-                                    labelText += (selected.parent.text + " | ");
-            
-                                labelText += selected.text;
-                                
-                                return labelText;
-                            },
-                            noneSelectedLabelText: "Ingen status valgt ennå",
-                            selectFirstTimeButtonText: 'Velg status',
-                            changeSelectedValueButtonText: 'Endre status',
-                            popoverSaveChoicesButtonText: 'Lagre valg',
                         });
             
                         document.addEventListener("{{managerName}}.contextUpdated", (e) => {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -33,6 +33,7 @@
                             value="{{ form.name.value|default:'' }}"
                             name="{{ form.name.name }}"
                             autocomplete="off"
+                            v-model="arrangement.title"
                             required />
                     </div>
                     {% if form.name.errors|length > 0 %}
@@ -50,6 +51,7 @@
                             id="{{ form.name_en.id_for_label }}"
                             value="{{ form.name_en.value|default:'' }}"
                             name="{{ form.name_en.name }}"
+                            v-model="arrangement.title_english"
                             autocomplete="off"
                             />
                     </div>
@@ -596,15 +598,22 @@
             data() {
                 return {
                     dialog: null,
-                    events: [],
-                    series: [],
-                    serviceOrders: [],
-                    rooms: [],
-                    planners: [],
-                    mainPlanner: { id: null, text: null },
                     mainPlannerSearchTerm: null,
                     mainPlannerSearchResults: [],
-                    mainPlannerPopover: null
+                    mainPlannerPopover: null,
+                    arrangement: {
+                        title: null,
+                        title_english: null,
+                        audience: null,         // TODO: implement component
+                        arrangement_type: null, // TODO: implement component
+                        status: null,           // TODO: implement component
+                        events: [],                
+                        series: [],
+                        rooms: [],
+                        serviceOrders: [],
+                        planners: [],
+                        mainPlanner: { id: null, text: null },
+                    },
                 }
             },
             computed: {},
@@ -723,8 +732,7 @@
                             triggerElement: dialog.dialogElement.querySelector('#setMainPlannerButton'),
                             wrapperElement: dialog.dialogElement.querySelector('#select-main-planner-popover'),
                         });
-                        dialog.vueApp.mainPlannerPopover = mainPlannerPopover;
-        
+                        dialog.vueApp.mainPlannerPopover = mainPlannerPopover;        
 
                         [
                             {
@@ -821,12 +829,12 @@
                         document.addEventListener("{{managerName}}.contextUpdated", (e) => {
                             if (e.detail.context.series !== undefined) {
                                 const series = e.detail.context.series;
-                                dialog.vueApp.series = Array.from(series.values());
+                                dialog.vueApp.arrangement.series = Array.from(series.values());
                                 dialog.data.seriesMap = series;
                             }
                             if (e.detail.context.events !== undefined) {
                                 const events = e.detail.context.events;
-                                dialog.vueApp.events = Array.from(events.values());
+                                dialog.vueApp.arrangement.events = Array.from(events.values());
                                 dialog.data.eventsMap = events;
                             }
                         });
@@ -839,8 +847,6 @@
                                 title: 'Generelt',
                                 stepIn: () => {},
                                 stepOut: () => {
-                                    debugger;
-            
                                     let field_elements = dialog.$('#step-1').find("input, select");
                                     [
                                         mdb.Select.getInstance(dialog.querySelector('#{{ form.location.id_for_label }}')),
@@ -1033,7 +1039,6 @@
                                     denyButtonText: "Opprett kollisjoner uten rom",
                                     confirmButtonText: 'Ignorer kolliderende aktiviteter'
                                 }).then((result) => {
-                                    console.log("SWAL RESULT", result)
                                     if (result.isConfirmed === true) {
                                         save(0); // 0 designates behaviour ignore colliding activities (dont create them)
                                     }
@@ -1086,28 +1091,28 @@
                         },
                     },
                     when: [
-                    { eventKnownAs: "newServiceOrder", do: (dialog, payload) => {
-                        // this stuff needs to be rewritten along with the other similar methods
-                        // maybe use vue or a dialog plugin -- because this is not even a remotely good way of doing it
-            
-                        dialog.data.servicePresets = new Map((payload.concat(
-                            Array.from(dialog.data.servicePresets.values())
-                        )).map(x => [crypto.randomUUID(), x]));
+                        { eventKnownAs: "newServiceOrder", do: (dialog, payload) => {
+                            // this stuff needs to be rewritten along with the other similar methods
+                            // maybe use vue or a dialog plugin -- because this is not even a remotely good way of doing it
+                
+                            dialog.data.servicePresets = new Map((payload.concat(
+                                Array.from(dialog.data.servicePresets.values())
+                            )).map(x => [crypto.randomUUID(), x]));
 
-                        dialog.vueApp.serviceOrders = 
-                            Array.from(dialog.data.servicePresets.entries())
-                            .map(x => { return { key: x[0], ...x[1] } });
+                            dialog.vueApp.arrangement.serviceOrders = 
+                                Array.from(dialog.data.servicePresets.entries())
+                                .map(x => { return { key: x[0], ...x[1] } });
 
-                    } },
-                    { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
-                            dialog.data.selectedRoomIds = new Map();
-                            dialog.data.roomPresets = new Map();
-                            payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );
-                            payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
-            
-                            dialog.data.roomPayload = payload;
+                        } },
+                        { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
+                                dialog.data.selectedRoomIds = new Map();
+                                dialog.data.roomPresets = new Map();
+                                payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );
+                                payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
+                
+                                dialog.data.roomPayload = payload;
 
-                            dialog.vueApp.rooms = payload.viewables;
+                                dialog.vueApp.arrangement.rooms = payload.viewables;
                         } },
                         { eventKnownAs: "plannersSelected", do: (dialog, payload) => {
                             dialog.data.selectedPlannerIds = new Map();
@@ -1116,9 +1121,8 @@
                             payload.selectedPresets.forEach( (presetId) => dialog.data.plannerPresets.set(presetId, payload.allPresets.get(presetId)));
             
                             dialog.data.plannerPayload = payload;
-                            console.log(dialog.data.plannerPayload);
 
-                            dialog.vueApp.planners = payload.viewables;
+                            dialog.vueApp.arrangement.planners = payload.viewables;
                         } },
                         { eventKnownAs: "setPlanner", do: (dialog, payload) => {
                             if (payload.allSelectedEntityIds.length == 0)
@@ -1130,7 +1134,7 @@
                             dialog.data.mainPlannerPayload = payload;
                             const person = payload.viewables[0];
                             
-                            dialog.vueApp.mainPlanner = { id: person.id, text: person.text }
+                            dialog.vueApp.arrangement.mainPlanner = { id: person.id, text: person.text }
 
                             dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
                             dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -1128,9 +1128,6 @@
             
                             // save the payload so that it can be re-used / re-applied to child activities / series
                             dialog.data.mainPlannerPayload = payload;
-
-                            console.log("SET PLANNER", payload)
-            
                             const person = payload.viewables[0];
                             
                             dialog.vueApp.mainPlanner = { id: person.id, text: person.text }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -19,568 +19,547 @@
 
     <hr>
 
-
-    <div class="row">
-        <div class="col-9">
-            <div>
-                <div id="step-1">
-                    <form id="arrangementInfoForm">
-                        <input type="submit" style="display:none;" />
-                        
-                        <fieldset>
-                            <div class="form-group mb-2">
-                                <label>
-                                    Tittel <i>(Norsk)</i>
-                                    <span class="fw-bold">&nbsp;*</span>
-                                </label>
-                                <input type="text"
-                                    class="form-control form-control-lg mb-2"
-                                    id="{{ form.name.id_for_label }}"
-                                    value="{{ form.name.value|default:'' }}"
-                                    name="{{ form.name.name }}"
-                                    autocomplete="off"
-                                    v-model="arrangement.title"
-                                    required />
-                            </div>
-                            {% if form.name.errors|length > 0 %}
-                                <div class="alert alert-danger">
-                                    {{ form.name.errors }}
-                                </div>
-                            {% endif %}
-        
-                            <div class="form-group mb-2">
-                                <label>
-                                    Tittel <i>(Engelsk)</i>
-                                </label>
-                                <input type="text"
-                                    class="form-control form-control-lg"
-                                    id="{{ form.name_en.id_for_label }}"
-                                    value="{{ form.name_en.value|default:'' }}"
-                                    name="{{ form.name_en.name }}"
-                                    v-model="arrangement.title_english"
-                                    autocomplete="off"
-                                    />
-                            </div>
-                            {% if form.name_en.errors|length > 0 %}
-                                <div class="alert alert-danger">
-                                    {{ form.name_en.errors }}
-                                </div>
-                            {% endif %}
-        
-        
-                            <tree-select-component
-                                class="mb-2"
-                                label="Målgruppe *"
-                                json-url="/arrangement/audience/tree"
-                                icon="fas fa-users"
-                                button-label="Velg målgruppe"
-                                :selected="arrangement.audience"
-                                @input="(id) => arrangement.audience = id">
-                            </tree-select-component>
-        
-                            <tree-select-component
-                                class="mb-2"
-                                label="Arrangementstype *"
-                                json-url="/arrangement/arrangementtype/treelist"
-                                icon="fas fa-cog"
-                                button-label="Velg arrangementstype"
-                                :selected="arrangement.arrangement_type"
-                                @input="(id) => arrangement.arrangement_type = id">
-                            </tree-select-component>
-        
-                            <tree-select-component
-                                class="mb-2"
-                                label="Status"
-                                json-url="/arrangement/statustype/tree"
-                                icon="fas fa-cog"
-                                button-label="Velg status"
-                                :selected="arrangement.status"
-                                @input="(id) => arrangement.status = id">
-                            </tree-select-component>
-        
-                            <div class="mb-2">
-                                <label>
-                                    <i class="fas fa-map-marker-alt"></i>&nbsp;
-                                    Lokasjon
-                                    <span class="fw-bold">&nbsp;*</span>
-                                </label>
-                                {{ form.location }}
-                            </div>
-                            {% if form.location.errors|length > 0 %}
-                                <div class="alert alert-danger">
-                                    {{ form.location.errors }}
-                                </div>
-                            {% endif %}
-                        </fieldset>
-                    </form>
-                </div>
-                <div id="step-services">
-                    <div class="clearfix">
-                        <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
-                            style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                            @click="openAddServiceOrderDialog()">
-                            <i class="fas fa-calendar-plus"></i>&nbsp;
-                            Bestill tjenester
-                        </a>
-                    </div>
-        
-                    <div class="alert alert-info mt-2">
-                        Du kan bestille forskjellige tjenester for dette arrangementet. Om du bestiller for arrangementet
-                        vil bestillingen gjelde alle tidspunkter for arrangementet. Du kan velge å også bare bestille for en
-                        gitt tidspunkt eller serie av tidspunkt.
-                    </div>
-        
-                    <div id="serviceOrders">
-                        <div
-                            class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' :id="order.key"
-                            v-for="order in arrangement.serviceOrders">
-                            
-                            <h5>
-                                [[order.service_name]]
-                                <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end' 
-                                    :id="order.key" 
-                                    @click="serviceOrders.splice(serviceOrders.indexOf(order), 1)"
-                                    select-type='serviceOrder' 
-                                    d-trigger="removeAssociation">
-                                    
-                                    <i class='fas fa-times'></i>
-                                </button>
-                            </h5>
-                            <code>
-                                [[order.freetext_comment]]
-                            </code>
-                        </div>
-                    </div>
-                </div>
-                <div id="step-2">
-                    <form id="arrangementDetailsForm">
-                        <input type="submit" value="" style="display: none;">
-        
-                        <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
-                            <input type="hidden" 
-                                name="{{ form.responsible.name }}" 
-                                id="{{ form.responsible.id_for_label }}">
-        
-                            <label for="" class="d-block form-label">
-                                <i class="fas fa-star"></i>
-                                Hovedplanlegger
-                            </label>
-        
-                            <div class="text-danger" style="display: none;"
-                                id="mainPlanner_validationText">
-                                Vennligst velg en hovedplanlegger
-                            </div>
-                            
-                            <div>
-                                [[ arrangement.mainPlanner.text ]]
-                            </div>
-        
-                            <button class="wb-btn-main"
-                                id="setMainPlannerButton"
-                                type="button">
-                                Velg hovedplanlegger
-                            </button>
-        
-                            <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
-                                <div class="popover_content" style="width: 50em!important;">
-                                    <h5>Velg hovedplanlegger</h5>
-                                    
-                                    <input type="search" name="" id="" class="form-control form-control-lg"
-                                        v-model="mainPlannerSearchTerm"
-                                        placeholder="Søk etter planlegger... (minst 3 tegn)">       
-        
-                                    <div class="mt-3">
-                                        <div v-if="mainPlannerSearchResults.length">
-                                            <div v-if="mainPlannerSearchTerm.length == 0"
-                                                class="alert alert-info">
-                                                <div class="d-flex align-items-center">
-                                                    <h2 class="mb-0"><i class="fas fa-info"></i></h2>
-                                                    
-                                                    <div class="ms-3">
-                                                        Uten søkeord vises alle personer med gruppe planlegger
-                                                        <br>
-                                                        Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
-                                                    </div>
-                                                </div>
-                                            </div>
-        
-                                            <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
-                                                <tbody>
-                                                    <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
-                                                        <td>
-                                                            <a>
-                                                                [[ result.full_name ]]
-                                                            </a>
-                                                        </td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                            
-                                            <div class="clearfix">
-                                                <small class="text-muted float-end fw-bold">
-                                                    <i class="fas fa-info"></i>&nbsp;
-                                                    Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
-                                                </small>
-                                            </div>
-                                        </div>
-                                        <div 
-                                            class="alert alert-info"
-                                            v-else>
-                                            Ingen resultater
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-        
-                        <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
-                            <label for="" class="form-label">
-                                <i class="fas fa-building"></i>&nbsp;
-                                Rom
-                            </label>
-                            <div>
-                                <button class="wb-btn-main"
-                                    type="button"
-                                    @click="openAddRoomsDialog()">
-                                    Velg rom
-                                </button>
-                            </div>
-                            <div id="roomChips" class="chipsList">
-                                <span v-for="room in arrangement.rooms">
-                                    <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
-                                        [[room.text]]
-                                        
-                                        <a href="#">
-                                            <i class="fa fa-times text-danger"
-                                                :id="room.id"
-                                                select-type="room"
-                                                @click="rooms.splice(rooms.indexOf(room), 1)"
-                                                d-trigger="removeAssociation">
-        
-                                            </i>
-                                        </a>
-                                    </div>
-                                </span>
-                            </div>
-                        </div>
-        
-                        <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
-                            <label for="" class="form-label">
-                                <i class="fas fa-users-cog"></i>&nbsp;
-                                Planleggere
-                            </label>
-                            <div>
-                                <button class="wb-btn-main"
-                                    type="button"
-                                    @click="openAddPlannersDialog()">
-                                    Velg planleggere
-                                </button>
-                            </div>
-                            <div id="plannerChips" class="chipsList">
-                                <span v-for="planner in arrangement.planners">
-                                    <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
-                                        [[planner.text]]
-                                        
-                                        <a href="#">
-                                            <i class="fa fa-times text-danger"
-                                                :id="planner.id"
-                                                select-type="person"
-                                                @click="planners.splice(planners.indexOf(room), 1)"
-                                                d-trigger="removeAssociation">
-        
-                                            </i>
-                                        </a>
-                                    </div>
-                                </span>
-                            </div>
-                        </div>
-        
-                        <div class="mb-2 mt-4 form-group">
-                            <label>
-                                <i class="fas fa-receipt"></i>&nbsp;
-                                Billetkode
-                            </label>
-                            <input type="text"
-                                class="form-control form-control-lg"
-                                id="{{ form.ticket_code.id_for_label }}"
-                                value="{{ form.ticket_code.value|default:'' }}"
-                                name="{{ form.ticket_code.name }}"
-                                placeholder="Billetkode..."
-                                v-model="arrangement.ticket_code"/>
-                        </div>
-                        {% if form.ticket_code.errors|length > 0 %}
-                            <div class="alert alert-danger">
-                                {{ form.ticket_code.errors }}
-                            </div>
-                        {% endif %}
-        
-                        <div class="mb-2 form-group">
-                            <label>
-                                Forventet besøkende
-                            </label>
-                            <input type="number"
-                                min="0"
-                                class="form-control form-control-lg"
-                                id="{{ form.expected_visitors.id_for_label }}"
-                                value="{{ form.expected_visitors.value|default:'0' }}"
-                                name="{{ form.expected_visitors.name }}"
-                                v-model="arrangement.expected_visitors"
-                                required />
-                        </div>
-                        {% if form.expected_visitors.errors|length > 0 %}
-                            <div class="alert alert-danger">
-                                {{ form.expected_visitors.errors }}
-                            </div>
-                        {% endif %}
-                    </form>
-                </div>
-                <div id="step-3">
-                    <div class="row">
-                        <div class="col-lg-4 col-sm-12">
-                            <h5 class="header-fonted">
-                                <i class="fas fa-tv"></i>
-                                Skjerm
-                            </h5>
-                            <label class="d-block">&nbsp; {% trans "Vises på skjerm:" %}</label>
-                            {{form.display_layouts}}
-                        </div>
-        
-                        <div class="col-lg-8 col-sm-12 mt-sm-2">
-                            <div
-                                class="form-group"
-                                id="display-layout-text-group">
-        
-                                <div v-show="showDisplayText">
-                                    <input type="text" name="{{form.display_text.name}}"
-                                        class="form-control form-control-lg"
-                                        id="{{form.display_text.id_for_label}}"
-                                        v-model="arrangement.display_text"
-                                        placeholder="Skjermtekst...">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+    <div>
+        <div id="step-1">
+            <form id="arrangementInfoForm">
+                <input type="submit" style="display:none;" />
                 
-                    <div class="mt-2 form-group">
+                <fieldset>
+                    <div class="form-group mb-2">
                         <label>
-                            <i class="fas fa-door-open"></i>&nbsp;
-                            Møtested <i>(Norsk)</i>
+                            Tittel <i>(Norsk)</i>
+                            <span class="fw-bold">&nbsp;*</span>
+                        </label>
+                        <input type="text"
+                            class="form-control form-control-lg mb-2"
+                            id="{{ form.name.id_for_label }}"
+                            value="{{ form.name.value|default:'' }}"
+                            name="{{ form.name.name }}"
+                            autocomplete="off"
+                            v-model="arrangement.title"
+                            required />
+                    </div>
+                    {% if form.name.errors|length > 0 %}
+                        <div class="alert alert-danger">
+                            {{ form.name.errors }}
+                        </div>
+                    {% endif %}
+
+                    <div class="form-group mb-2">
+                        <label>
+                            Tittel <i>(Engelsk)</i>
                         </label>
                         <input type="text"
                             class="form-control form-control-lg"
-                            id="{{ form.meeting_place.id_for_label }}"
-                            value="{{ form.meeting_place.value|default:'' }}"
-                            name="{{ form.meeting_place.name }}"
-                            placeholder="{% trans 'Møtested' %}..."
-                            v-model="arrangement.meeting_place"/>
-                        <div class="form-helper text-end">
-                            <i class="fas fa-info-circle"></i>&nbsp;
-                            Vil overskrive sted/rom vist på skjerm
-                        </div>
+                            id="{{ form.name_en.id_for_label }}"
+                            value="{{ form.name_en.value|default:'' }}"
+                            name="{{ form.name_en.name }}"
+                            v-model="arrangement.title_english"
+                            autocomplete="off"
+                            />
                     </div>
-                    {% if form.meeting_place.errors|length > 0 %}
+                    {% if form.name_en.errors|length > 0 %}
                         <div class="alert alert-danger">
-                            {{ form.meeting_place.errors }}
+                            {{ form.name_en.errors }}
                         </div>
                     {% endif %}
-        
-                    <div class="mt-2 form-group">
+
+
+                    <tree-select-component
+                        class="mb-2"
+                        label="Målgruppe *"
+                        json-url="/arrangement/audience/tree"
+                        icon="fas fa-users"
+                        button-label="Velg målgruppe"
+                        :selected="arrangement.audience"
+                        @input="(id) => arrangement.audience = id">
+                    </tree-select-component>
+
+                    <tree-select-component
+                        class="mb-2"
+                        label="Arrangementstype *"
+                        json-url="/arrangement/arrangementtype/treelist"
+                        icon="fas fa-cog"
+                        button-label="Velg arrangementstype"
+                        :selected="arrangement.arrangement_type"
+                        @input="(id) => arrangement.arrangement_type = id">
+                    </tree-select-component>
+
+                    <tree-select-component
+                        class="mb-2"
+                        label="Status"
+                        json-url="/arrangement/statustype/tree"
+                        icon="fas fa-cog"
+                        button-label="Velg status"
+                        :selected="arrangement.status"
+                        @input="(id) => arrangement.status = id">
+                    </tree-select-component>
+
+                    <div class="mb-2">
                         <label>
-                            <i class="fas fa-door-open"></i>&nbsp;
-                            Møtested <i>(Engelsk)</i>
+                            <i class="fas fa-map-marker-alt"></i>&nbsp;
+                            Lokasjon
+                            <span class="fw-bold">&nbsp;*</span>
                         </label>
-                        <input type="text"
-                            class="form-control form-control-lg"
-                            id="{{ form.meeting_place_en.id_for_label }}"
-                            value="{{ form.meeting_place_en.value|default:'' }}"
-                            name="{{ form.meeting_place_en.name }}"
-                            placeholder="{% trans 'Møtested' %}..."
-                            v-model="arrangement.meeting_place_en"/>
-                        <div class="form-helper text-end">
-                            <i class="fas fa-info-circle"></i>&nbsp;
-                            Vil overskrive sted/rom vist på skjerm
-                        </div>
+                        {{ form.location }}
                     </div>
-                    {% if form.meeting_place.errors|length > 0 %}
+                    {% if form.location.errors|length > 0 %}
                         <div class="alert alert-danger">
-                            {{ form.meeting_place.errors }}
+                            {{ form.location.errors }}
                         </div>
                     {% endif %}
-                </div>
-                <div id="step-4">
-                    <div class="row">
-                        <div class="col-6">
-                            <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
-                                style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                                @click="openPlanSerieDialog()">
-                                <i class="fas fa-calendar-plus"></i>&nbsp;
-                                Ny gjentagende aktivitet
-                            </a>
-                        </div>
-                        <div class="col-6">
-                            <a class="btn btn-lg btn-outline-dark shadow-0 btn-block mb-2 p-2"
-                                style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                                @click="openPlanActivityDialog()">
-                                <i class="fas fa-calendar-plus"></i>&nbsp;
-                                Ny enkel aktivitet
-                            </a>
-                        </div>
-                    </div>
-        
-                    <hr class="mt-0">
-        
-                    <div id="eventsBody">
-                        <div class="border border-2 rounded-2 p-3" id='[[element._uuid]]' style="background-color: #f6f6f0;"
-                            v-for="event in events">
+                </fieldset>
+            </form>
+        </div>
+        <div id="step-services">
+            <div class="clearfix">
+                <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
+                    style="text-transform: none; font-size: larger; border-width: 0.7px;"
+                    @click="openAddServiceOrderDialog()">
+                    <i class="fas fa-calendar-plus"></i>&nbsp;
+                    Bestill tjenester
+                </a>
+            </div>
+
+            <div class="alert alert-info mt-2">
+                Du kan bestille forskjellige tjenester for dette arrangementet. Om du bestiller for arrangementet
+                vil bestillingen gjelde alle tidspunkter for arrangementet. Du kan velge å også bare bestille for en
+                gitt tidspunkt eller serie av tidspunkt.
+            </div>
+
+            <div id="serviceOrders">
+                <div
+                    class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' :id="order.key"
+                    v-for="order in arrangement.serviceOrders">
+                    
+                    <h5>
+                        [[order.service_name]]
+                        <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end' 
+                            :id="order.key" 
+                            @click="serviceOrders.splice(serviceOrders.indexOf(order), 1)"
+                            select-type='serviceOrder' 
+                            d-trigger="removeAssociation">
                             
-                            <div class="d-flex justify-content-between align-items-center">
-                                <h3>
-                                    <i class="fas fa-calendar"></i>&nbsp;
-                                    [[event.title]]
-                                </h3>
-            
-                                <h5>
-                                    [[event.start.toLocaleString()]] - [[event.end.toLocaleString()]]
-                                </h5>    
-                            </div>
-                            
-                            <div>
-                                <span class="fw-bolder">Målgruppe:</span> [[event.audienceName]]
-                            </div>
-                            <div>
-                                <span class="fw-bolder">Arrangement Type:</span> [[event.arrangementTypeName]]
-                            </div>
-        
-                            <div class="mt-2">
-                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 "
-                                    data-toggle='tooltip' title='{% trans "Edit this activity" %}'
-                                    @click="openDialog('newSimpleActivityDialog', { event_uuid: event._uuid})">
-                                    <i class="fas fa-edit"></i>&nbsp;
-                                    Rediger
-                                </a>
-                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
-                                    data-toggle='tooltip' title='{% trans "Remove this activity from the arrangement" %}'
-                                    @click="events.splice(events.indexOf(event), 1); dialog.data.eventsMap.delete(event._uuid);">
-                                    <i class="fas fa-trash"></i>&nbsp;
-                                    Slett
-                                </a>
-                            </div>
-                        </div>
-        
-                    </div>
-                    <div id="timeplansBody">
-        
-                        <div class="rounded-2 border border-2 p-3 ps-4 pe-4" 
-                            :id='serie._uuid' 
-                            style="background-color: #f6f6f0;"
-                            v-for="serie in series">
-                            <h3 class="mb-0">
-                                <i class="fas fa-sync"></i>&nbsp;
-                                [[serie.time.title]]
-                            </h5>
-                            <h5 class="mb-0"><i class="fas fa-clock"></i> [[serie.time.start]] - [[serie.time.end]] </h6>
-                            <h6>[[serie.friendlyDesc]] </h6>
-        
-                            <div class="mb-2">
-                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0"
-                                    data-toggle='tooltip' title='{% trans "Edit this recurring activity" %}'
-                                    @click="openDialog('newTimePlanDialog', { serie_uuid: serie._uuid })">
-                                    <i class="fas fa-edit"></i>&nbsp;
-                                    Rediger tidsplan
-                                </a>
-        
-                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
-                                    data-toggle='tooltip' title='{% trans "Remove this recurring activity from the arrangement to be" %}'
-                                    @click="series.splice(series.indexOf(serie), 1); dialog.data.seriesMap.delete(serie._uuid);">
-                                    <i class="fas fa-trash"></i>&nbsp;
-                                    Slett
-                                </a>
-                            </div>
-        
-                            <div class="accordion" id="accordion_series_[[serie._uuid]]" v-if="serie.collisions.length">
-                                <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingOne">
-                                    <a
-                                    class="accordion-button text-muted collapsed"
-                                    type="button"
-                                    data-mdb-toggle="collapse"
-                                    data-mdb-target="#collisionsCollapse_[[serie._uuid]]"
-                                    aria-expanded="true"
-                                    aria-controls="collisionsCollapse_[[serie._uuid]]"
-                                    >
-                                    <span class="bg-danger rounded-pill text-white p-1 collisions-counter" id='[[serie._uuid]]_collisionCounter'>[[serie.collisions.length]]</span>
-                                    <i class="fas fa-exclamation-triangle ms-2"></i>&nbsp; Kollisjoner
-                                </a>
-                                </h2>
-                                <div id="collisionsCollapse_[[serie._uuid]]" class="accordion-collapse collapse" aria-labelledby="headingOne" data-mdb-parent="#accordion_series_[[serie._uuid]]">
-                                    <div class="accordion-body" style="max-height: 35em; overflow: scroll;">
-                                        <div class="alert alert-danger small">
-                                            <strong>OBS: </strong> kollisjoner som ikke blir <abbr title="Bryt ut kollisjoner til enkle aktiviteter og løs kollisjonen">brutt ut</abbr> og løst vil ikke bli opprettet
-                                            når arrangementet opprettes.
-                                        </div>
-                                        
-                                        <div
-                                            v-for="collisionRecord in serie.collisions">
-        
-                                                <div class="bg-dark border p-2 border-2 border-warning text-white p-3 shadow-3 conflict_summary_${collisionsCounter}"
-                                                    style='background-color: #f6f6f0'>
-                                                    <h5><i class="fas fa-exclamation-triangle"></i>&nbsp; Konflikt på [[collisionRecord.contested_resource_name]]</h5>
-                                                    <div class="row">
-                                                        <div class="col-5">
-                                                            <div>
-                                                                <div class="fw-bolder">[[collisionRecord.event_a_title]]</div>
-                                                                <h6>[[collisionRecord.event_a_start]] - [[collisionRecord.event_a_end]]</h6>
-                                                            </div>
-                                                        </div>
-                                                        <div class="col-2">
-                                                            <h3 class=" text-center"><i class="fas fa-arrow-right"></i></h3>
-                                                        </div>
-                                                        <div class="col-5">
-                                                            <div>
-                                                                <div class="fw-bolder">[[collisionRecord.event_b_title]]</div>
-                                                                <h6>[[collisionRecord.event_b_start]] - [[collisionRecord.event_b_end]]</h6>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                    <div class="clearfix">
-                                                        <a href="#" class="btn wb-btn-secondary shadow-0"
-                                                            d-trigger="breakOutEvent" d-arg-serie_uuid="[[serie._uuid]]" d-arg-collision_index="[[serie.collisions.length]]"><i class='fas fa-code-branch'></i>&nbsp; Løs konflikt
-                                                        </a>
-                                                    </div>
-                                                    <div v-if="collisionRecord.is_rigging">
-                                                        <br>
-        
-                                                        <i class="fas fa-hammer"></i>&nbsp;Rigghendelse
-                                                    </div>
-                                                </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                </div>
-                            </div>
-                        </div>
-        
-                    </div>
+                            <i class='fas fa-times'></i>
+                        </button>
+                    </h5>
+                    <code>
+                        [[order.freetext_comment]]
+                    </code>
                 </div>
             </div>
         </div>
-        <div class="col-3">
-            <div class="wb-bg-secondary p-2">
+        <div id="step-2">
+            <form id="arrangementDetailsForm">
+                <input type="submit" value="" style="display: none;">
 
-                <table class="table table-striped">
-                    <tbody>
-                        <tr v-for="prop in Object.entries(arrangement)">
-                            <th>[[prop]]</th>
-                            <td>[[ arrangement[prop] ]]</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                    <input type="hidden" 
+                        name="{{ form.responsible.name }}" 
+                        id="{{ form.responsible.id_for_label }}">
+
+                    <label for="" class="d-block form-label">
+                        <i class="fas fa-star"></i>
+                        Hovedplanlegger
+                    </label>
+
+                    <div class="text-danger" style="display: none;"
+                        id="mainPlanner_validationText">
+                        Vennligst velg en hovedplanlegger
+                    </div>
+                    
+                    <div>
+                        [[ arrangement.mainPlanner.text ]]
+                    </div>
+
+                    <button class="wb-btn-main"
+                        id="setMainPlannerButton"
+                        type="button">
+                        Velg hovedplanlegger
+                    </button>
+
+                    <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
+                        <div class="popover_content" style="width: 50em!important;">
+                            <h5>Velg hovedplanlegger</h5>
+                            
+                            <input type="search" name="" id="" class="form-control form-control-lg"
+                                v-model="mainPlannerSearchTerm"
+                                placeholder="Søk etter planlegger... (minst 3 tegn)">       
+
+                            <div class="mt-3">
+                                <div v-if="mainPlannerSearchResults.length">
+                                    <div v-if="mainPlannerSearchTerm.length == 0"
+                                        class="alert alert-info">
+                                        <div class="d-flex align-items-center">
+                                            <h2 class="mb-0"><i class="fas fa-info"></i></h2>
+                                            
+                                            <div class="ms-3">
+                                                Uten søkeord vises alle personer med gruppe planlegger
+                                                <br>
+                                                Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
+                                        <tbody>
+                                            <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
+                                                <td>
+                                                    <a>
+                                                        [[ result.full_name ]]
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    
+                                    <div class="clearfix">
+                                        <small class="text-muted float-end fw-bold">
+                                            <i class="fas fa-info"></i>&nbsp;
+                                            Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
+                                        </small>
+                                    </div>
+                                </div>
+                                <div 
+                                    class="alert alert-info"
+                                    v-else>
+                                    Ingen resultater
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
+                    <label for="" class="form-label">
+                        <i class="fas fa-building"></i>&nbsp;
+                        Rom
+                    </label>
+                    <div>
+                        <button class="wb-btn-main"
+                            type="button"
+                            @click="openAddRoomsDialog()">
+                            Velg rom
+                        </button>
+                    </div>
+                    <div id="roomChips" class="chipsList">
+                        <span v-for="room in arrangement.rooms">
+                            <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
+                                [[room.text]]
+                                
+                                <a href="#">
+                                    <i class="fa fa-times text-danger"
+                                        :id="room.id"
+                                        select-type="room"
+                                        @click="rooms.splice(rooms.indexOf(room), 1)"
+                                        d-trigger="removeAssociation">
+
+                                    </i>
+                                </a>
+                            </div>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
+                    <label for="" class="form-label">
+                        <i class="fas fa-users-cog"></i>&nbsp;
+                        Planleggere
+                    </label>
+                    <div>
+                        <button class="wb-btn-main"
+                            type="button"
+                            @click="openAddPlannersDialog()">
+                            Velg planleggere
+                        </button>
+                    </div>
+                    <div id="plannerChips" class="chipsList">
+                        <span v-for="planner in arrangement.planners">
+                            <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
+                                [[planner.text]]
+                                
+                                <a href="#">
+                                    <i class="fa fa-times text-danger"
+                                        :id="planner.id"
+                                        select-type="person"
+                                        @click="planners.splice(planners.indexOf(room), 1)"
+                                        d-trigger="removeAssociation">
+
+                                    </i>
+                                </a>
+                            </div>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="mb-2 mt-4 form-group">
+                    <label>
+                        <i class="fas fa-receipt"></i>&nbsp;
+                        Billetkode
+                    </label>
+                    <input type="text"
+                        class="form-control form-control-lg"
+                        id="{{ form.ticket_code.id_for_label }}"
+                        value="{{ form.ticket_code.value|default:'' }}"
+                        name="{{ form.ticket_code.name }}"
+                        placeholder="Billetkode..."
+                        v-model="arrangement.ticket_code"/>
+                </div>
+                {% if form.ticket_code.errors|length > 0 %}
+                    <div class="alert alert-danger">
+                        {{ form.ticket_code.errors }}
+                    </div>
+                {% endif %}
+
+                <div class="mb-2 form-group">
+                    <label>
+                        Forventet besøkende
+                    </label>
+                    <input type="number"
+                        min="0"
+                        class="form-control form-control-lg"
+                        id="{{ form.expected_visitors.id_for_label }}"
+                        value="{{ form.expected_visitors.value|default:'0' }}"
+                        name="{{ form.expected_visitors.name }}"
+                        v-model="arrangement.expected_visitors"
+                        required />
+                </div>
+                {% if form.expected_visitors.errors|length > 0 %}
+                    <div class="alert alert-danger">
+                        {{ form.expected_visitors.errors }}
+                    </div>
+                {% endif %}
+            </form>
+        </div>
+        <div id="step-3">
+            <div class="row">
+                <div class="col-lg-4 col-sm-12">
+                    <h5 class="header-fonted">
+                        <i class="fas fa-tv"></i>
+                        Skjerm
+                    </h5>
+                    <label class="d-block">&nbsp; {% trans "Vises på skjerm:" %}</label>
+                    {{form.display_layouts}}
+                </div>
+
+                <div class="col-lg-8 col-sm-12 mt-sm-2">
+                    <div
+                        class="form-group"
+                        id="display-layout-text-group">
+
+                        <div v-show="showDisplayText">
+                            <input type="text" name="{{form.display_text.name}}"
+                                class="form-control form-control-lg"
+                                id="{{form.display_text.id_for_label}}"
+                                v-model="arrangement.display_text"
+                                placeholder="Skjermtekst...">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        
+            <div class="mt-2 form-group">
+                <label>
+                    <i class="fas fa-door-open"></i>&nbsp;
+                    Møtested <i>(Norsk)</i>
+                </label>
+                <input type="text"
+                    class="form-control form-control-lg"
+                    id="{{ form.meeting_place.id_for_label }}"
+                    value="{{ form.meeting_place.value|default:'' }}"
+                    name="{{ form.meeting_place.name }}"
+                    placeholder="{% trans 'Møtested' %}..."
+                    v-model="arrangement.meeting_place"/>
+                <div class="form-helper text-end">
+                    <i class="fas fa-info-circle"></i>&nbsp;
+                    Vil overskrive sted/rom vist på skjerm
+                </div>
+            </div>
+            {% if form.meeting_place.errors|length > 0 %}
+                <div class="alert alert-danger">
+                    {{ form.meeting_place.errors }}
+                </div>
+            {% endif %}
+
+            <div class="mt-2 form-group">
+                <label>
+                    <i class="fas fa-door-open"></i>&nbsp;
+                    Møtested <i>(Engelsk)</i>
+                </label>
+                <input type="text"
+                    class="form-control form-control-lg"
+                    id="{{ form.meeting_place_en.id_for_label }}"
+                    value="{{ form.meeting_place_en.value|default:'' }}"
+                    name="{{ form.meeting_place_en.name }}"
+                    placeholder="{% trans 'Møtested' %}..."
+                    v-model="arrangement.meeting_place_en"/>
+                <div class="form-helper text-end">
+                    <i class="fas fa-info-circle"></i>&nbsp;
+                    Vil overskrive sted/rom vist på skjerm
+                </div>
+            </div>
+            {% if form.meeting_place.errors|length > 0 %}
+                <div class="alert alert-danger">
+                    {{ form.meeting_place.errors }}
+                </div>
+            {% endif %}
+        </div>
+        <div id="step-4">
+            <div class="row">
+                <div class="col-6">
+                    <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
+                        style="text-transform: none; font-size: larger; border-width: 0.7px;"
+                        @click="openPlanSerieDialog()">
+                        <i class="fas fa-calendar-plus"></i>&nbsp;
+                        Ny gjentagende aktivitet
+                    </a>
+                </div>
+                <div class="col-6">
+                    <a class="btn btn-lg btn-outline-dark shadow-0 btn-block mb-2 p-2"
+                        style="text-transform: none; font-size: larger; border-width: 0.7px;"
+                        @click="openPlanActivityDialog()">
+                        <i class="fas fa-calendar-plus"></i>&nbsp;
+                        Ny enkel aktivitet
+                    </a>
+                </div>
+            </div>
+
+            <hr class="mt-0">
+
+            <div id="eventsBody">
+                <div class="border border-2 rounded-2 p-3" id='[[element._uuid]]' style="background-color: #f6f6f0;"
+                    v-for="event in events">
+                    
+                    <div class="d-flex justify-content-between align-items-center">
+                        <h3>
+                            <i class="fas fa-calendar"></i>&nbsp;
+                            [[event.title]]
+                        </h3>
+    
+                        <h5>
+                            [[event.start.toLocaleString()]] - [[event.end.toLocaleString()]]
+                        </h5>    
+                    </div>
+                    
+                    <div>
+                        <span class="fw-bolder">Målgruppe:</span> [[event.audienceName]]
+                    </div>
+                    <div>
+                        <span class="fw-bolder">Arrangement Type:</span> [[event.arrangementTypeName]]
+                    </div>
+
+                    <div class="mt-2">
+                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 "
+                            data-toggle='tooltip' title='{% trans "Edit this activity" %}'
+                            @click="openDialog('newSimpleActivityDialog', { event_uuid: event._uuid})">
+                            <i class="fas fa-edit"></i>&nbsp;
+                            Rediger
+                        </a>
+                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
+                            data-toggle='tooltip' title='{% trans "Remove this activity from the arrangement" %}'
+                            @click="events.splice(events.indexOf(event), 1); dialog.data.eventsMap.delete(event._uuid);">
+                            <i class="fas fa-trash"></i>&nbsp;
+                            Slett
+                        </a>
+                    </div>
+                </div>
+
+            </div>
+            <div id="timeplansBody">
+
+                <div class="rounded-2 border border-2 p-3 ps-4 pe-4" 
+                    :id='serie._uuid' 
+                    style="background-color: #f6f6f0;"
+                    v-for="serie in series">
+                    <h3 class="mb-0">
+                        <i class="fas fa-sync"></i>&nbsp;
+                        [[serie.time.title]]
+                    </h5>
+                    <h5 class="mb-0"><i class="fas fa-clock"></i> [[serie.time.start]] - [[serie.time.end]] </h6>
+                    <h6>[[serie.friendlyDesc]] </h6>
+
+                    <div class="mb-2">
+                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0"
+                            data-toggle='tooltip' title='{% trans "Edit this recurring activity" %}'
+                            @click="openDialog('newTimePlanDialog', { serie_uuid: serie._uuid })">
+                            <i class="fas fa-edit"></i>&nbsp;
+                            Rediger tidsplan
+                        </a>
+
+                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
+                            data-toggle='tooltip' title='{% trans "Remove this recurring activity from the arrangement to be" %}'
+                            @click="series.splice(series.indexOf(serie), 1); dialog.data.seriesMap.delete(serie._uuid);">
+                            <i class="fas fa-trash"></i>&nbsp;
+                            Slett
+                        </a>
+                    </div>
+
+                    <div class="accordion" id="accordion_series_[[serie._uuid]]" v-if="serie.collisions.length">
+                        <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingOne">
+                            <a
+                            class="accordion-button text-muted collapsed"
+                            type="button"
+                            data-mdb-toggle="collapse"
+                            data-mdb-target="#collisionsCollapse_[[serie._uuid]]"
+                            aria-expanded="true"
+                            aria-controls="collisionsCollapse_[[serie._uuid]]"
+                            >
+                            <span class="bg-danger rounded-pill text-white p-1 collisions-counter" id='[[serie._uuid]]_collisionCounter'>[[serie.collisions.length]]</span>
+                            <i class="fas fa-exclamation-triangle ms-2"></i>&nbsp; Kollisjoner
+                        </a>
+                        </h2>
+                        <div id="collisionsCollapse_[[serie._uuid]]" class="accordion-collapse collapse" aria-labelledby="headingOne" data-mdb-parent="#accordion_series_[[serie._uuid]]">
+                            <div class="accordion-body" style="max-height: 35em; overflow: scroll;">
+                                <div class="alert alert-danger small">
+                                    <strong>OBS: </strong> kollisjoner som ikke blir <abbr title="Bryt ut kollisjoner til enkle aktiviteter og løs kollisjonen">brutt ut</abbr> og løst vil ikke bli opprettet
+                                    når arrangementet opprettes.
+                                </div>
+                                
+                                <div
+                                    v-for="collisionRecord in serie.collisions">
+
+                                        <div class="bg-dark border p-2 border-2 border-warning text-white p-3 shadow-3 conflict_summary_${collisionsCounter}"
+                                            style='background-color: #f6f6f0'>
+                                            <h5><i class="fas fa-exclamation-triangle"></i>&nbsp; Konflikt på [[collisionRecord.contested_resource_name]]</h5>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <div>
+                                                        <div class="fw-bolder">[[collisionRecord.event_a_title]]</div>
+                                                        <h6>[[collisionRecord.event_a_start]] - [[collisionRecord.event_a_end]]</h6>
+                                                    </div>
+                                                </div>
+                                                <div class="col-2">
+                                                    <h3 class=" text-center"><i class="fas fa-arrow-right"></i></h3>
+                                                </div>
+                                                <div class="col-5">
+                                                    <div>
+                                                        <div class="fw-bolder">[[collisionRecord.event_b_title]]</div>
+                                                        <h6>[[collisionRecord.event_b_start]] - [[collisionRecord.event_b_end]]</h6>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="clearfix">
+                                                <a href="#" class="btn wb-btn-secondary shadow-0"
+                                                    d-trigger="breakOutEvent" d-arg-serie_uuid="[[serie._uuid]]" d-arg-collision_index="[[serie.collisions.length]]"><i class='fas fa-code-branch'></i>&nbsp; Løs konflikt
+                                                </a>
+                                            </div>
+                                            <div v-if="collisionRecord.is_rigging">
+                                                <br>
+
+                                                <i class="fas fa-hammer"></i>&nbsp;Rigghendelse
+                                            </div>
+                                        </div>
+                                </div>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </div>
 
             </div>
         </div>
     </div>
-
-
 
     <div class="navigationButtons clearfix pt-2">
         <div class="float-start">

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -19,540 +19,568 @@
 
     <hr>
 
-    <div>
-        <div id="step-1">
-            <form id="arrangementInfoForm">
-                <input type="submit" style="display:none;" />
-                
-                <fieldset>
-                    <div class="form-group mb-2">
-                        <label>
-                            Tittel <i>(Norsk)</i>
-                            <span class="fw-bold">&nbsp;*</span>
-                        </label>
-                        <input type="text"
-                            class="form-control form-control-lg mb-2"
-                            id="{{ form.name.id_for_label }}"
-                            value="{{ form.name.value|default:'' }}"
-                            name="{{ form.name.name }}"
-                            autocomplete="off"
-                            v-model="arrangement.title"
-                            required />
-                    </div>
-                    {% if form.name.errors|length > 0 %}
-                        <div class="alert alert-danger">
-                            {{ form.name.errors }}
-                        </div>
-                    {% endif %}
 
-                    <div class="form-group mb-2">
+    <div class="row">
+        <div class="col-9">
+            <div>
+                <div id="step-1">
+                    <form id="arrangementInfoForm">
+                        <input type="submit" style="display:none;" />
+                        
+                        <fieldset>
+                            <div class="form-group mb-2">
+                                <label>
+                                    Tittel <i>(Norsk)</i>
+                                    <span class="fw-bold">&nbsp;*</span>
+                                </label>
+                                <input type="text"
+                                    class="form-control form-control-lg mb-2"
+                                    id="{{ form.name.id_for_label }}"
+                                    value="{{ form.name.value|default:'' }}"
+                                    name="{{ form.name.name }}"
+                                    autocomplete="off"
+                                    v-model="arrangement.title"
+                                    required />
+                            </div>
+                            {% if form.name.errors|length > 0 %}
+                                <div class="alert alert-danger">
+                                    {{ form.name.errors }}
+                                </div>
+                            {% endif %}
+        
+                            <div class="form-group mb-2">
+                                <label>
+                                    Tittel <i>(Engelsk)</i>
+                                </label>
+                                <input type="text"
+                                    class="form-control form-control-lg"
+                                    id="{{ form.name_en.id_for_label }}"
+                                    value="{{ form.name_en.value|default:'' }}"
+                                    name="{{ form.name_en.name }}"
+                                    v-model="arrangement.title_english"
+                                    autocomplete="off"
+                                    />
+                            </div>
+                            {% if form.name_en.errors|length > 0 %}
+                                <div class="alert alert-danger">
+                                    {{ form.name_en.errors }}
+                                </div>
+                            {% endif %}
+        
+        
+                            <tree-select-component
+                                class="mb-2"
+                                label="Målgruppe *"
+                                json-url="/arrangement/audience/tree"
+                                icon="fas fa-users"
+                                button-label="Velg målgruppe"
+                                :selected="arrangement.audience"
+                                @input="(id) => arrangement.audience = id">
+                            </tree-select-component>
+        
+                            <tree-select-component
+                                class="mb-2"
+                                label="Arrangementstype *"
+                                json-url="/arrangement/arrangementtype/treelist"
+                                icon="fas fa-cog"
+                                button-label="Velg arrangementstype"
+                                :selected="arrangement.arrangement_type"
+                                @input="(id) => arrangement.arrangement_type = id">
+                            </tree-select-component>
+        
+                            <tree-select-component
+                                class="mb-2"
+                                label="Status"
+                                json-url="/arrangement/statustype/tree"
+                                icon="fas fa-cog"
+                                button-label="Velg status"
+                                :selected="arrangement.status"
+                                @input="(id) => arrangement.status = id">
+                            </tree-select-component>
+        
+                            <div class="mb-2">
+                                <label>
+                                    <i class="fas fa-map-marker-alt"></i>&nbsp;
+                                    Lokasjon
+                                    <span class="fw-bold">&nbsp;*</span>
+                                </label>
+                                {{ form.location }}
+                            </div>
+                            {% if form.location.errors|length > 0 %}
+                                <div class="alert alert-danger">
+                                    {{ form.location.errors }}
+                                </div>
+                            {% endif %}
+                        </fieldset>
+                    </form>
+                </div>
+                <div id="step-services">
+                    <div class="clearfix">
+                        <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
+                            style="text-transform: none; font-size: larger; border-width: 0.7px;"
+                            @click="openAddServiceOrderDialog()">
+                            <i class="fas fa-calendar-plus"></i>&nbsp;
+                            Bestill tjenester
+                        </a>
+                    </div>
+        
+                    <div class="alert alert-info mt-2">
+                        Du kan bestille forskjellige tjenester for dette arrangementet. Om du bestiller for arrangementet
+                        vil bestillingen gjelde alle tidspunkter for arrangementet. Du kan velge å også bare bestille for en
+                        gitt tidspunkt eller serie av tidspunkt.
+                    </div>
+        
+                    <div id="serviceOrders">
+                        <div
+                            class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' :id="order.key"
+                            v-for="order in arrangement.serviceOrders">
+                            
+                            <h5>
+                                [[order.service_name]]
+                                <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end' 
+                                    :id="order.key" 
+                                    @click="serviceOrders.splice(serviceOrders.indexOf(order), 1)"
+                                    select-type='serviceOrder' 
+                                    d-trigger="removeAssociation">
+                                    
+                                    <i class='fas fa-times'></i>
+                                </button>
+                            </h5>
+                            <code>
+                                [[order.freetext_comment]]
+                            </code>
+                        </div>
+                    </div>
+                </div>
+                <div id="step-2">
+                    <form id="arrangementDetailsForm">
+                        <input type="submit" value="" style="display: none;">
+        
+                        <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
+                            <input type="hidden" 
+                                name="{{ form.responsible.name }}" 
+                                id="{{ form.responsible.id_for_label }}">
+        
+                            <label for="" class="d-block form-label">
+                                <i class="fas fa-star"></i>
+                                Hovedplanlegger
+                            </label>
+        
+                            <div class="text-danger" style="display: none;"
+                                id="mainPlanner_validationText">
+                                Vennligst velg en hovedplanlegger
+                            </div>
+                            
+                            <div>
+                                [[ arrangement.mainPlanner.text ]]
+                            </div>
+        
+                            <button class="wb-btn-main"
+                                id="setMainPlannerButton"
+                                type="button">
+                                Velg hovedplanlegger
+                            </button>
+        
+                            <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
+                                <div class="popover_content" style="width: 50em!important;">
+                                    <h5>Velg hovedplanlegger</h5>
+                                    
+                                    <input type="search" name="" id="" class="form-control form-control-lg"
+                                        v-model="mainPlannerSearchTerm"
+                                        placeholder="Søk etter planlegger... (minst 3 tegn)">       
+        
+                                    <div class="mt-3">
+                                        <div v-if="mainPlannerSearchResults.length">
+                                            <div v-if="mainPlannerSearchTerm.length == 0"
+                                                class="alert alert-info">
+                                                <div class="d-flex align-items-center">
+                                                    <h2 class="mb-0"><i class="fas fa-info"></i></h2>
+                                                    
+                                                    <div class="ms-3">
+                                                        Uten søkeord vises alle personer med gruppe planlegger
+                                                        <br>
+                                                        Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
+                                                    </div>
+                                                </div>
+                                            </div>
+        
+                                            <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
+                                                <tbody>
+                                                    <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
+                                                        <td>
+                                                            <a>
+                                                                [[ result.full_name ]]
+                                                            </a>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                            
+                                            <div class="clearfix">
+                                                <small class="text-muted float-end fw-bold">
+                                                    <i class="fas fa-info"></i>&nbsp;
+                                                    Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
+                                                </small>
+                                            </div>
+                                        </div>
+                                        <div 
+                                            class="alert alert-info"
+                                            v-else>
+                                            Ingen resultater
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+        
+                        <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
+                            <label for="" class="form-label">
+                                <i class="fas fa-building"></i>&nbsp;
+                                Rom
+                            </label>
+                            <div>
+                                <button class="wb-btn-main"
+                                    type="button"
+                                    @click="openAddRoomsDialog()">
+                                    Velg rom
+                                </button>
+                            </div>
+                            <div id="roomChips" class="chipsList">
+                                <span v-for="room in arrangement.rooms">
+                                    <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
+                                        [[room.text]]
+                                        
+                                        <a href="#">
+                                            <i class="fa fa-times text-danger"
+                                                :id="room.id"
+                                                select-type="room"
+                                                @click="rooms.splice(rooms.indexOf(room), 1)"
+                                                d-trigger="removeAssociation">
+        
+                                            </i>
+                                        </a>
+                                    </div>
+                                </span>
+                            </div>
+                        </div>
+        
+                        <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
+                            <label for="" class="form-label">
+                                <i class="fas fa-users-cog"></i>&nbsp;
+                                Planleggere
+                            </label>
+                            <div>
+                                <button class="wb-btn-main"
+                                    type="button"
+                                    @click="openAddPlannersDialog()">
+                                    Velg planleggere
+                                </button>
+                            </div>
+                            <div id="plannerChips" class="chipsList">
+                                <span v-for="planner in arrangement.planners">
+                                    <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
+                                        [[planner.text]]
+                                        
+                                        <a href="#">
+                                            <i class="fa fa-times text-danger"
+                                                :id="planner.id"
+                                                select-type="person"
+                                                @click="planners.splice(planners.indexOf(room), 1)"
+                                                d-trigger="removeAssociation">
+        
+                                            </i>
+                                        </a>
+                                    </div>
+                                </span>
+                            </div>
+                        </div>
+        
+                        <div class="mb-2 mt-4 form-group">
+                            <label>
+                                <i class="fas fa-receipt"></i>&nbsp;
+                                Billetkode
+                            </label>
+                            <input type="text"
+                                class="form-control form-control-lg"
+                                id="{{ form.ticket_code.id_for_label }}"
+                                value="{{ form.ticket_code.value|default:'' }}"
+                                name="{{ form.ticket_code.name }}"
+                                placeholder="Billetkode..."
+                                v-model="arrangement.ticket_code"/>
+                        </div>
+                        {% if form.ticket_code.errors|length > 0 %}
+                            <div class="alert alert-danger">
+                                {{ form.ticket_code.errors }}
+                            </div>
+                        {% endif %}
+        
+                        <div class="mb-2 form-group">
+                            <label>
+                                Forventet besøkende
+                            </label>
+                            <input type="number"
+                                min="0"
+                                class="form-control form-control-lg"
+                                id="{{ form.expected_visitors.id_for_label }}"
+                                value="{{ form.expected_visitors.value|default:'0' }}"
+                                name="{{ form.expected_visitors.name }}"
+                                v-model="arrangement.expected_visitors"
+                                required />
+                        </div>
+                        {% if form.expected_visitors.errors|length > 0 %}
+                            <div class="alert alert-danger">
+                                {{ form.expected_visitors.errors }}
+                            </div>
+                        {% endif %}
+                    </form>
+                </div>
+                <div id="step-3">
+                    <div class="row">
+                        <div class="col-lg-4 col-sm-12">
+                            <h5 class="header-fonted">
+                                <i class="fas fa-tv"></i>
+                                Skjerm
+                            </h5>
+                            <label class="d-block">&nbsp; {% trans "Vises på skjerm:" %}</label>
+                            {{form.display_layouts}}
+                        </div>
+        
+                        <div class="col-lg-8 col-sm-12 mt-sm-2">
+                            <div
+                                class="form-group"
+                                id="display-layout-text-group">
+        
+                                <div v-show="showDisplayText">
+                                    <input type="text" name="{{form.display_text.name}}"
+                                        class="form-control form-control-lg"
+                                        id="{{form.display_text.id_for_label}}"
+                                        v-model="arrangement.display_text"
+                                        placeholder="Skjermtekst...">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                
+                    <div class="mt-2 form-group">
                         <label>
-                            Tittel <i>(Engelsk)</i>
+                            <i class="fas fa-door-open"></i>&nbsp;
+                            Møtested <i>(Norsk)</i>
                         </label>
                         <input type="text"
                             class="form-control form-control-lg"
-                            id="{{ form.name_en.id_for_label }}"
-                            value="{{ form.name_en.value|default:'' }}"
-                            name="{{ form.name_en.name }}"
-                            v-model="arrangement.title_english"
-                            autocomplete="off"
-                            />
+                            id="{{ form.meeting_place.id_for_label }}"
+                            value="{{ form.meeting_place.value|default:'' }}"
+                            name="{{ form.meeting_place.name }}"
+                            placeholder="{% trans 'Møtested' %}..."
+                            v-model="arrangement.meeting_place"/>
+                        <div class="form-helper text-end">
+                            <i class="fas fa-info-circle"></i>&nbsp;
+                            Vil overskrive sted/rom vist på skjerm
+                        </div>
                     </div>
-                    {% if form.name_en.errors|length > 0 %}
+                    {% if form.meeting_place.errors|length > 0 %}
                         <div class="alert alert-danger">
-                            {{ form.name_en.errors }}
+                            {{ form.meeting_place.errors }}
                         </div>
                     {% endif %}
-
-
-                    <tree-select-component
-                        class="mb-2"
-                        label="Målgruppe *"
-                        json-url="/arrangement/audience/tree"
-                        icon="fas fa-users"
-                        button-label="Velg målgruppe"
-                        :selected="arrangement.audience"
-                        @input="(id) => arrangement.audience = id">
-                    </tree-select-component>
-
-                    <tree-select-component
-                        class="mb-2"
-                        label="Arrangementstype *"
-                        json-url="/arrangement/arrangementtype/treelist"
-                        icon="fas fa-cog"
-                        button-label="Velg arrangementstype"
-                        :selected="arrangement.arrangement_type"
-                        @input="(id) => arrangement.arrangement_type = id">
-                    </tree-select-component>
-
-                    <tree-select-component
-                        class="mb-2"
-                        label="Status"
-                        json-url="/arrangement/statustype/tree"
-                        icon="fas fa-cog"
-                        button-label="Velg status"
-                        :selected="arrangement.status"
-                        @input="(id) => arrangement.status = id">
-                    </tree-select-component>
-
-                    <div class="mb-2">
-                        <label>
-                            <i class="fas fa-map-marker-alt"></i>&nbsp;
-                            Lokasjon
-                            <span class="fw-bold">&nbsp;*</span>
-                        </label>
-                        {{ form.location }}
-                    </div>
-                    {% if form.location.errors|length > 0 %}
-                        <div class="alert alert-danger">
-                            {{ form.location.errors }}
-                        </div>
-                    {% endif %}
-                </fieldset>
-            </form>
-        </div>
-        <div id="step-services">
-            <div class="clearfix">
-                <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
-                    style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                    @click="openAddServiceOrderDialog()">
-                    <i class="fas fa-calendar-plus"></i>&nbsp;
-                    Bestill tjenester
-                </a>
-            </div>
-
-            <div class="alert alert-info mt-2">
-                Du kan bestille forskjellige tjenester for dette arrangementet. Om du bestiller for arrangementet
-                vil bestillingen gjelde alle tidspunkter for arrangementet. Du kan velge å også bare bestille for en
-                gitt tidspunkt eller serie av tidspunkt.
-            </div>
-
-            <div id="serviceOrders">
-                <div
-                    class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' :id="order.key"
-                    v-for="order in serviceOrders">
-                    
-                    <h5>
-                        [[order.service_name]]
-                        <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end' 
-                            :id="order.key" 
-                            @click="serviceOrders.splice(serviceOrders.indexOf(order), 1)"
-                            select-type='serviceOrder' 
-                            d-trigger="removeAssociation">
-                            
-                            <i class='fas fa-times'></i>
-                        </button>
-                    </h5>
-                    <code>
-                        [[order.freetext_comment]]
-                    </code>
-                </div>
-            </div>
-        </div>
-        <div id="step-2">
-            <form id="arrangementDetailsForm">
-                <input type="submit" value="" style="display: none;">
-
-                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
-                    <input type="hidden" 
-                        name="{{ form.responsible.name }}" 
-                        id="{{ form.responsible.id_for_label }}"
-                        >
-
-                    <label for="" class="d-block form-label">
-                        <i class="fas fa-star"></i>
-                        Hovedplanlegger
-                    </label>
-
-                    <div class="text-danger" style="display: none;"
-                        id="mainPlanner_validationText">
-                        Vennligst velg en hovedplanlegger
-                    </div>
-
-                    <!-- <h5 class="mb-2">[[ mainPlanner.text ]]</h5> -->
-                    <button class="wb-btn-main"
-                        id="setMainPlannerButton"
-                        type="button">
-                        Velg hovedplanlegger
-                    </button>
-
-                    <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
-                        <div class="popover_content" style="width: 50em!important;">
-                            <h5>Velg hovedplanlegger</h5>
-                            
-                            
-                            <input type="search" name="" id="" class="form-control form-control-lg"
-                                v-model="mainPlannerSearchTerm"
-                                placeholder="Søk etter planlegger... (minst 3 tegn)">       
-
-                            <div class="mt-3">
-                                <div v-if="mainPlannerSearchResults.length">
-                                    <div v-if="mainPlannerSearchTerm.length == 0"
-                                        class="alert alert-info">
-                                        <div class="d-flex align-items-center">
-                                            <h2 class="mb-0"><i class="fas fa-info"></i></h2>
-                                            
-                                            <div class="ms-3">
-                                                Uten søkeord vises alle personer med gruppe planlegger
-                                                <br>
-                                                Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
-                                        <tbody>
-                                            <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
-                                                <td>
-                                                    <a>
-                                                        [[ result.full_name ]]
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    
-                                    <div class="clearfix">
-                                        <small class="text-muted float-end fw-bold">
-                                            <i class="fas fa-info"></i>&nbsp;
-                                            Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
-                                        </small>
-                                    </div>
-                                </div>
-                                <div 
-                                    class="alert alert-info"
-                                    v-else>
-                                    Ingen resultater
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
-                    <label for="" class="form-label">
-                        <i class="fas fa-building"></i>&nbsp;
-                        Rom
-                    </label>
-                    <div>
-                        <button class="wb-btn-main"
-                            type="button"
-                            @click="openAddRoomsDialog()">
-                            Velg rom
-                        </button>
-                    </div>
-                    <div id="roomChips" class="chipsList">
-                        <span v-for="room in rooms">
-                            <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
-                                [[room.text]]
-                                
-                                <a href="#">
-                                    <i class="fa fa-times text-danger"
-                                        :id="room.id"
-                                        select-type="room"
-                                        @click="rooms.splice(rooms.indexOf(room), 1)"
-                                        d-trigger="removeAssociation">
-
-                                    </i>
-                                </a>
-                            </div>
-                        </span>
-                    </div>
-                </div>
-
-                <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
-                    <label for="" class="form-label">
-                        <i class="fas fa-users-cog"></i>&nbsp;
-                        Planleggere
-                    </label>
-                    <div>
-                        <button class="wb-btn-main"
-                            type="button"
-                            @click="openAddPlannersDialog()">
-                            Velg planleggere
-                        </button>
-                    </div>
-                    <div id="plannerChips" class="chipsList">
-                        <span v-for="planner in planners">
-                            <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
-                                [[planner.text]]
-                                
-                                <a href="#">
-                                    <i class="fa fa-times text-danger"
-                                        :id="planner.id"
-                                        select-type="person"
-                                        @click="planners.splice(planners.indexOf(room), 1)"
-                                        d-trigger="removeAssociation">
-
-                                    </i>
-                                </a>
-                            </div>
-                        </span>
-                    </div>
-                </div>
-
-                <div class="mb-2 mt-4 form-group">
-                    <label>
-                        <i class="fas fa-receipt"></i>&nbsp;
-                        Billetkode
-                    </label>
-                    <input type="text"
-                        class="form-control form-control-lg"
-                        id="{{ form.ticket_code.id_for_label }}"
-                        value="{{ form.ticket_code.value|default:'' }}"
-                        name="{{ form.ticket_code.name }}"
-                        placeholder="Billetkode..."/>
-                </div>
-                {% if form.ticket_code.errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        {{ form.ticket_code.errors }}
-                    </div>
-                {% endif %}
-
-                <div class="mb-2 form-group">
-                    <label>
-                        Forventet besøkende
-                    </label>
-                    <input type="number"
-                        min="0"
-                        class="form-control form-control-lg"
-                        id="{{ form.expected_visitors.id_for_label }}"
-                        value="{{ form.expected_visitors.value|default:'0' }}"
-                        name="{{ form.expected_visitors.name }}"
-                        required />
-                </div>
-                {% if form.expected_visitors.errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        {{ form.expected_visitors.errors }}
-                    </div>
-                {% endif %}
-            </form>
-        </div>
-        <div id="step-3">
-            <div class="row">
-                <div class="col-lg-4 col-sm-12">
-                    <h5 class="header-fonted">
-                        <i class="fas fa-tv"></i>
-                        Skjerm
-                    </h5>
-                    <label class="d-block">&nbsp; {% trans "Vises på skjerm:" %}</label>
-                    {{form.display_layouts}}
-                </div>
-
-                <div class="col-lg-8 col-sm-12 mt-sm-2">
-                    <div
-                        class="form-group"
-                        id="display-layout-text-group"
-                        style="display: none;">
-
-                        <div>
-                            {{ form.display_text|as_crispy_field }}
-                        </div>
-                    </div>
-                </div>
-            </div>
         
-
-                <div class="mt-2 form-group">
-                <label>
-                    <i class="fas fa-door-open"></i>&nbsp;
-                    Møtested <i>(Norsk)</i>
-                </label>
-                <input type="text"
-                    class="form-control form-control-lg"
-                    id="{{ form.meeting_place.id_for_label }}"
-                    value="{{ form.meeting_place.value|default:'' }}"
-                    name="{{ form.meeting_place.name }}"
-                    placeholder="{% trans 'Møtested' %}..."/>
-                <div class="form-helper text-end">
-                    <i class="fas fa-info-circle"></i>&nbsp;
-                    Vil overskrive sted/rom vist på skjerm
-                </div>
-            </div>
-            {% if form.meeting_place.errors|length > 0 %}
-                <div class="alert alert-danger">
-                    {{ form.meeting_place.errors }}
-                </div>
-            {% endif %}
-
-            <div class="mt-2 form-group">
-                <label>
-                    <i class="fas fa-door-open"></i>&nbsp;
-                    Møtested <i>(Engelsk)</i>
-                </label>
-                <input type="text"
-                    class="form-control form-control-lg"
-                    id="{{ form.meeting_place_en.id_for_label }}"
-                    value="{{ form.meeting_place_en.value|default:'' }}"
-                    name="{{ form.meeting_place_en.name }}"
-                    placeholder="{% trans 'Møtested' %}..."/>
-                <div class="form-helper text-end">
-                    <i class="fas fa-info-circle"></i>&nbsp;
-                    Vil overskrive sted/rom vist på skjerm
-                </div>
-            </div>
-            {% if form.meeting_place.errors|length > 0 %}
-                <div class="alert alert-danger">
-                    {{ form.meeting_place.errors }}
-                </div>
-            {% endif %}
-        </div>
-        <div id="step-4">
-            <div class="row">
-                <div class="col-6">
-                    <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
-                        style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                        @click="openPlanSerieDialog()">
-                        <i class="fas fa-calendar-plus"></i>&nbsp;
-                        Ny gjentagende aktivitet
-                    </a>
-                </div>
-                <div class="col-6">
-                    <a class="btn btn-lg btn-outline-dark shadow-0 btn-block mb-2 p-2"
-                        style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                        @click="openPlanActivityDialog()">
-                        <i class="fas fa-calendar-plus"></i>&nbsp;
-                        Ny enkel aktivitet
-                    </a>
-                </div>
-            </div>
-
-            <hr class="mt-0">
-
-            <div id="eventsBody">
-                <div class="border border-2 rounded-2 p-3" id='[[element._uuid]]' style="background-color: #f6f6f0;"
-                    v-for="event in events">
-                    
-                    <div class="d-flex justify-content-between align-items-center">
-                        <h3>
-                            <i class="fas fa-calendar"></i>&nbsp;
-                            [[event.title]]
-                        </h3>
-    
-                        <h5>
-                            [[event.start.toLocaleString()]] - [[event.end.toLocaleString()]]
-                        </h5>    
+                    <div class="mt-2 form-group">
+                        <label>
+                            <i class="fas fa-door-open"></i>&nbsp;
+                            Møtested <i>(Engelsk)</i>
+                        </label>
+                        <input type="text"
+                            class="form-control form-control-lg"
+                            id="{{ form.meeting_place_en.id_for_label }}"
+                            value="{{ form.meeting_place_en.value|default:'' }}"
+                            name="{{ form.meeting_place_en.name }}"
+                            placeholder="{% trans 'Møtested' %}..."
+                            v-model="arrangement.meeting_place_en"/>
+                        <div class="form-helper text-end">
+                            <i class="fas fa-info-circle"></i>&nbsp;
+                            Vil overskrive sted/rom vist på skjerm
+                        </div>
                     </div>
-                    
-                    <div>
-                        <span class="fw-bolder">Målgruppe:</span> [[event.audienceName]]
-                    </div>
-                    <div>
-                        <span class="fw-bolder">Arrangement Type:</span> [[event.arrangementTypeName]]
-                    </div>
-
-                    <div class="mt-2">
-                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 "
-                            data-toggle='tooltip' title='{% trans "Edit this activity" %}'
-                            @click="openDialog('newSimpleActivityDialog', { event_uuid: event._uuid})">
-                            <i class="fas fa-edit"></i>&nbsp;
-                            Rediger
-                        </a>
-                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
-                            data-toggle='tooltip' title='{% trans "Remove this activity from the arrangement" %}'
-                            @click="events.splice(events.indexOf(event), 1); dialog.data.eventsMap.delete(event._uuid);">
-                            <i class="fas fa-trash"></i>&nbsp;
-                            Slett
-                        </a>
-                    </div>
+                    {% if form.meeting_place.errors|length > 0 %}
+                        <div class="alert alert-danger">
+                            {{ form.meeting_place.errors }}
+                        </div>
+                    {% endif %}
                 </div>
-
-            </div>
-            <div id="timeplansBody">
-
-                <div class="rounded-2 border border-2 p-3 ps-4 pe-4" 
-                    :id='serie._uuid' 
-                    style="background-color: #f6f6f0;"
-                    v-for="serie in series">
-                    <h3 class="mb-0">
-                        <i class="fas fa-sync"></i>&nbsp;
-                        [[serie.time.title]]
-                    </h5>
-                    <h5 class="mb-0"><i class="fas fa-clock"></i> [[serie.time.start]] - [[serie.time.end]] </h6>
-                    <h6>[[serie.friendlyDesc]] </h6>
-
-                    <div class="mb-2">
-                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0"
-                            data-toggle='tooltip' title='{% trans "Edit this recurring activity" %}'
-                            @click="openDialog('newTimePlanDialog', { serie_uuid: serie._uuid })">
-                            <i class="fas fa-edit"></i>&nbsp;
-                            Rediger tidsplan
-                        </a>
-
-                        <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
-                            data-toggle='tooltip' title='{% trans "Remove this recurring activity from the arrangement to be" %}'
-                            @click="series.splice(series.indexOf(serie), 1); dialog.data.seriesMap.delete(serie._uuid);">
-                            <i class="fas fa-trash"></i>&nbsp;
-                            Slett
-                        </a>
+                <div id="step-4">
+                    <div class="row">
+                        <div class="col-6">
+                            <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
+                                style="text-transform: none; font-size: larger; border-width: 0.7px;"
+                                @click="openPlanSerieDialog()">
+                                <i class="fas fa-calendar-plus"></i>&nbsp;
+                                Ny gjentagende aktivitet
+                            </a>
+                        </div>
+                        <div class="col-6">
+                            <a class="btn btn-lg btn-outline-dark shadow-0 btn-block mb-2 p-2"
+                                style="text-transform: none; font-size: larger; border-width: 0.7px;"
+                                @click="openPlanActivityDialog()">
+                                <i class="fas fa-calendar-plus"></i>&nbsp;
+                                Ny enkel aktivitet
+                            </a>
+                        </div>
                     </div>
-
-                    <div class="accordion" id="accordion_series_[[serie._uuid]]" v-if="serie.collisions.length">
-                        <div class="accordion-item">
-                        <h2 class="accordion-header" id="headingOne">
-                            <a
-                            class="accordion-button text-muted collapsed"
-                            type="button"
-                            data-mdb-toggle="collapse"
-                            data-mdb-target="#collisionsCollapse_[[serie._uuid]]"
-                            aria-expanded="true"
-                            aria-controls="collisionsCollapse_[[serie._uuid]]"
-                            >
-                            <span class="bg-danger rounded-pill text-white p-1 collisions-counter" id='[[serie._uuid]]_collisionCounter'>[[serie.collisions.length]]</span>
-                            <i class="fas fa-exclamation-triangle ms-2"></i>&nbsp; Kollisjoner
-                        </a>
-                        </h2>
-                        <div id="collisionsCollapse_[[serie._uuid]]" class="accordion-collapse collapse" aria-labelledby="headingOne" data-mdb-parent="#accordion_series_[[serie._uuid]]">
-                            <div class="accordion-body" style="max-height: 35em; overflow: scroll;">
-                                <div class="alert alert-danger small">
-                                    <strong>OBS: </strong> kollisjoner som ikke blir <abbr title="Bryt ut kollisjoner til enkle aktiviteter og løs kollisjonen">brutt ut</abbr> og løst vil ikke bli opprettet
-                                    når arrangementet opprettes.
-                                </div>
-                                
-                                <div
-                                    v-for="collisionRecord in serie.collisions">
-
-                                        <div class="bg-dark border p-2 border-2 border-warning text-white p-3 shadow-3 conflict_summary_${collisionsCounter}"
-                                            style='background-color: #f6f6f0'>
-                                            <h5><i class="fas fa-exclamation-triangle"></i>&nbsp; Konflikt på [[collisionRecord.contested_resource_name]]</h5>
-                                            <div class="row">
-                                                <div class="col-5">
-                                                    <div>
-                                                        <div class="fw-bolder">[[collisionRecord.event_a_title]]</div>
-                                                        <h6>[[collisionRecord.event_a_start]] - [[collisionRecord.event_a_end]]</h6>
-                                                    </div>
-                                                </div>
-                                                <div class="col-2">
-                                                    <h3 class=" text-center"><i class="fas fa-arrow-right"></i></h3>
-                                                </div>
-                                                <div class="col-5">
-                                                    <div>
-                                                        <div class="fw-bolder">[[collisionRecord.event_b_title]]</div>
-                                                        <h6>[[collisionRecord.event_b_start]] - [[collisionRecord.event_b_end]]</h6>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="clearfix">
-                                                <a href="#" class="btn wb-btn-secondary shadow-0"
-                                                    d-trigger="breakOutEvent" d-arg-serie_uuid="[[serie._uuid]]" d-arg-collision_index="[[serie.collisions.length]]"><i class='fas fa-code-branch'></i>&nbsp; Løs konflikt
-                                                </a>
-                                            </div>
-                                            <div v-if="collisionRecord.is_rigging">
-                                                <br>
-
-                                                <i class="fas fa-hammer"></i>&nbsp;Rigghendelse
-                                            </div>
+        
+                    <hr class="mt-0">
+        
+                    <div id="eventsBody">
+                        <div class="border border-2 rounded-2 p-3" id='[[element._uuid]]' style="background-color: #f6f6f0;"
+                            v-for="event in events">
+                            
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h3>
+                                    <i class="fas fa-calendar"></i>&nbsp;
+                                    [[event.title]]
+                                </h3>
+            
+                                <h5>
+                                    [[event.start.toLocaleString()]] - [[event.end.toLocaleString()]]
+                                </h5>    
+                            </div>
+                            
+                            <div>
+                                <span class="fw-bolder">Målgruppe:</span> [[event.audienceName]]
+                            </div>
+                            <div>
+                                <span class="fw-bolder">Arrangement Type:</span> [[event.arrangementTypeName]]
+                            </div>
+        
+                            <div class="mt-2">
+                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 "
+                                    data-toggle='tooltip' title='{% trans "Edit this activity" %}'
+                                    @click="openDialog('newSimpleActivityDialog', { event_uuid: event._uuid})">
+                                    <i class="fas fa-edit"></i>&nbsp;
+                                    Rediger
+                                </a>
+                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
+                                    data-toggle='tooltip' title='{% trans "Remove this activity from the arrangement" %}'
+                                    @click="events.splice(events.indexOf(event), 1); dialog.data.eventsMap.delete(event._uuid);">
+                                    <i class="fas fa-trash"></i>&nbsp;
+                                    Slett
+                                </a>
+                            </div>
+                        </div>
+        
+                    </div>
+                    <div id="timeplansBody">
+        
+                        <div class="rounded-2 border border-2 p-3 ps-4 pe-4" 
+                            :id='serie._uuid' 
+                            style="background-color: #f6f6f0;"
+                            v-for="serie in series">
+                            <h3 class="mb-0">
+                                <i class="fas fa-sync"></i>&nbsp;
+                                [[serie.time.title]]
+                            </h5>
+                            <h5 class="mb-0"><i class="fas fa-clock"></i> [[serie.time.start]] - [[serie.time.end]] </h6>
+                            <h6>[[serie.friendlyDesc]] </h6>
+        
+                            <div class="mb-2">
+                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0"
+                                    data-toggle='tooltip' title='{% trans "Edit this recurring activity" %}'
+                                    @click="openDialog('newTimePlanDialog', { serie_uuid: serie._uuid })">
+                                    <i class="fas fa-edit"></i>&nbsp;
+                                    Rediger tidsplan
+                                </a>
+        
+                                <a href="#" class="btn wb-btn-main-outline bg-white border border-dark shadow-0 ms-2"
+                                    data-toggle='tooltip' title='{% trans "Remove this recurring activity from the arrangement to be" %}'
+                                    @click="series.splice(series.indexOf(serie), 1); dialog.data.seriesMap.delete(serie._uuid);">
+                                    <i class="fas fa-trash"></i>&nbsp;
+                                    Slett
+                                </a>
+                            </div>
+        
+                            <div class="accordion" id="accordion_series_[[serie._uuid]]" v-if="serie.collisions.length">
+                                <div class="accordion-item">
+                                <h2 class="accordion-header" id="headingOne">
+                                    <a
+                                    class="accordion-button text-muted collapsed"
+                                    type="button"
+                                    data-mdb-toggle="collapse"
+                                    data-mdb-target="#collisionsCollapse_[[serie._uuid]]"
+                                    aria-expanded="true"
+                                    aria-controls="collisionsCollapse_[[serie._uuid]]"
+                                    >
+                                    <span class="bg-danger rounded-pill text-white p-1 collisions-counter" id='[[serie._uuid]]_collisionCounter'>[[serie.collisions.length]]</span>
+                                    <i class="fas fa-exclamation-triangle ms-2"></i>&nbsp; Kollisjoner
+                                </a>
+                                </h2>
+                                <div id="collisionsCollapse_[[serie._uuid]]" class="accordion-collapse collapse" aria-labelledby="headingOne" data-mdb-parent="#accordion_series_[[serie._uuid]]">
+                                    <div class="accordion-body" style="max-height: 35em; overflow: scroll;">
+                                        <div class="alert alert-danger small">
+                                            <strong>OBS: </strong> kollisjoner som ikke blir <abbr title="Bryt ut kollisjoner til enkle aktiviteter og løs kollisjonen">brutt ut</abbr> og løst vil ikke bli opprettet
+                                            når arrangementet opprettes.
                                         </div>
+                                        
+                                        <div
+                                            v-for="collisionRecord in serie.collisions">
+        
+                                                <div class="bg-dark border p-2 border-2 border-warning text-white p-3 shadow-3 conflict_summary_${collisionsCounter}"
+                                                    style='background-color: #f6f6f0'>
+                                                    <h5><i class="fas fa-exclamation-triangle"></i>&nbsp; Konflikt på [[collisionRecord.contested_resource_name]]</h5>
+                                                    <div class="row">
+                                                        <div class="col-5">
+                                                            <div>
+                                                                <div class="fw-bolder">[[collisionRecord.event_a_title]]</div>
+                                                                <h6>[[collisionRecord.event_a_start]] - [[collisionRecord.event_a_end]]</h6>
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-2">
+                                                            <h3 class=" text-center"><i class="fas fa-arrow-right"></i></h3>
+                                                        </div>
+                                                        <div class="col-5">
+                                                            <div>
+                                                                <div class="fw-bolder">[[collisionRecord.event_b_title]]</div>
+                                                                <h6>[[collisionRecord.event_b_start]] - [[collisionRecord.event_b_end]]</h6>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="clearfix">
+                                                        <a href="#" class="btn wb-btn-secondary shadow-0"
+                                                            d-trigger="breakOutEvent" d-arg-serie_uuid="[[serie._uuid]]" d-arg-collision_index="[[serie.collisions.length]]"><i class='fas fa-code-branch'></i>&nbsp; Løs konflikt
+                                                        </a>
+                                                    </div>
+                                                    <div v-if="collisionRecord.is_rigging">
+                                                        <br>
+        
+                                                        <i class="fas fa-hammer"></i>&nbsp;Rigghendelse
+                                                    </div>
+                                                </div>
+                                        </div>
+                                    </div>
+                                </div>
                                 </div>
                             </div>
                         </div>
-                        </div>
+        
                     </div>
                 </div>
+            </div>
+        </div>
+        <div class="col-3">
+            <div class="wb-bg-secondary p-2">
+
+                <table class="table table-striped">
+                    <tbody>
+                        <tr v-for="prop in Object.entries(arrangement)">
+                            <th>[[prop]]</th>
+                            <td>[[ arrangement[prop] ]]</td>
+                        </tr>
+                    </tbody>
+                </table>
 
             </div>
         </div>
     </div>
+
+
 
     <div class="navigationButtons clearfix pt-2">
         <div class="float-start">
@@ -591,16 +619,44 @@
                         audience: null,         // TODO: implement component
                         arrangement_type: null, // TODO: implement component
                         status: null,           // TODO: implement component
+                        ticket_code: null,
+                        expected_visitors: null,
+                        location: null,
                         events: [],                
                         series: [],
                         rooms: [],
+                        meeting_place: null,
+                        meeting_place_en: null,
                         serviceOrders: [],
                         planners: [],
                         mainPlanner: { id: null, text: null },
+                        display_text: null,
+                        display_layouts: []
                     },
                 }
             },
-            computed: {},
+            computed: {
+                showDisplayText() {
+                    let displayLayoutsWithRequisiteText = new Map([
+                        {% for display_layout in DISPLAY_LAYOUTS_WITH_REQUISITE_TEXT %}
+                            [ "{{ display_layout.id }}", true],
+                        {% endfor %}
+                    ]);
+
+                    console.log("displayLayoutsWithRequisiteText", displayLayoutsWithRequisiteText)
+
+                    let showDisplayText = false;
+
+                    this.arrangement.display_layouts.forEach((displayLayout) => {
+                        if (displayLayoutsWithRequisiteText.has(displayLayout)) {
+                            console.log("is trueeeee")
+                            showDisplayText = true;
+                        }
+                    });
+
+                    return showDisplayText;
+                },
+            },
             methods: {
 
                 updateArrangementType(payload) {
@@ -667,7 +723,7 @@
                 },
 
                 setMainPlanner(planner) {
-                    this.mainPlanner = { id: planner.id, text: planner.full_name };
+                    this.arrangement.mainPlanner = { id: planner.id, text: planner.full_name };
 
                     this.dialog.data.mainPlannerPayload = {
                         allPresets: new Map(),
@@ -1075,21 +1131,6 @@
                         stepper: null,
                         vueApp: null,
                     },
-                    plugins: [
-                        {
-                            name: 'showIfSelected',
-                            pluginClass: DialogShowIfSelectedPlugin,
-                            args: {
-                                checkboxesSelector: "[name='display_layouts']",
-                                elementToShowOrHide: ( dialog ) => { return dialog.getElementById('display-layout-text-group'); },
-                                showIfAnyOfTheseValuesMap: new Map([
-                                    {% for display_layout in DISPLAY_LAYOUTS_WITH_REQUISITE_TEXT %}
-                                        [ "{{ display_layout.id }}", true],
-                                    {% endfor %}
-                                ]),
-                            },
-                        }
-                    ],
                 });
             }
         });

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -428,7 +428,7 @@
 
             <div id="eventsBody">
                 <div class="border border-2 rounded-2 p-3" id='[[element._uuid]]' style="background-color: #f6f6f0;"
-                    v-for="event in events">
+                    v-for="event in arrangement.events">
                     
                     <div class="d-flex justify-content-between align-items-center">
                         <h3>
@@ -658,9 +658,12 @@
                  */
                 openPlanActivityDialog() {
                     this.openDialog("newSimpleActivityDialog", {
-                        preorderedServices: Array.from(this.dialog.data.servicePresets.values()),
-                        preselectedMainPlanner: this.dialog.data.mainPlannerPayload,
-                        preselectedRooms: this.dialog.data.roomPayload, 
+                        data: { 
+                            servicePresets: this.dialog.data.servicePresets,
+                            mainPlannerPayload: this.dialog.data.mainPlannerPayload,
+                            roomPayload: this.dialog.data.roomPayload,
+                            ...this.dialog.vueApp.arrangement
+                        }
                     });
                 },
                 /**
@@ -713,7 +716,7 @@
             },
             watch: {
                 mainPlannerSearchTerm: async function (val) {
-                    if (val.length > 2 || val.length == 0) {
+                        if (val.length > 2 || val.length == 0) {
                         await fetch("{% url 'arrangement:person_search_planners_ajax_view' %}?term=" + val, {
                             method: "GET",
                             headers: {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -939,9 +939,9 @@
                                 console.log("name", dialog.getElementById('id_name').value);
                                 formData.append("name",             dialog.getElementById('id_name').value);
                                 formData.append("name_en",          dialog.getElementById('id_name_en').value);
-                                formData.append("audience",         dialog.data.audienceJsTreeSelect.getSelectedValue());
+                                formData.append("audience",         dialog.vueApp.arrangement.audience);
                                 formData.append("location",         dialog.getElementById('id_location').value);
-                                formData.append("arrangement_type", dialog.data.arrangementTypeJsTreeSelect.getSelectedValue());
+                                formData.append("arrangement_type", dialog.vueApp.arrangement.arrangement_type);
                                 formData.append("responsible",      dialog.getElementById('id_responsible').value);
                                 formData.append("ticket_code",      dialog.getElementById('id_ticket_code').value || '');
                                 formData.append("meeting_place",    dialog.getElementById('id_meeting_place').value);
@@ -951,10 +951,10 @@
                                     Array.from(dialog.data.selectedPlannerIds.keys())
                                         .forEach( ( id ) => formData.append("planners", id) )
             
-                                let statusValue = dialog.data.statusTypeJsTreeSelect.getSelectedValue();
+                                let statusValue = dialog.vueApp.arrangement.status;
                                 if (statusValue !== undefined)
                                     formData.append("status", statusValue);
-                                formData.append("display_text",     dialog.plugins.showIfSelected.isInShowState() ? dialog.getElementById('id_display_text').value : '');
+                                formData.append("display_text",     dialog.vueApp.arrangement.display_text);
                                 formData.append("collision_resolution_behaviour", resolution_behaviour);
                 
                                 let displayLayouts = [];

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -79,7 +79,7 @@
                         class="mb-2"
                         label="Arrangementstype *"
                         json-url="/arrangement/arrangementtype/treelist"
-                        icon="fas fa-users"
+                        icon="fas fa-cog"
                         button-label="Velg arrangementstype"
                         :selected="arrangement.arrangement_type"
                         @input="(id) => arrangement.arrangement_type = id">
@@ -788,11 +788,11 @@
                                         }
                                     }
             
-                                    if (!dialog.data.audienceJsTreeSelect.isValid()) {
-                                        dialog.data.audienceJsTreeSelect.showInvalidFeedback();
+                                    if (dialog.vueApp.arrangement.audience === null) {
+                                        toastr.error("Vennligst velg en målgruppe");
                                         return false;
                                     }
-                                    if (!dialog.data.arrangementTypeJsTreeSelect.isValid()) {
+                                    if (!dialog.vueApp.arrangement.arrangement_type) {
                                         dialog.data.arrangementTypeJsTreeSelect.showInvalidFeedback();
                                         return false;
                                     }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/createArrangementDialog.html
@@ -588,7 +588,7 @@
 
 <script type="module">
     import { JSTreeSelect } from "{% static 'js/jsTreeSelect.js' %}";
-    import { Popover } from "{% static 'js/popover.js' %}"
+    import { Popover } from "{% static 'js/popover.js' %}";
 
     $(document).ready(function () {
         let createArrangementDialogApp = Vue.createApp({

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -10,13 +10,13 @@
     <input type="hidden" id="_backingArrangementTypeId" />
     <input type="hidden" id="_statusTypeId" />
 
-    <input type="hidden" id="_serie_reference">
-    <input type="hidden" id="_serie_position_hash" name="">
-    <input type="hidden" id="_parent_serie_position_hash" name="">
+    <input type="hidden" id="_serie_reference" v-model="activity.serie_uuid">
+    <input type="hidden" id="_serie_position_hash" v-model="activity.serie_position_hash">
+    <input type="hidden" id="_parent_serie_position_hash" v-model="activity.parent_serie_position_hash">
 
-    <input type="hidden" id="start_before_collision_resolution">
-    <input type="hidden" id="end_before_collision_resolution">
-    <input type="hidden" id="title_before_collision_resolution" name="">
+    <input type="hidden" id="start_before_collision_resolution" v-model="activity.start_before_collision_resolution">
+    <input type="hidden" id="end_before_collision_resolution" v-model="activity.end_before_collision_resolution">
+    <input type="hidden" id="title_before_collision_resolution" v-model="activity.title_before_collision_resolution">
 
     <div class="clearfix">
         <div class="float-start">
@@ -36,7 +36,7 @@
         <div id="step-1">
             <form id="newSimpleActivityForm">
                 <input type="submit" name="submit" style="display:none;" />
-                <input type="hidden" name="uuid" id="event_uuid" />
+                <input type="hidden" name="uuid" id="event_uuid" v-model="activity._uuid" />
                 
                 <div class="form-group mb-2">
                     <label class="form-label" for="title">
@@ -58,7 +58,7 @@
                     icon="fas fa-users"
                     button-label="Velg målgruppe"
                     :selected="activity.audience"
-                    @input="(id) => activity.audience = id">
+                    @input="(id, name) => { activity.audience = id; activity.audienceName = name; }">
                 </tree-select-component>
 
                 <tree-select-component
@@ -68,7 +68,7 @@
                     icon="fas fa-cog"
                     button-label="Velg arrangementstype"
                     :selected="activity.arrangement_type"
-                    @input="(id) => activity.arrangement_type = id">
+                    @input="(id, name) => { activity.arrangement_type = id; activity.arrangementTypeName = name; }">
                 </tree-select-component>
 
                 <tree-select-component
@@ -78,7 +78,7 @@
                     icon="fas fa-cog"
                     button-label="Velg status"
                     :selected="activity.status"
-                    @input="(id) => activity.status = id">
+                    @input="(id, name) => { activity.status = id; activity.statusName = name; }">
                 </tree-select-component>
     
                 <div class="form-group mt-2">
@@ -89,12 +89,12 @@
                     <div class="row">
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="date" id="fromDate" name="fromDate" class="form-control form-control-lg" v-model="activity.from_date" required />
+                                <input type="date" id="fromDate" name="fromDate" class="form-control form-control-lg" v-model="activity.fromDate" required />
                             </div>
                         </div>
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="time" id="fromTime" name="fromTime" class="form-control form-control-lg" v-model="activity.from_time" required />
+                                <input type="time" id="fromTime" name="fromTime" class="form-control form-control-lg" v-model="activity.fromTime" required />
                             </div>
                         </div>
                     </div>
@@ -108,12 +108,12 @@
                     <div class="row">
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="date" id="toDate" name="toDate" class="form-control form-control-lg" v-model="activity.to_date" required />
+                                <input type="date" id="toDate" name="toDate" class="form-control form-control-lg" v-model="activity.toDate" required />
                             </div>
                         </div>
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="time" id="toTime" name="toTime" class="form-control form-control-lg" v-model="activity.to_time" required />
+                                <input type="time" id="toTime" name="toTime" class="form-control form-control-lg" v-model="activity.toTime" required />
                             </div>
                         </div>
                     </div>
@@ -419,7 +419,7 @@
             <div class="form-group mt-2">
                 <label for="{{form.meeting_place.id_for_label}}">{{form.meeting_place.label}}</label>
                 <input type="text" 
-                    name="{{form.meeting_place.name}}" 
+                    name="{{form.meeting_place.name}}"
                     id="{{form.meeting_place.id_for_label}}" 
                     class="form-control"
                     v-model="activity.meeting_place">
@@ -435,7 +435,7 @@
             </div>
         </div>
     </div>
-
+    
     <div class="clearfix">
         <div class="float-start">
             <button class="btn wb-btn-blank btn-lg text-muted"
@@ -481,11 +481,21 @@
                     mainPlannerPopover: null,
 
                     activity: {
+                        _uuid: null,
+                        arrangement: 0,
+                        serie_position_hash: null,
+                        parent_serie_position_hash: null,
+                        title_before_collision_resolution: null,
+                        serie_uuid: null,
                         id: null,
                         title: null,
                         title_en: null,
                         ticket_code: null,
-                        participants: null,
+                        fromDate: null,
+                        fromTime: null,
+                        toDate: null,
+                        toTime: null,
+                        expected_visitors: null,
                         buffer_before_title: null,
                         buffer_after_title: null,
                         buffer_before_date: null,
@@ -495,8 +505,11 @@
                         buffer_after_start: null,
                         buffer_after_end: null,
                         audience: null,
+                        audienceName: "",
                         arrangement_type: null,
+                        arrangementTypeName: "",
                         status: null,
+                        statusName: "",
                         display_layouts: [],
                         display_text: null,
                         meeting_place: null,
@@ -757,8 +770,20 @@
                                 console.warn("Validation failed.")
                                 return;
                             }
-            
-            
+                            
+
+                            let qualifiedEvent = dialog.vueApp.activity;
+                            qualifiedEvent.responsible = qualifiedEvent.main_planner.id;
+                            qualifiedEvent.room_payload = dialog.data.roomPayload;
+                            qualifiedEvent.planner_payload = dialog.data.mainPlannerPayload;
+                            qualifiedEvent.ordered_services = qualifiedEvent.serviceOrders; //rename
+                            qualifiedEvent.start = new Date(qualifiedEvent.fromDate + "T" + qualifiedEvent.fromTime);
+                            qualifiedEvent.end = new Date(qualifiedEvent.toDate + "T" + qualifiedEvent.toTime);                            
+
+                            qualifiedEvent.room_name_map = dialog.data.roomsNameMap;
+                            qualifiedEvent.rooms = qualifiedEvent.rooms.map(room => room.id);
+
+                            /* 
                             let qualifiedEvent = {
                                 _uuid:                      dialog.interior.event_uuid.value,
                                 title:                      dialog.interior.title.value,
@@ -795,17 +820,9 @@
                                 start_before_collision_resolution: dialog.interior.start_before_collision_resolution.value,
                                 end_before_collision_resolution: dialog.interior.end_before_collision_resolution.value,
                                 title_before_collision_resolution: dialog.interior.title_before_collision_resolution.value,
-                            };
-            
-                            let statusValue = dialog.data.statusTypeJsTreeSelect.getSelectedValue();
-                            if (statusValue !== undefined)
-                                qualifiedEvent.status = statusValue;
+                            }; */
             
                             console.log("qualifiedEvent", qualifiedEvent);
-            
-                            qualifiedEvent.display_layouts = 
-                                [...dialog.querySelectorAll("input[name='display_layouts_create_event'][type='checkbox']:checked")]
-                                    .map(element => element.value);
             
                             dialog.raiseSubmitEvent({
                                 event: qualifiedEvent,
@@ -870,6 +887,18 @@
                     when: [
                         { eventKnownAs: "populateDialogWithEvent", do: (dialog, payload) => {
                             console.log("populateDialogWithEvent", payload);
+
+                            dialog.vueApp.activity.title = payload.title;
+                            dialog.vueApp.activity.title_en = payload.title_english;
+                            dialog.vueApp.activity.ticket_code = payload.ticket_code;
+                            dialog.vueApp.activity.expected_visitors = payload.expected_visitors;
+                            dialog.vueApp.activity.audience = payload.audience;
+                            dialog.vueApp.activity.arrangement_type = payload.arrangement_type;
+                            dialog.vueApp.activity.status = payload.status;
+                            dialog.vueApp.activity.meeting_place = payload.meeting_place;
+                            dialog.vueApp.activity.meeting_place_en = payload.meeting_place_en;
+                            dialog.vueApp.activity.display_layouts = payload.display_layouts;
+                            dialog.vueApp.activity.display_text = payload.display_text;
                         } },
                         { eventKnownAs: "newServiceOrder", do: (dialog, payload) => {
                             // this stuff needs to be rewritten along with the other similar methods

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -172,7 +172,23 @@
                         Velg rom
                     </button>
                 </div>
-                <div id="selectedRoomsWrapper" class="chipsList"></div>
+                <div id="selectedRoomsWrapper" class="chipsList">
+                    <span v-for="room in rooms">
+                        <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
+                            [[room.text]]
+                            
+                            <a href="#">
+                                <i class="fa fa-times text-danger"
+                                    :id="room.id"
+                                    select-type="room"
+                                    @click="rooms.splice(rooms.indexOf(room), 1)"
+                                    d-trigger="removeAssociation">
+
+                                </i>
+                            </a>
+                        </div>
+                    </span>
+                </div>
             </div>
 
             <div class="form-group mb-2">
@@ -822,19 +838,6 @@
                             }
                         } },
                         { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
-                            let wrapper = dialog.$('#selectedRoomsWrapper');
-                            wrapper.empty();
-            
-                            payload.viewables.forEach((room) => {
-                                wrapper.append(
-                                    $(`<selected-pill name='${room.text}'
-                                                      id='${room.id}'
-                                                      class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
-                                                      d-trigger='removeAssociation'>
-                                       </selected-pill>`)    
-                                );
-                            });
-            
                             dialog.data.selectedRoomIds = new Map();
                             dialog.data.roomPresets = new Map();
                             payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -43,12 +43,12 @@
                         Tittel <i>(Norsk)</i>
                         <span class="fw-bold">&nbsp;*</span>
                     </label>
-                    <input type="text" id="title" name="title" class="form-control form-control-lg" required />
+                    <input type="text" id="title" name="title" v-model="activity.title" class="form-control form-control-lg" required />
                 </div>
 
                 <div class="form-group mb-2">
                     <label class="form-label" for="title_en">Tittel <i>(Engelsk)</i></label>
-                    <input type="text" id="title_en" name="title_en" class="form-control form-control-lg" />
+                    <input type="text" id="title_en" name="title_en" v-model="activity.title_en" class="form-control form-control-lg" />
                 </div>
 
                 <tree-select-component
@@ -89,12 +89,12 @@
                     <div class="row">
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="date" id="fromDate" name="fromDate" class="form-control form-control-lg" required />
+                                <input type="date" id="fromDate" name="fromDate" class="form-control form-control-lg" v-model="activity.from_date" required />
                             </div>
                         </div>
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="time" id="fromTime" name="fromTime" class="form-control form-control-lg" required />
+                                <input type="time" id="fromTime" name="fromTime" class="form-control form-control-lg" v-model="activity.from_time" required />
                             </div>
                         </div>
                     </div>
@@ -108,12 +108,12 @@
                     <div class="row">
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="date" id="toDate" name="toDate" class="form-control form-control-lg" required />
+                                <input type="date" id="toDate" name="toDate" class="form-control form-control-lg" v-model="activity.to_date" required />
                             </div>
                         </div>
                         <div class="col-6">
                             <div class="form-outline">
-                                <input type="time" id="toTime" name="toTime" class="form-control form-control-lg" required />
+                                <input type="time" id="toTime" name="toTime" class="form-control form-control-lg" v-model="activity.to_time" required />
                             </div>
                         </div>
                     </div>
@@ -131,14 +131,14 @@
                 <input type="hidden" 
                     name="{{ form.responsible.name }}" 
                     id="{{ form.responsible.id_for_label }}"
-                    v-model="mainPlanner.id">
+                    v-model="activity.main_planner.id">
 
                 <label for="" class="d-block form-label">
                     <i class="fas fa-star"></i>
                     Hovedplanlegger
                 </label>
 
-                <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
+                <h5 class="mb-2">[[ activity.main_planner.text ]]</h5>
                 <button class="wb-btn-main"
                     id="setMainPlannerButton"
                     type="button">
@@ -211,7 +211,7 @@
                     </button>
                 </div>
                 <div id="selectedRoomsWrapper" class="chipsList">
-                    <span v-for="room in rooms">
+                    <span v-for="room in activity.rooms">
                         <div class="bg-white p-2 rounded-3 me-2 mt-1 border border-dark">
                             [[room.text]]
                             
@@ -234,7 +234,7 @@
                     <i class="fas fa-receipt"></i>&nbsp;
                     Billettkode
                 </label>
-                <input type="text" id="ticket_code" name="ticket_code" class="form-control form-control-lg" />
+                <input type="text" id="ticket_code" name="ticket_code" v-model="activity.ticket_code" class="form-control form-control-lg" />
             </div>
 
             <div class="form-group mb-2">
@@ -242,7 +242,7 @@
                     <i class="fas fa-users"></i>
                     Forventet besøkende
                 </label>
-                <input type="text" id="expected_visitors" name="expected_visitors" class="form-control form-control-lg" required />
+                <input type="text" id="expected_visitors" name="expected_visitors" v-model="activity.expected_visitors" class="form-control form-control-lg" required />
             </div>
         </div>
         <div id="step-services">
@@ -264,7 +264,7 @@
             <div id="serviceOrders" class="mb-2">
                 <div
                     class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' :id="order.key"
-                    v-for="order in serviceOrders">
+                    v-for="order in activity.serviceOrders">
                     
                     <h5>
                         [[order.service_name]]
@@ -296,21 +296,21 @@
                         <th colspan="3" class="h4">Opprigg før aktiviteten:</th>
                     </tr>
                     <tr style="border-bottom:none;">
-                       <td colspan="2" style="border: none;">
+                        <td colspan="2" style="border: none;">
                         <div>
                             <label for="buffer_before_title" class="form-label">
                                 Tittel
                             </label>
-                            <input type="text" class="form-control form-control-lg" id="buffer_before_title" placeholder="Tittel... (valgfritt)">
+                            <input type="text" v-model="activity.buffer_before_title" class="form-control form-control-lg" id="buffer_before_title" placeholder="Tittel... (valgfritt)">
                         </div>
 
                         <div class="mt-2">
                             <label for="buffer_before_date" class="form-label">
                                 Dato
                             </label>
-                            <input type="date" id="buffer_before_date" class="form-control form-control-lg">
+                            <input type="date" v-model="activity.buffer_before_date" id="buffer_before_date" class="form-control form-control-lg">
                         </div>
-                       </td> 
+                        </td> 
                     </tr>
                     <tr>
                         <td style="padding-top: 0;">
@@ -318,7 +318,7 @@
                                 Fra
                             </label>
                             <div class="form-outline">
-                                <input type="time" id="buffer_before_start" name="buffer_before_start" class="form-control form-control-lg" />
+                                <input type="time" id="buffer_before_start" v-model="activity.buffer_before_start" name="buffer_before_start" class="form-control form-control-lg" />
                             </div>
                         </td>
                         <td style="padding-top: 0;">
@@ -326,7 +326,7 @@
                                 Til
                             </label>
                             <div class="form-outline">
-                                <input type="time" id="buffer_before_end" name="buffer_before_end" class="form-control form-control-lg" />
+                                <input type="time" id="buffer_before_end" v-model="activity.buffer_before_end" name="buffer_before_end" class="form-control form-control-lg" />
                             </div>  
                         </td>
                     </tr>
@@ -343,28 +343,28 @@
                     </tr>
                     <tr style="border-bottom:none;">
                         <td colspan="2" style="border: none;">
-                         <div>
+                            <div>
                             <label for="after_buffer_title" class="form-label">
                                 Tittel
                             </label>
-                             <input type="text" class="form-control form-control-lg" id="buffer_after_title" placeholder="Tittel... (valgfritt)">
-                         </div>
- 
-                         <div class="mt-2">
+                                <input type="text" v-model="activity.buffer_after_title" class="form-control form-control-lg" id="buffer_after_title" placeholder="Tittel... (valgfritt)">
+                            </div>
+    
+                            <div class="mt-2">
                             <label for="" class="form-label">
                                 Dato
                             </label>
-                            <input type="date" name="" class="form-control form-control-lg" id="buffer_after_date">
-                         </div>
+                            <input type="date" v-model="activity.buffer_after_date" class="form-control form-control-lg" id="buffer_after_date">
+                            </div>
                         </td> 
-                     </tr>
+                        </tr>
                     <tr>
                         <td style="padding-top: 0;">
                             <label for="buffer_after_start" class="form-label">
                                 Fra
                             </label>
                             <div class="form-outline">
-                                <input type="time" id="buffer_after_start" name="buffer_after_start" class="form-control form-control-lg" />
+                                <input type="time" id="buffer_after_start" v-model="activity.buffer_after_start" name="buffer_after_start" class="form-control form-control-lg" />
                             </div>
                         </td>
                         <td style="padding-top:0;">
@@ -372,7 +372,7 @@
                                 Til
                             </label>
                             <div class="form-outline">
-                                <input type="time" id="buffer_after_end" name="buffer_after_end" class="form-control form-control-lg" />
+                                <input type="time" id="buffer_after_end" v-model="activity.buffer_after_end" name="buffer_after_end" class="form-control form-control-lg" />
                             </div>
                         </td>
                     </tr>
@@ -395,7 +395,8 @@
                         <label class="d-block form-label"><i class='fas fa-desktop text-muted'></i>&nbsp; {% trans "Vises på:" %}</label>
                         <ul>
                             {% for choice_id, choice_label in form.display_layouts.field.choices %}
-                                <li class='your class'> <input type="checkbox" value="{{choice_id}}" name="display_layouts_create_event" id="{{choice_id}}_dlcheck" />
+                                <li class='your class'> <input type="checkbox" value="{{choice_id}}" name="display_layouts_create_event" id="{{choice_id}}_dlcheck"
+                                    v-model="activity.display_layouts" />
                                 <label for="{{choice_id}}_dlcheck">{{choice_label}}</label></li>
                             {% endfor %}
                         </ul>
@@ -403,20 +404,34 @@
                     {% endif %}
                 </div>
                 <div class="col-lg-8 col-sm-12 mt-sm-2">
-                    <div class="form-group" id="display-layout-text-group" style="display: none;">
-                        <div>
-                            {{ form.display_text|as_crispy_field }}
+                    <div class="form-group" id="display-layout-text-group">
+                        <div v-show="showDisplayText">
+                            <input type="text" name="{{form.display_text.name}}"
+                                class="form-control form-control-lg"
+                                id="{{form.display_text.id_for_label}}"
+                                v-model="activity.display_text"
+                                placeholder="Skjermtekst...">
                         </div>
                     </div>
                 </div>
             </div>
 
             <div class="form-group mt-2">
-                {{ form.meeting_place | as_crispy_field }}
+                <label for="{{form.meeting_place.id_for_label}}">{{form.meeting_place.label}}</label>
+                <input type="text" 
+                    name="{{form.meeting_place.name}}" 
+                    id="{{form.meeting_place.id_for_label}}" 
+                    class="form-control"
+                    v-model="activity.meeting_place">
             </div>
 
             <div class="form-group mt-2 mb-2">
-                {{ form.meeting_place_en | as_crispy_field }}
+                <label for="{{form.meeting_place_en.id_for_label}}">{{form.meeting_place_en.label}}</label>
+                <input type="text" 
+                    name="{{form.meeting_place_en.name}}" 
+                    id="{{form.meeting_place_en.id_for_label}}" 
+                    class="form-control"
+                    v-model="activity.meeting_place_en">
             </div>
         </div>
     </div>
@@ -461,7 +476,6 @@
             data() {
                 return {
                     dialog: null,
-                    mainPlanner: { id: null, text: null },
                     mainPlannerSearchTerm: null,
                     mainPlannerSearchResults: [],
                     mainPlannerPopover: null,
@@ -470,12 +484,8 @@
                         id: null,
                         title: null,
                         title_en: null,
-                        start: null,
-                        end: null,
                         ticket_code: null,
                         participants: null,
-                        buffer_before: null,
-                        buffer_after: null,
                         buffer_before_title: null,
                         buffer_after_title: null,
                         buffer_before_date: null,
@@ -494,9 +504,28 @@
                         serviceOrders: [],
                         rooms: [],
                         planners: [],
-                        main_planner: null,
+                        main_planner: { id: null, text: null },
                     },
                 }
+            },
+            computed: {
+                showDisplayText() {
+                    let displayLayoutsWithRequisiteText = new Map([
+                        {% for display_layout in DISPLAY_LAYOUTS_WITH_REQUISITE_TEXT %}
+                            [ "{{ display_layout.id }}", true],
+                        {% endfor %}
+                    ]);
+
+                    let showDisplayText = false;
+
+                    this.activity.display_layouts.forEach((displayLayout) => {
+                        if (displayLayoutsWithRequisiteText.has(displayLayout)) {
+                            showDisplayText = true;
+                        }
+                    });
+
+                    return showDisplayText;
+                },
             },
             methods: {
                 /**
@@ -538,7 +567,7 @@
                     this.openDialog("orderServiceDialog", { multiple: false, data: { whenEventName: "newServiceOrder" }, entity_type: "unknown", entity_id: "0" });
                 },
                 setMainPlanner(planner) {
-                    this.mainPlanner = { id: planner.id, text: planner.full_name };
+                    this.activity.main_planner = { id: planner.id, text: planner.full_name };
 
                     this.dialog.data.mainPlannerPayload = {
                         allPresets: new Map(),
@@ -849,23 +878,10 @@
                             dialog.data.servicePresets = new Map((payload.concat(
                                 Array.from(dialog.data.servicePresets.values())
                             )).map(x => [crypto.randomUUID(), x]));
-            
-                            let wrapper = dialog.$('#serviceOrders');
-                            wrapper.empty();
                             
-                            for (const [key, value] of dialog.data.servicePresets) {
-                                wrapper.append(
-                                    $(`<div class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' id="${key}">
-                                        <h5>
-                                            ${value.service_name}
-                                            <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end'  id="${key}" select-type='serviceOrder' d-trigger="removeAssociation"><i class='fas fa-times'></i></button>
-                                        </h5>
-                                        <code>
-                                            ${value.freetext_comment}
-                                        </code>
-                                    </div>`)
-                                );
-                            }
+                            dialog.vueApp.activity.serviceOrders = 
+                                Array.from(dialog.data.servicePresets.entries())
+                                .map(x => { return { key: x[0], ...x[1] } });
                         } },
                         { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
                             dialog.data.selectedRoomIds = new Map();
@@ -875,7 +891,7 @@
             
                             dialog.data.roomPayload = payload;
 
-                            dialog.vueApp.rooms = payload.viewables;
+                            dialog.vueApp.activity.rooms = payload.viewables;
                         } },
                         { eventKnownAs: "setPlanner", do: (dialog, payload) => {
                             if (payload.allSelectedEntityIds.length == 0)
@@ -884,7 +900,7 @@
                             const person = payload.viewables[0];
             
                             dialog.data.mainPlannerPayload = payload;
-                            dialog.vueApp.mainPlanner = { id: person.id, text: person.text }
+                            dialog.vueApp.activity.main_planner = { id: person.id, text: person.text }
 
                             dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
                             dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
@@ -907,21 +923,6 @@
                             else
                                 dialog.$('#_statusTypeId').val(payload);
                         } },
-                    ],
-                    plugins: [
-                        {
-                            name: 'showIfSelected',
-                            pluginClass: DialogShowIfSelectedPlugin,
-                            args: {
-                                checkboxesSelector: "[name='display_layouts_create_event']",
-                                elementToShowOrHide: ( dialog ) => { return dialog.getElementById('display-layout-text-group'); },
-                                showIfAnyOfTheseValuesMap: new Map([
-                                    {% for display_layout in DISPLAY_LAYOUTS_WITH_REQUISITE_TEXT %}
-                                        [ "{{ display_layout.id }}", true],
-                                    {% endfor %}
-                                ]),
-                            },
-                        }
                     ],
                 });
             }

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -168,7 +168,7 @@
                 <div>
                     <button class="wb-btn-main"
                         type="button"
-                        d-trigger="triggerAddRooms">
+                        @click="openAddRoomsDialog()">
                         Velg rom
                     </button>
                 </div>
@@ -195,7 +195,7 @@
             <div class="clearfix">
                 <a class="btn btn-lg btn-outline-dark btn-block shadow-0 mb-2 p-2"
                     style="text-transform: none; font-size: larger; border-width: 0.7px;"
-                    d-trigger="triggerNewServiceOrder">
+                    @click="openAddServiceOrderDialog()">
                     <i class="fas fa-calendar-plus"></i>&nbsp;
                     Bestill tjenester
                 </a>
@@ -382,423 +382,518 @@
     import { JSTreeSelect } from "{% static 'js/jsTreeSelect.js' %}";
     import { DateExtensions } from "{% static 'modules/planner/seriesutil.js' %}";
 
-    new Dialog({
-        dialogId: '{{ dialogId }}',
-        managerName: '{{ managerName }}',
-        discriminator: '{{ discriminator }}',
-        postInit: function (dialog) {
-            document.querySelectorAll('.form-outline').forEach((formOutline) => {
-                new mdb.Input(formOutline).init();
-            });
-
-            dialog.$('#fromDate').on('change', (e) => {
-                dialog.interior.buffer_before_date.value = e.target.value;
-            });
-            dialog.$('#toDate').on('change', (e) => {
-                dialog.interior.buffer_after_date.value = e.target.value;
-            });
-
-            dialog.data.audienceJsTreeSelect = new JSTreeSelect({
-                element: dialog.querySelector('#audience_jstree_select'),
-                treeJsonSrcUrl: "/arrangement/audience/tree",
-                initialSelected: dialog.getElementById('_backingAudienceId').value ? { id: dialog.getElementById('_backingAudienceId').value } : undefined,
-                valueSelectedLabelText: ( selected ) => {
-                    let labelText = '';
-
-                    if (selected.parent && selected.parent.text)
-                        labelText += (selected.parent.text + " | ");
-                    
-                    labelText += selected.text;
-
-                    return labelText;
-                },
-                noneSelectedLabelText: "Ingen målgruppe valgt ennå",
-                selectFirstTimeButtonText: 'Velg målgruppe',
-                changeSelectedValueButtonText: 'Endre målgruppe',
-                popoverSaveChoicesButtonText: 'Lagre valg',
-            });
-
-            dialog.data.arrangementTypeJsTreeSelect = new JSTreeSelect({
-                element: dialog.querySelector('#arrangement_type_jstree_select'),
-                treeJsonSrcUrl: '/arrangement/arrangementtype/treelist',
-                initialSelected: dialog.getElementById('_backingArrangementTypeId').value ? { id: dialog.getElementById('_backingArrangementTypeId').value } : undefined,
-                valueSelectedLabelText: ( selected ) => {
-                    let labelText = '';
-
-                    if (selected.parent && selected.parent.text)
-                        labelText += (selected.parent.text + " | ");
-                    
-                    labelText += selected.text;
-
-                    return labelText;
-                },
-                noneSelectedLabelText: "Ingen arrangementstype valgt ennå",
-                selectFirstTimeButtonText: 'Velg arrangementstype',
-                changeSelectedValueButtonText: 'Endre arrangementstype',
-                popoverSaveChoicesButtonText: 'Lagre valg',
-            });
-            dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
-                element: dialog.querySelector('#status_type_jstree_select'),
-                treeJsonSrcUrl: "/arrangement/statustype/tree",
-                initialSelected: dialog.getElementById('_statusTypeId').value ? { id: dialog.getElementById('_statusTypeId').value } : undefined,
-                onValueSet: ( data ) => {
-                    dialog.getElementById('_statusTypeId').value = data.selected[0];
-                },
-                valueSelectedLabelText: ( selected ) => {
-                    let labelText = '';
-
-                    if (selected.parent && selected.parent.text)
-                        labelText += (selected.parent.text + " | ");
-
-                    labelText += selected.text;
-                    
-                    return labelText;
-                },
-                noneSelectedLabelText: "Ingen status valgt ennå",
-                selectFirstTimeButtonText: 'Velg status',
-                changeSelectedValueButtonText: 'Endre status',
-                popoverSaveChoicesButtonText: 'Lagre valg',
-            });
-
-            dialog.$("#fromTime").on("change", (event) => {
-                dialog.$("#buffer_before_end").val(event.target.value);
-            });
-            dialog.$("#toTime").on("change", (event) => {
-                dialog.$("#buffer_after_start").val(event.target.value);
-            });
-
-            document.addEventListener("{{managerName}}.d1_roomsSelected", (e) => {
-                dialog.data.roomsNameMap = e.detail.context.room_name_map;
-                dialog.setRooms({ rooms: e.detail.context.rooms });
-
-                dialog.$("#roomsCounter").text(dialog.$("#selectedRoomsWrapper").children().length);
-            });
-
-            dialog.data.stepper = new DialogStepper({
-                allowRailBasedNavigation: true,
-                railWrapperElement: dialog.getElementById('stepper'),
-                steps: [
-                    {
-                        element: dialog.getElementById('step-1'),
-                        title: 'Detaljer',
-                        stepIn: () => { console.log("1. Step In") },
-                        stepOut: () => { 
-                            /** PS!
-                             * Be aware that this will cause issues the moment you have inputs or selects
-                             * that are not in step-1. As of the writing of this comment all the fields we care
-                             * about validating are in step-1, so we can blanket-validate it like this.
-                             * This is not the case if you add input or selects to any other steps - and this will
-                             * prevent progression to further steps, until the inputs in those future steps are considered
-                             * valid, which is of course impossible, since one can not reach them due to this blanket-validation.
-                             * */                            
-                            if (dialog.validate() === false)
-                                return false;
-
-                            const fromDateTime = DateExtensions.OverwriteDateTimeWithTimeInputValue(
-                                dialog.interior.fromDate.value,
-                                dialog.interior.fromTime.value,
-                            )
-                            const toDateTime = DateExtensions.OverwriteDateTimeWithTimeInputValue(
-                                dialog.interior.toDate.value,
-                                dialog.interior.toTime.value,
-                            )
-
-                            if (fromDateTime >= toDateTime){
-                                $('#eventTimesInvalidFeedback').show();
-
-                                return false;
-                            }
-
-                            $('#eventTimesInvalidFeedback').hide();
-
-                            return true;
-                        }
-                    },
-                    {
-                        element: dialog.getElementById('step-2'),
-                        title: 'Rom & Personer',
-                        stepIn: () => { console.log("1. Step In") },
-                        stepOut: () => { console.log("2. Step Out"); }
-                    },
-                    {
-                        element: dialog.getElementById('step-services'),
-                        title: 'Tjenestebestillinger',
-                        stepIn: () => { },
-                        stepout: () => { },
-                    },
-                    {
-                        element: dialog.getElementById('step-3'),
-                        title: 'Opp og ned-rigg',
-                        visible: {% if HIDE_RIGGING %}false{% else %}true{% endif %},
-                        stepIn: () => {},
-                        stepOut: (isSteppingForwards) => {
-                            let isValid = true;
-                            if (dialog.interior.buffer_before_start.value &&
-                                dialog.interior.buffer_before_end.value)
-                                if (dialog.interior.buffer_before_start.value > dialog.interior.buffer_before_end.value) {
-                                    dialog.$('#beforeRiggingTimesInvalidFeedback').show();
-                                    isValid = false;
-                                }
-                                else {
-                                    dialog.$('#beforeRiggingTimesInvalidFeedback').hide();
-                                }
-                            if (dialog.interior.buffer_after_start.value &&
-                                dialog.interior.buffer_after_end.value)
-                                if (dialog.interior.buffer_after_start.value > dialog.interior.buffer_after_end.value) {
-                                    dialog.$('#afterRiggingTimesInvalidFeedback').show();
-                                    isValid = false;
-                                }
-                                else {
-                                    dialog.$('#afterRiggingTimesInvalidFeedback').hide();
-                                }
-                            
-                            if (isValid === true) {
-                                dialog.$('#beforeRiggingTimesInvalidFeedback').hide();
-                                dialog.$('#afterRiggingTimesInvalidFeedback').hide();
-                            }
-
-                            return isValid;
-                        },
-                    },
-                    {
-                        element: dialog.getElementById('step-4'),
-                        title: 'Skjermer',
-                        stepIn: () => { 
-                            dialog.getElementById('next').style.display = "none";
-                            dialog.getElementById('finish').style.display = "inline-block";
-                        },
-                        stepOut: () => {
-                            dialog.getElementById('finish').style.display = "none";
-                            dialog.getElementById('next').style.display = "inline-block";
-                        },
-                    },
-                ]
-            });
-            dialog.getElementById('next').onclick = () => dialog.data.stepper.next();
-            dialog.getElementById('back').onclick = () => dialog.data.stepper.back();
-        },
-        methods: {
-            close(dialog, {} = {}, triggeredByElement) {
-                dialog.closeMe();
-            },
-            submit(dialog, {} = {}, triggeredByElement) {
-                if (dialog.validate() === false) {
-                    console.warn("Validation failed.")
-                    return;
+    $(document).ready(function() {
+        let createActivityDialog = Vue.createApp({
+            components: {},
+            data() {
+                return {
+                    dialog: null,
+                    events: [],
+                    series: [],
+                    serviceOrders: [],
+                    rooms: [],
+                    planners: [],
+                    mainPlanner: { id: null, text: null },
+                    mainPlannerSearchTerm: null,
+                    mainPlannerSearchResults: [],
+                    mainPlannerPopover: null
                 }
-
-
-                let qualifiedEvent = {
-                    _uuid:                      dialog.interior.event_uuid.value,
-                    title:                      dialog.interior.title.value,
-                    title_en:                   dialog.interior.title_en.value,
-                    ticket_code:                dialog.interior.ticket_code.value,
-                    expected_visitors:          dialog.interior.expected_visitors.value,
-                    audience:                   dialog.data.audienceJsTreeSelect.getSelectedValue(),
-                    audienceName:               dialog.data.audienceJsTreeSelect.getSelectedText(),
-                    arrangement_type:           dialog.data.arrangementTypeJsTreeSelect.getSelectedValue(),
-                    arrangementTypeName:        dialog.data.arrangementTypeJsTreeSelect.getSelectedText(),     
-                    start:                      new Date( dialog.interior.fromDate.value   + "T" + dialog.interior.fromTime.value ),
-                    end:                        new Date( dialog.interior.toDate.value     + "T" + dialog.interior.toTime.value ),
-                    arrangement:                0,
-                    rooms:                      Array.from(dialog.data.selectedRoomIds.keys()),
-                    room_name_map:              dialog.data.roomsNameMap,       // Kept due to edit - not pertinent for save
-                    before_buffer_title:        dialog.interior.buffer_before_title.value ?? "",
-                    before_buffer_date:         dialog.interior.buffer_before_date.value,
-                    before_buffer_start:        dialog.interior.buffer_before_start.value ?? "",
-                    before_buffer_end:          dialog.interior.buffer_before_end.value ?? "",
-                    after_buffer_title:         dialog.interior.buffer_after_title.value ?? "",
-                    after_buffer_date:          dialog.interior.buffer_after_date.value,
-                    after_buffer_start:         dialog.interior.buffer_after_start.value ?? "",
-                    after_buffer_end:           dialog.interior.buffer_after_end.value ?? "",
-                    meeting_place:              dialog.interior.id_meeting_place.value,
-                    meeting_place_en:           dialog.interior.id_meeting_place_en.value,
-                    responsible:                dialog.interior.id_responsible.value,
-                    display_text:               dialog.plugins.showIfSelected.isInShowState() ? dialog.interior.id_display_text.value : '',
-                    room_payload:               dialog.data.roomPayload,
-                    planner_payload:            dialog.data.mainPlannerPayload,
-                    ordered_services:           Array.from(dialog.data.servicePresets.values()),
-                    serie_uuid:                 dialog.interior._serie_reference.value,
-                    serie_position_hash:        dialog.interior._serie_position_hash.value,
-                    parent_serie_position_hash: dialog.interior._parent_serie_position_hash.value,
-                    start_before_collision_resolution: dialog.interior.start_before_collision_resolution.value,
-                    end_before_collision_resolution: dialog.interior.end_before_collision_resolution.value,
-                    title_before_collision_resolution: dialog.interior.title_before_collision_resolution.value,
-                };
-
-                let statusValue = dialog.data.statusTypeJsTreeSelect.getSelectedValue();
-                if (statusValue !== undefined)
-                    qualifiedEvent.status = statusValue;
-
-                console.log("qualifiedEvent", qualifiedEvent);
-
-                qualifiedEvent.display_layouts = 
-                    [...dialog.querySelectorAll("input[name='display_layouts_create_event'][type='checkbox']:checked")]
-                        .map(element => element.value);
-
-                dialog.raiseSubmitEvent({
-                    event: qualifiedEvent,
-                    csrf_token: '{{csrf_token}}',
-                });
             },
-            validate(dialog, {} = {}, triggeredByElement) {
-                let field_elements = dialog.$('#newSimpleActivityForm').find("input, select");
-                let isInvalid = false;
+            methods: {
+                /**
+                 * @summary Open a dialog, with the option to send data to the dialog 
+                 * @param {string} dialogName
+                 * @param {object} data
+                 */
+                 openDialog(dialogName, data = {}) {
+                    let payload = {
+                        $parent: this.dialog.dialogElement,
+                        sendTo: '{{dialogId}}',
+                        ...data
+                    }
 
-                for (let i = 0; i < field_elements.length; i++) {
-                    if (field_elements[i].checkValidity() === false) {
-                        isInvalid = true;
-                        break;
+                    this.dialog.raiseTriggerEvent("{{managerName}}", dialogName, payload);
+                },
+                                /**
+                * @summary Open dialog for adding new rooms to the arrangement
+                */
+                openAddRoomsDialog(dialog, {} = {}, triggeredByElement) {
+                    this.openDialog("{{orderRoomDialog}}");
+                },
+                /**
+                * @summary Open dialog for adding new planners to the arrangement
+                */
+                openAddPlannersDialog(dialog, {} = {}, triggeredByElement) {
+                    this.openDialog("{{orderPersonDialog}}", { multiple: true, data: { whenEventName: "plannersSelected" } });
+                },
+                /**
+                * @summary Open dialog for setting the main planner
+                */
+                openSetMainPlannerDialog(dialog, {} = {}, triggeredByElement) {
+                    this.openDialog("{{orderPersonDialog}}", { multiple: false, data: { whenEventName: "setPlanner" } });
+                },
+                /**
+                * @summary Open dialog for ordering new services to the arrangement
+                */
+                openAddServiceOrderDialog(dialog, {} = {}, triggeredByElement) {
+                    this.openDialog("orderServiceDialog", { multiple: false, data: { whenEventName: "newServiceOrder" }, entity_type: "unknown", entity_id: "0" });
+                },
+                setMainPlanner(planner) {
+                    this.mainPlanner = { id: planner.id, text: planner.full_name };
+
+                    this.dialog.data.mainPlannerPayload = {
+                        allPresets: new Map(),
+                        allSelectedEntityIds: [ { id: planner.id, text: planner.full_name } ],
+                        selectedPresets: [],
+                        viewables: [ { id: planner.id, text: planner.full_name } ]
+                    }
+
+                    this.mainPlannerPopover.fadeAndHide();
+                }
+            },
+            watch: {
+                mainPlannerSearchTerm: async function (val) {
+                    if (val.length > 2 || val.length == 0) {
+                        await fetch("{% url 'arrangement:person_search_planners_ajax_view' %}?term=" + val, {
+                            method: "GET",
+                            headers: {
+                                "X-CSRFToken": "{{ csrf_token }}",
+                            },
+                        }).then((response) => {
+                            if (response.ok) {
+                                response.json().then((data) => {
+                                    this.mainPlannerSearchResults = JSON.parse(data);
+
+                                    this.mainPlannerSearchResults.forEach((planner) => {
+                                        planner.full_name = [ planner.first_name, planner.middle_name, planner.last_name ].join(" ");
+                                    });
+                                });
+                            }
+                            else {
+                                console.log("HTTP-Error: " + response.status);
+                            }
+                        })
                     }
                 }
-
-                if (isInvalid) {
-                    dialog.$('#newSimpleActivityForm').find(':submit').click();
-                    return false;
-                }
-
-                return true;
             },
-            removeAssociation(dialog, {} = {}, triggeredByElement) {
-                const itemId = triggeredByElement.id;
-                const type = triggeredByElement.getAttribute("select-type");
+            delimiters: ['[[', ']]'],
+            mounted() {
+                this.mainPlannerSearchTerm = "";
 
-                let mapOfSelectedItemIds = null;
-                let appropriatePresetMap = null;
+                this.dialog = new Dialog({
+                    vueApp: this,
+                    dialogId: '{{ dialogId }}',
+                    managerName: '{{ managerName }}',
+                    discriminator: '{{ discriminator }}',
+                    postInit: function (dialog) {
+                        document.querySelectorAll('.form-outline').forEach((formOutline) => {
+                            new mdb.Input(formOutline).init();
+                        });
+            
+                        dialog.$('#fromDate').on('change', (e) => {
+                            dialog.interior.buffer_before_date.value = e.target.value;
+                        });
+                        dialog.$('#toDate').on('change', (e) => {
+                            dialog.interior.buffer_after_date.value = e.target.value;
+                        });
+            
+                        dialog.data.audienceJsTreeSelect = new JSTreeSelect({
+                            element: dialog.querySelector('#audience_jstree_select'),
+                            treeJsonSrcUrl: "/arrangement/audience/tree",
+                            initialSelected: dialog.getElementById('_backingAudienceId').value ? { id: dialog.getElementById('_backingAudienceId').value } : undefined,
+                            valueSelectedLabelText: ( selected ) => {
+                                let labelText = '';
+            
+                                if (selected.parent && selected.parent.text)
+                                    labelText += (selected.parent.text + " | ");
+                                
+                                labelText += selected.text;
+            
+                                return labelText;
+                            },
+                            noneSelectedLabelText: "Ingen målgruppe valgt ennå",
+                            selectFirstTimeButtonText: 'Velg målgruppe',
+                            changeSelectedValueButtonText: 'Endre målgruppe',
+                            popoverSaveChoicesButtonText: 'Lagre valg',
+                        });
+            
+                        dialog.data.arrangementTypeJsTreeSelect = new JSTreeSelect({
+                            element: dialog.querySelector('#arrangement_type_jstree_select'),
+                            treeJsonSrcUrl: '/arrangement/arrangementtype/treelist',
+                            initialSelected: dialog.getElementById('_backingArrangementTypeId').value ? { id: dialog.getElementById('_backingArrangementTypeId').value } : undefined,
+                            valueSelectedLabelText: ( selected ) => {
+                                let labelText = '';
+            
+                                if (selected.parent && selected.parent.text)
+                                    labelText += (selected.parent.text + " | ");
+                                
+                                labelText += selected.text;
+            
+                                return labelText;
+                            },
+                            noneSelectedLabelText: "Ingen arrangementstype valgt ennå",
+                            selectFirstTimeButtonText: 'Velg arrangementstype',
+                            changeSelectedValueButtonText: 'Endre arrangementstype',
+                            popoverSaveChoicesButtonText: 'Lagre valg',
+                        });
+                        dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
+                            element: dialog.querySelector('#status_type_jstree_select'),
+                            treeJsonSrcUrl: "/arrangement/statustype/tree",
+                            initialSelected: dialog.getElementById('_statusTypeId').value ? { id: dialog.getElementById('_statusTypeId').value } : undefined,
+                            onValueSet: ( data ) => {
+                                dialog.getElementById('_statusTypeId').value = data.selected[0];
+                            },
+                            valueSelectedLabelText: ( selected ) => {
+                                let labelText = '';
+            
+                                if (selected.parent && selected.parent.text)
+                                    labelText += (selected.parent.text + " | ");
+            
+                                labelText += selected.text;
+                                
+                                return labelText;
+                            },
+                            noneSelectedLabelText: "Ingen status valgt ennå",
+                            selectFirstTimeButtonText: 'Velg status',
+                            changeSelectedValueButtonText: 'Endre status',
+                            popoverSaveChoicesButtonText: 'Lagre valg',
+                        });
+            
+                        dialog.$("#fromTime").on("change", (event) => {
+                            dialog.$("#buffer_before_end").val(event.target.value);
+                        });
+                        dialog.$("#toTime").on("change", (event) => {
+                            dialog.$("#buffer_after_start").val(event.target.value);
+                        });
+            
+                        document.addEventListener("{{managerName}}.d1_roomsSelected", (e) => {
+                            dialog.data.roomsNameMap = e.detail.context.room_name_map;
+                            dialog.setRooms({ rooms: e.detail.context.rooms });
+            
+                            dialog.$("#roomsCounter").text(dialog.$("#selectedRoomsWrapper").children().length);
+                        });
+            
+                        dialog.data.stepper = new DialogStepper({
+                            allowRailBasedNavigation: true,
+                            railWrapperElement: dialog.getElementById('stepper'),
+                            steps: [
+                                {
+                                    element: dialog.getElementById('step-1'),
+                                    title: 'Detaljer',
+                                    stepIn: () => { console.log("1. Step In") },
+                                    stepOut: () => { 
+                                        /** PS!
+                                         * Be aware that this will cause issues the moment you have inputs or selects
+                                         * that are not in step-1. As of the writing of this comment all the fields we care
+                                         * about validating are in step-1, so we can blanket-validate it like this.
+                                         * This is not the case if you add input or selects to any other steps - and this will
+                                         * prevent progression to further steps, until the inputs in those future steps are considered
+                                         * valid, which is of course impossible, since one can not reach them due to this blanket-validation.
+                                         * */                            
+                                        if (dialog.validate() === false)
+                                            return false;
+            
+                                        const fromDateTime = DateExtensions.OverwriteDateTimeWithTimeInputValue(
+                                            dialog.interior.fromDate.value,
+                                            dialog.interior.fromTime.value,
+                                        )
+                                        const toDateTime = DateExtensions.OverwriteDateTimeWithTimeInputValue(
+                                            dialog.interior.toDate.value,
+                                            dialog.interior.toTime.value,
+                                        )
+            
+                                        if (fromDateTime >= toDateTime){
+                                            $('#eventTimesInvalidFeedback').show();
+            
+                                            return false;
+                                        }
+            
+                                        $('#eventTimesInvalidFeedback').hide();
+            
+                                        return true;
+                                    }
+                                },
+                                {
+                                    element: dialog.getElementById('step-2'),
+                                    title: 'Rom & Personer',
+                                    stepIn: () => { console.log("1. Step In") },
+                                    stepOut: () => { console.log("2. Step Out"); }
+                                },
+                                {
+                                    element: dialog.getElementById('step-services'),
+                                    title: 'Tjenestebestillinger',
+                                    stepIn: () => { },
+                                    stepout: () => { },
+                                },
+                                {
+                                    element: dialog.getElementById('step-3'),
+                                    title: 'Opp og ned-rigg',
+                                    visible: {% if HIDE_RIGGING %}false{% else %}true{% endif %},
+                                    stepIn: () => {},
+                                    stepOut: (isSteppingForwards) => {
+                                        let isValid = true;
+                                        if (dialog.interior.buffer_before_start.value &&
+                                            dialog.interior.buffer_before_end.value)
+                                            if (dialog.interior.buffer_before_start.value > dialog.interior.buffer_before_end.value) {
+                                                dialog.$('#beforeRiggingTimesInvalidFeedback').show();
+                                                isValid = false;
+                                            }
+                                            else {
+                                                dialog.$('#beforeRiggingTimesInvalidFeedback').hide();
+                                            }
+                                        if (dialog.interior.buffer_after_start.value &&
+                                            dialog.interior.buffer_after_end.value)
+                                            if (dialog.interior.buffer_after_start.value > dialog.interior.buffer_after_end.value) {
+                                                dialog.$('#afterRiggingTimesInvalidFeedback').show();
+                                                isValid = false;
+                                            }
+                                            else {
+                                                dialog.$('#afterRiggingTimesInvalidFeedback').hide();
+                                            }
+                                        
+                                        if (isValid === true) {
+                                            dialog.$('#beforeRiggingTimesInvalidFeedback').hide();
+                                            dialog.$('#afterRiggingTimesInvalidFeedback').hide();
+                                        }
+            
+                                        return isValid;
+                                    },
+                                },
+                                {
+                                    element: dialog.getElementById('step-4'),
+                                    title: 'Skjermer',
+                                    stepIn: () => { 
+                                        dialog.getElementById('next').style.display = "none";
+                                        dialog.getElementById('finish').style.display = "inline-block";
+                                    },
+                                    stepOut: () => {
+                                        dialog.getElementById('finish').style.display = "none";
+                                        dialog.getElementById('next').style.display = "inline-block";
+                                    },
+                                },
+                            ]
+                        });
+                        dialog.getElementById('next').onclick = () => dialog.data.stepper.next();
+                        dialog.getElementById('back').onclick = () => dialog.data.stepper.back();
+                    },
+                    methods: {
+                        close(dialog, {} = {}, triggeredByElement) {
+                            dialog.closeMe();
+                        },
+                        submit(dialog, {} = {}, triggeredByElement) {
+                            if (dialog.validate() === false) {
+                                console.warn("Validation failed.")
+                                return;
+                            }
+            
+            
+                            let qualifiedEvent = {
+                                _uuid:                      dialog.interior.event_uuid.value,
+                                title:                      dialog.interior.title.value,
+                                title_en:                   dialog.interior.title_en.value,
+                                ticket_code:                dialog.interior.ticket_code.value,
+                                expected_visitors:          dialog.interior.expected_visitors.value,
+                                audience:                   dialog.data.audienceJsTreeSelect.getSelectedValue(),
+                                audienceName:               dialog.data.audienceJsTreeSelect.getSelectedText(),
+                                arrangement_type:           dialog.data.arrangementTypeJsTreeSelect.getSelectedValue(),
+                                arrangementTypeName:        dialog.data.arrangementTypeJsTreeSelect.getSelectedText(),     
+                                start:                      new Date( dialog.interior.fromDate.value   + "T" + dialog.interior.fromTime.value ),
+                                end:                        new Date( dialog.interior.toDate.value     + "T" + dialog.interior.toTime.value ),
+                                arrangement:                0,
+                                rooms:                      Array.from(dialog.data.selectedRoomIds.keys()),
+                                room_name_map:              dialog.data.roomsNameMap,       // Kept due to edit - not pertinent for save
+                                before_buffer_title:        dialog.interior.buffer_before_title.value ?? "",
+                                before_buffer_date:         dialog.interior.buffer_before_date.value,
+                                before_buffer_start:        dialog.interior.buffer_before_start.value ?? "",
+                                before_buffer_end:          dialog.interior.buffer_before_end.value ?? "",
+                                after_buffer_title:         dialog.interior.buffer_after_title.value ?? "",
+                                after_buffer_date:          dialog.interior.buffer_after_date.value,
+                                after_buffer_start:         dialog.interior.buffer_after_start.value ?? "",
+                                after_buffer_end:           dialog.interior.buffer_after_end.value ?? "",
+                                meeting_place:              dialog.interior.id_meeting_place.value,
+                                meeting_place_en:           dialog.interior.id_meeting_place_en.value,
+                                responsible:                dialog.interior.id_responsible.value,
+                                display_text:               dialog.plugins.showIfSelected.isInShowState() ? dialog.interior.id_display_text.value : '',
+                                room_payload:               dialog.data.roomPayload,
+                                planner_payload:            dialog.data.mainPlannerPayload,
+                                ordered_services:           Array.from(dialog.data.servicePresets.values()),
+                                serie_uuid:                 dialog.interior._serie_reference.value,
+                                serie_position_hash:        dialog.interior._serie_position_hash.value,
+                                parent_serie_position_hash: dialog.interior._parent_serie_position_hash.value,
+                                start_before_collision_resolution: dialog.interior.start_before_collision_resolution.value,
+                                end_before_collision_resolution: dialog.interior.end_before_collision_resolution.value,
+                                title_before_collision_resolution: dialog.interior.title_before_collision_resolution.value,
+                            };
+            
+                            let statusValue = dialog.data.statusTypeJsTreeSelect.getSelectedValue();
+                            if (statusValue !== undefined)
+                                qualifiedEvent.status = statusValue;
+            
+                            console.log("qualifiedEvent", qualifiedEvent);
+            
+                            qualifiedEvent.display_layouts = 
+                                [...dialog.querySelectorAll("input[name='display_layouts_create_event'][type='checkbox']:checked")]
+                                    .map(element => element.value);
+            
+                            dialog.raiseSubmitEvent({
+                                event: qualifiedEvent,
+                                csrf_token: '{{csrf_token}}',
+                            });
+                        },
+                        validate(dialog, {} = {}, triggeredByElement) {
+                            let field_elements = dialog.$('#newSimpleActivityForm').find("input, select");
+                            let isInvalid = false;
+            
+                            for (let i = 0; i < field_elements.length; i++) {
+                                if (field_elements[i].checkValidity() === false) {
+                                    isInvalid = true;
+                                    break;
+                                }
+                            }
+            
+                            if (isInvalid) {
+                                dialog.$('#newSimpleActivityForm').find(':submit').click();
+                                return false;
+                            }
+            
+                            return true;
+                        },
+                        removeAssociation(dialog, {} = {}, triggeredByElement) {
+                            const itemId = triggeredByElement.id;
+                            const type = triggeredByElement.getAttribute("select-type");
+            
+                            let mapOfSelectedItemIds = null;
+                            let appropriatePresetMap = null;
+            
+                            if (type === "room") {
+                                mapOfSelectedItemIds = dialog.data.selectedRoomIds;
+                                appropriatePresetMap = dialog.data.roomPresets;
+                            }
+                            else if (type === "serviceOrder") {
+                                dialog.data.servicePresets.delete(itemId);
+                                triggeredByElement.parentElement.parentElement.remove();
+                                return;
+                            }
+                            else {
+                                throw Error("Type not recognized")
+                            }
+            
+                            if (itemId.startsWith("preset_")) {
+                                const preset = appropriatePresetMap.get(id.split("_")[1]);
+                                preset.ids.forEach((id) => mapOfSelectedItemIds.delete(id));
+                            }
+                            else {
+                                mapOfSelectedItemIds.delete(itemId);
+                            }
+            
+                            triggeredByElement.remove();
+                        },
+                    },
+                    data: {
+                        servicePresets: new Map(),
+                        selectedRoomIds: new Map(),
+                        roomsNameMap: new Map(),
+                        stepper: null,
+                    },
+                    when: [
+                        { eventKnownAs: "newServiceOrder", do: (dialog, payload) => {
+                            // this stuff needs to be rewritten along with the other similar methods
+                            // maybe use vue or a dialog plugin -- because this is not even a remotely good way of doing it
 
-                if (type === "room") {
-                    mapOfSelectedItemIds = dialog.data.selectedRoomIds;
-                    appropriatePresetMap = dialog.data.roomPresets;
-                }
-                else if (type === "serviceOrder") {
-                    dialog.data.servicePresets.delete(itemId);
-                    triggeredByElement.parentElement.parentElement.remove();
-                    return;
-                }
-                else {
-                    throw Error("Type not recognized")
-                }
-
-                if (itemId.startsWith("preset_")) {
-                    const preset = appropriatePresetMap.get(id.split("_")[1]);
-                    preset.ids.forEach((id) => mapOfSelectedItemIds.delete(id));
-                }
-                else {
-                    mapOfSelectedItemIds.delete(itemId);
-                }
-
-                triggeredByElement.remove();
-            },
-            triggerAddRooms(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("{{managerName}}", "{{orderRoomDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', renderInChain: true,  });
-            },
-            triggerSetPlanner(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("{{managerName}}", "{{orderPersonDialog}}", { $parent: dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, renderInChain: true, data: { whenEventName: "setPlanner" } })
-            },
-            triggerNewServiceOrder(dialog, {} = {}, triggeredByElement) {
-                dialog.raiseTriggerEvent("{{managerName}}", "orderServiceDialog", { $parent:dialog.dialogElement, sendTo: '{{dialogId}}', multiple: false, data: { whenEventName: "newServiceOrder"}, entity_type:"event", entity_id:"0" })
-            },
-        },
-        data: {
-            servicePresets: new Map(),
-            selectedRoomIds: new Map(),
-            roomsNameMap: new Map(),
-            stepper: null,
-        },
-        when: [
-            { eventKnownAs: "newServiceOrder", do: (dialog, payload) => {
-                // this stuff needs to be rewritten along with the other similar methods
-                // maybe use vue or a dialog plugin -- because this is not even a remotely good way of doing it
-
-                console.log("payload!", payload);
-
-                dialog.data.servicePresets = new Map((payload.concat(
-                    Array.from(dialog.data.servicePresets.values())
-                )).map(x => [crypto.randomUUID(), x]));
-
-                let wrapper = dialog.$('#serviceOrders');
-                wrapper.empty();
-                
-                for (const [key, value] of dialog.data.servicePresets) {
-                    wrapper.append(
-                        $(`<div class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' id="${key}">
-                            <h5>
-                                ${value.service_name}
-                                <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end'  id="${key}" select-type='serviceOrder' d-trigger="removeAssociation"><i class='fas fa-times'></i></button>
-                            </h5>
-                            <code>
-                                ${value.freetext_comment}
-                            </code>
-                        </div>`)
-                    );
-                }
-            } },
-            { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
-                let wrapper = dialog.$('#selectedRoomsWrapper');
-                wrapper.empty();
-
-                payload.viewables.forEach((room) => {
-                    wrapper.append(
-                        $(`<selected-pill name='${room.text}'
-                                          id='${room.id}'
-                                          class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
-                                          d-trigger='removeAssociation'>
-                           </selected-pill>`)    
-                    );
+                            dialog.data.servicePresets = new Map((payload.concat(
+                                Array.from(dialog.data.servicePresets.values())
+                            )).map(x => [crypto.randomUUID(), x]));
+            
+                            let wrapper = dialog.$('#serviceOrders');
+                            wrapper.empty();
+                            
+                            for (const [key, value] of dialog.data.servicePresets) {
+                                wrapper.append(
+                                    $(`<div class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' id="${key}">
+                                        <h5>
+                                            ${value.service_name}
+                                            <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end'  id="${key}" select-type='serviceOrder' d-trigger="removeAssociation"><i class='fas fa-times'></i></button>
+                                        </h5>
+                                        <code>
+                                            ${value.freetext_comment}
+                                        </code>
+                                    </div>`)
+                                );
+                            }
+                        } },
+                        { eventKnownAs: "roomsSelected", do: (dialog, payload) => {
+                            let wrapper = dialog.$('#selectedRoomsWrapper');
+                            wrapper.empty();
+            
+                            payload.viewables.forEach((room) => {
+                                wrapper.append(
+                                    $(`<selected-pill name='${room.text}'
+                                                      id='${room.id}'
+                                                      class='bg-white p-2 shadow-4 me-2 mt-1 border border-dark'
+                                                      d-trigger='removeAssociation'>
+                                       </selected-pill>`)    
+                                );
+                            });
+            
+                            dialog.data.selectedRoomIds = new Map();
+                            dialog.data.roomPresets = new Map();
+                            payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );
+                            payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
+            
+                            dialog.data.roomPayload = payload;
+                        } },
+                        { eventKnownAs: "setPlanner", do: (dialog, payload) => {
+                            if (payload.allSelectedEntityIds.length == 0)
+                                return;
+            
+                            const person = payload.viewables[0];
+            
+                            dialog.data.mainPlannerPayload = payload;
+                            
+                            dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
+                            dialog.getElementById('mainPlannerName').innerText = person.text;
+                            dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
+                        } },
+                        { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
+                            if (dialog.data.audienceJsTreeSelect)
+                                dialog.data.audienceJsTreeSelect.setSelected(payload);
+                            else
+                                dialog.$('#_backingAudienceId').val(payload);
+                        } },
+                        { eventKnownAs: "setArrangementTypeFromParent", do: (dialog, payload) => {
+                            if (dialog.data.arrangementTypeJsTreeSelect)
+                                dialog.data.arrangementTypeJsTreeSelect.setSelected(payload);
+                            else
+                                dialog.$('#_backingArrangementTypeId').val(payload);
+                        } },
+                        { eventKnownAs: "setStatusFromParent", do: (dialog, payload) => {
+                            if (dialog.data.statusTypeJsTreeSelect)
+                                dialog.data.statusTypeJsTreeSelect.setSelected(payload);
+                            else
+                                dialog.$('#_statusTypeId').val(payload);
+                        } },
+                    ],
+                    plugins: [
+                        {
+                            name: 'showIfSelected',
+                            pluginClass: DialogShowIfSelectedPlugin,
+                            args: {
+                                checkboxesSelector: "[name='display_layouts_create_event']",
+                                elementToShowOrHide: ( dialog ) => { return dialog.getElementById('display-layout-text-group'); },
+                                showIfAnyOfTheseValuesMap: new Map([
+                                    {% for display_layout in DISPLAY_LAYOUTS_WITH_REQUISITE_TEXT %}
+                                        [ "{{ display_layout.id }}", true],
+                                    {% endfor %}
+                                ]),
+                            },
+                        }
+                    ],
                 });
-
-                dialog.data.selectedRoomIds = new Map();
-                dialog.data.roomPresets = new Map();
-                payload.allSelectedEntityIds.forEach( (x) => dialog.data.selectedRoomIds.set(x.id, true) );
-                payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
-
-                dialog.data.roomPayload = payload;
-            } },
-            { eventKnownAs: "setPlanner", do: (dialog, payload) => {
-                if (payload.allSelectedEntityIds.length == 0)
-                    return;
-
-                const person = payload.viewables[0];
-
-                dialog.data.mainPlannerPayload = payload;
-                
-                dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
-                dialog.getElementById('mainPlannerName').innerText = person.text;
-                dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
-            } },
-            { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {
-                if (dialog.data.audienceJsTreeSelect)
-                    dialog.data.audienceJsTreeSelect.setSelected(payload);
-                else
-                    dialog.$('#_backingAudienceId').val(payload);
-            } },
-            { eventKnownAs: "setArrangementTypeFromParent", do: (dialog, payload) => {
-                if (dialog.data.arrangementTypeJsTreeSelect)
-                    dialog.data.arrangementTypeJsTreeSelect.setSelected(payload);
-                else
-                    dialog.$('#_backingArrangementTypeId').val(payload);
-            } },
-            { eventKnownAs: "setStatusFromParent", do: (dialog, payload) => {
-                if (dialog.data.statusTypeJsTreeSelect)
-                    dialog.data.statusTypeJsTreeSelect.setSelected(payload);
-                else
-                    dialog.$('#_statusTypeId').val(payload);
-            } },
-        ],
-        plugins: [
-            {
-                name: 'showIfSelected',
-                pluginClass: DialogShowIfSelectedPlugin,
-                args: {
-                    checkboxesSelector: "[name='display_layouts_create_event']",
-                    elementToShowOrHide: ( dialog ) => { return dialog.getElementById('display-layout-text-group'); },
-                    showIfAnyOfTheseValuesMap: new Map([
-                        {% for display_layout in DISPLAY_LAYOUTS_WITH_REQUISITE_TEXT %}
-                            [ "{{ display_layout.id }}", true],
-                        {% endfor %}
-                    ]),
-                },
             }
-        ],
-    });
+        });
+
+        createActivityDialog.mount(
+            document.getElementsByClassName('{{discriminator}}')[0]
+        );
+    })
 </script>

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -146,23 +146,67 @@
                     <i class="fas fa-star"></i>
                     Hovedplanlegger
                 </label>
+
                 <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
                 <button class="wb-btn-main"
                     id="setMainPlannerButton"
-                    type="button"
-                    @click="openSetMainPlannerDialog()">
+                    type="button">
                     Velg hovedplanlegger
                 </button>
+
+                <div id="select-main-planner-popover" class="popover_wrapper dialog-popover-left-fix" style="display: none;">
+                    <div class="popover_content" style="width: 50em!important;">
+                        <h5>Velg hovedplanlegger</h5>
+                        
+                        
+                        <input type="search" name="" id="" class="form-control form-control-lg"
+                            v-model="mainPlannerSearchTerm"
+                            placeholder="Søk etter planlegger... (minst 3 tegn)">       
+
+                        <div class="mt-3">
+                            <div v-if="mainPlannerSearchResults.length">
+                                <div v-if="mainPlannerSearchTerm.length == 0"
+                                    class="alert alert-info">
+                                    <div class="d-flex align-items-center">
+                                        <h2 class="mb-0"><i class="fas fa-info"></i></h2>
+                                        
+                                        <div class="ms-3">
+                                            Uten søkeord vises alle personer med gruppe planlegger
+                                            <br>
+                                            Du kan fortsatt søke etter og velge personer uten gruppe planlegger ved å skrive inn minst 3 tegn i søkefeltet.
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <table class="table table-highlight table-bordered table-sm" v-if="mainPlannerSearchResults.length">
+                                    <tbody>
+                                        <tr v-for="result in mainPlannerSearchResults" class="secondary-hover" @click="setMainPlanner(result)">
+                                            <td>
+                                                <a>
+                                                    [[ result.full_name ]]
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                
+                                <div class="clearfix">
+                                    <small class="text-muted float-end fw-bold">
+                                        <i class="fas fa-info"></i>&nbsp;
+                                        Trykk på navnet til personen du ønsker å velge som hovedplanlegger for arrangementet
+                                    </small>
+                                </div>
+                            </div>
+                            <div 
+                                class="alert alert-info"
+                                v-else>
+                                Ingen resultater
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-            {% comment %} <div class="form-group mb-2">
-                <label for="{{form.responsible.id_for_label}}"
-                        class="form-label">
-                        <i class="fas fa-star"></i>&nbsp;
-                        Hovedplanlegger
-                </label>
-                {{ form.responsible }}
-            </div> {% endcomment %}
-            
+
             <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mt-4">
                 <label for="" class="form-label">
                     <i class="fas fa-building"></i>&nbsp;
@@ -400,6 +444,7 @@
 <script type="module">
     import { JSTreeSelect } from "{% static 'js/jsTreeSelect.js' %}";
     import { DateExtensions } from "{% static 'modules/planner/seriesutil.js' %}";
+    import { Popover } from "{% static 'js/popover.js' %}";
 
     $(document).ready(function() {
         let createActivityDialog = Vue.createApp({
@@ -508,7 +553,13 @@
                         document.querySelectorAll('.form-outline').forEach((formOutline) => {
                             new mdb.Input(formOutline).init();
                         });
-            
+                        
+                        const mainPlannerPopover = new Popover({
+                            triggerElement: dialog.dialogElement.querySelector('#setMainPlannerButton'),
+                            wrapperElement: dialog.dialogElement.querySelector('#select-main-planner-popover'),
+                        });
+                        dialog.vueApp.mainPlannerPopover = mainPlannerPopover;
+
                         dialog.$('#fromDate').on('change', (e) => {
                             dialog.interior.buffer_before_date.value = e.target.value;
                         });

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -271,7 +271,25 @@
             </div>
 
             <div id="serviceOrders" class="mb-2">
-
+                <div
+                    class='card card-body shadow-0 wb-bg-secondary border border-dark mt-2' :id="order.key"
+                    v-for="order in serviceOrders">
+                    
+                    <h5>
+                        [[order.service_name]]
+                        <button class='btn wb-btn-main-outline border border-dark shadow-0 float-end' 
+                            :id="order.key" 
+                            @click="serviceOrders.splice(serviceOrders.indexOf(order), 1)"
+                            select-type='serviceOrder' 
+                            d-trigger="removeAssociation">
+                            
+                            <i class='fas fa-times'></i>
+                        </button>
+                    </h5>
+                    <code>
+                        [[order.freetext_comment]]
+                    </code>
+                </div>
             </div>
         </div>
         <div id="step-3">
@@ -866,6 +884,9 @@
                         stepper: null,
                     },
                     when: [
+                        { eventKnownAs: "populateDialogWithEvent", do: (dialog, payload) => {
+                            console.log("populateDialogWithEvent", payload);
+                        } },
                         { eventKnownAs: "newServiceOrder", do: (dialog, payload) => {
                             // this stuff needs to be rewritten along with the other similar methods
                             // maybe use vue or a dialog plugin -- because this is not even a remotely good way of doing it

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -841,6 +841,8 @@
                             payload.selectedPresets.forEach( (presetId) => dialog.data.roomPresets.set(presetId, payload.allPresets.get(presetId)) );
             
                             dialog.data.roomPayload = payload;
+
+                            dialog.vueApp.rooms = payload.viewables;
                         } },
                         { eventKnownAs: "setPlanner", do: (dialog, payload) => {
                             if (payload.allSelectedEntityIds.length == 0)
@@ -849,7 +851,8 @@
                             const person = payload.viewables[0];
             
                             dialog.data.mainPlannerPayload = payload;
-                            
+                            dialog.vueApp.mainPlanner = { id: person.id, text: person.text }
+
                             dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
                             dialog.getElementById('mainPlannerName').innerText = person.text;
                             dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -137,17 +137,20 @@
         </div>
         <div id="step-2">
             <div class="border rounded box-shadow-2 wb-bg-secondary p-4 mb-4">
-                <input type="hidden" name="{{ form.responsible.name }}" id="{{ form.responsible.id_for_label }}">
+                <input type="hidden" 
+                    name="{{ form.responsible.name }}" 
+                    id="{{ form.responsible.id_for_label }}"
+                    v-model="mainPlanner.id">
 
                 <label for="" class="d-block form-label">
                     <i class="fas fa-star"></i>
                     Hovedplanlegger
                 </label>
-                <h5 class="mb-2" id="mainPlannerName"></h5>
+                <h5 class="mb-2">[[ mainPlanner.text ]]</h5>
                 <button class="wb-btn-main"
                     id="setMainPlannerButton"
                     type="button"
-                    d-trigger="triggerSetPlanner">
+                    @click="openSetMainPlannerDialog()">
                     Velg hovedplanlegger
                 </button>
             </div>
@@ -857,7 +860,6 @@
                             dialog.vueApp.mainPlanner = { id: person.id, text: person.text }
 
                             dialog.getElementById('{{ form.responsible.id_for_label }}').value = person.id;
-                            dialog.getElementById('mainPlannerName').innerText = person.text;
                             dialog.getElementById('setMainPlannerButton').innerText = "Endre hovedplanlegger";
                         } },
                         { eventKnownAs: "setAudienceFromParent", do: (dialog, payload) => {

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -886,8 +886,6 @@
                     },
                     when: [
                         { eventKnownAs: "populateDialogWithEvent", do: (dialog, payload) => {
-                            console.log("populateDialogWithEvent", payload);
-
                             dialog.vueApp.activity.title = payload.title;
                             dialog.vueApp.activity.title_en = payload.title_english;
                             dialog.vueApp.activity.ticket_code = payload.ticket_code;

--- a/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
+++ b/webook/templates/arrangement/planner/dialogs/arrangement_dialogs/dialog_create_event_arrangement.html
@@ -1,6 +1,9 @@
 {% load static i18n %}
 {% load crispy_forms_tags %}
 
+
+{% include "arrangement/vue/js_tree_select_component.html" %}
+
 <div id="{{dialogId}}" class="{{discriminator}}" >
 
     <input type="hidden" id="_backingAudienceId" />
@@ -48,47 +51,35 @@
                     <input type="text" id="title_en" name="title_en" class="form-control form-control-lg" />
                 </div>
 
-                <div class="form-group mb-2">
-                    <label>
-                        <i class="fas fa-users"></i>&nbsp;
-                        Målgruppe
-                        <span class="fw-bold">&nbsp;*</span>
-                    </label>
-                    <div id="audience_jstree_select" class="dialog-popover-left-fix"></div>
-                    
-                    {% if form.audience.errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        {{ form.audience.errors }}
-                    </div>
-                    {% endif %}
-                </div>
+                <tree-select-component
+                    class="mb-2"
+                    label="Målgruppe *"
+                    json-url="/arrangement/audience/tree"
+                    icon="fas fa-users"
+                    button-label="Velg målgruppe"
+                    :selected="activity.audience"
+                    @input="(id) => activity.audience = id">
+                </tree-select-component>
 
-                <div class="form-group mb-2">
-                    <label>
-                        <i class="fas fa-cog"></i>&nbsp;
-                        Arrangementstype
-                        <span class="fw-bold">&nbsp;*</span>
-                    </label>
-                    <div id="arrangement_type_jstree_select" class="dialog-popover-left-fix"></div>
-                    {% if form.arrangement_type.errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        {{ form.arrangement_type.errors }}
-                    </div>
-                    {% endif %}
-                </div>
+                <tree-select-component
+                    class="mb-2"
+                    label="Arrangementstype *"
+                    json-url="/arrangement/arrangementtype/treelist"
+                    icon="fas fa-cog"
+                    button-label="Velg arrangementstype"
+                    :selected="activity.arrangement_type"
+                    @input="(id) => activity.arrangement_type = id">
+                </tree-select-component>
 
-                <div class="form-group mb-2">
-                    <label>
-                        <i class="fas fa-cog"></i>&nbsp;
-                        Status
-                    </label>
-                    <div id="status_type_jstree_select" class="dialog-popover-left-fix"></div>
-                    {% if form.status_type.errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        {{ form.status_type.errors }}
-                    </div>
-                    {% endif %}
-                </div>
+                <tree-select-component
+                    class="mb-2"
+                    label="Status"
+                    json-url="/arrangement/statustype/tree"
+                    icon="fas fa-cog"
+                    button-label="Velg status"
+                    :selected="activity.status"
+                    @input="(id) => activity.status = id">
+                </tree-select-component>
     
                 <div class="form-group mt-2">
                     <label for="" class="form-label">
@@ -466,19 +457,45 @@
 
     $(document).ready(function() {
         let createActivityDialog = Vue.createApp({
-            components: {},
+            components: { TreeSelectComponent },
             data() {
                 return {
                     dialog: null,
-                    events: [],
-                    series: [],
-                    serviceOrders: [],
-                    rooms: [],
-                    planners: [],
                     mainPlanner: { id: null, text: null },
                     mainPlannerSearchTerm: null,
                     mainPlannerSearchResults: [],
-                    mainPlannerPopover: null
+                    mainPlannerPopover: null,
+
+                    activity: {
+                        id: null,
+                        title: null,
+                        title_en: null,
+                        start: null,
+                        end: null,
+                        ticket_code: null,
+                        participants: null,
+                        buffer_before: null,
+                        buffer_after: null,
+                        buffer_before_title: null,
+                        buffer_after_title: null,
+                        buffer_before_date: null,
+                        buffer_after_date: null,
+                        buffer_before_start: null,
+                        buffer_before_end: null,
+                        buffer_after_start: null,
+                        buffer_after_end: null,
+                        audience: null,
+                        arrangement_type: null,
+                        status: null,
+                        display_layouts: [],
+                        display_text: null,
+                        meeting_place: null,
+                        meeting_place_en: null,
+                        serviceOrders: [],
+                        rooms: [],
+                        planners: [],
+                        main_planner: null,
+                    },
                 }
             },
             methods: {
@@ -583,68 +600,6 @@
                         });
                         dialog.$('#toDate').on('change', (e) => {
                             dialog.interior.buffer_after_date.value = e.target.value;
-                        });
-            
-                        dialog.data.audienceJsTreeSelect = new JSTreeSelect({
-                            element: dialog.querySelector('#audience_jstree_select'),
-                            treeJsonSrcUrl: "/arrangement/audience/tree",
-                            initialSelected: dialog.getElementById('_backingAudienceId').value ? { id: dialog.getElementById('_backingAudienceId').value } : undefined,
-                            valueSelectedLabelText: ( selected ) => {
-                                let labelText = '';
-            
-                                if (selected.parent && selected.parent.text)
-                                    labelText += (selected.parent.text + " | ");
-                                
-                                labelText += selected.text;
-            
-                                return labelText;
-                            },
-                            noneSelectedLabelText: "Ingen målgruppe valgt ennå",
-                            selectFirstTimeButtonText: 'Velg målgruppe',
-                            changeSelectedValueButtonText: 'Endre målgruppe',
-                            popoverSaveChoicesButtonText: 'Lagre valg',
-                        });
-            
-                        dialog.data.arrangementTypeJsTreeSelect = new JSTreeSelect({
-                            element: dialog.querySelector('#arrangement_type_jstree_select'),
-                            treeJsonSrcUrl: '/arrangement/arrangementtype/treelist',
-                            initialSelected: dialog.getElementById('_backingArrangementTypeId').value ? { id: dialog.getElementById('_backingArrangementTypeId').value } : undefined,
-                            valueSelectedLabelText: ( selected ) => {
-                                let labelText = '';
-            
-                                if (selected.parent && selected.parent.text)
-                                    labelText += (selected.parent.text + " | ");
-                                
-                                labelText += selected.text;
-            
-                                return labelText;
-                            },
-                            noneSelectedLabelText: "Ingen arrangementstype valgt ennå",
-                            selectFirstTimeButtonText: 'Velg arrangementstype',
-                            changeSelectedValueButtonText: 'Endre arrangementstype',
-                            popoverSaveChoicesButtonText: 'Lagre valg',
-                        });
-                        dialog.data.statusTypeJsTreeSelect = new JSTreeSelect({
-                            element: dialog.querySelector('#status_type_jstree_select'),
-                            treeJsonSrcUrl: "/arrangement/statustype/tree",
-                            initialSelected: dialog.getElementById('_statusTypeId').value ? { id: dialog.getElementById('_statusTypeId').value } : undefined,
-                            onValueSet: ( data ) => {
-                                dialog.getElementById('_statusTypeId').value = data.selected[0];
-                            },
-                            valueSelectedLabelText: ( selected ) => {
-                                let labelText = '';
-            
-                                if (selected.parent && selected.parent.text)
-                                    labelText += (selected.parent.text + " | ");
-            
-                                labelText += selected.text;
-                                
-                                return labelText;
-                            },
-                            noneSelectedLabelText: "Ingen status valgt ennå",
-                            selectFirstTimeButtonText: 'Velg status',
-                            changeSelectedValueButtonText: 'Endre status',
-                            popoverSaveChoicesButtonText: 'Lagre valg',
                         });
             
                         dialog.$("#fromTime").on("change", (event) => {

--- a/webook/templates/arrangement/vue/js_tree_select_component.html
+++ b/webook/templates/arrangement/vue/js_tree_select_component.html
@@ -55,6 +55,16 @@
                 let json = await response.json();
                 return json;
             },
+            setSelected() {
+                if (this.selected && this.hasInit) {
+                    $(this.$refs.jsTreeEl).jstree('select_node', this.selected);
+
+                    let node = $(this.$refs.jsTreeEl).jstree(true).get_node(this.selected);
+                    this.selectedValues.id = node.id;
+                    this.selectedValues.parent = node.parent;
+                    this.selectedValues.text = node.text;
+                }
+            },
             async initJsTree() {
                 await this.loadJson()
                     .then(treeValidObj => {
@@ -71,14 +81,8 @@
                         });
 
                         $(this.$refs.jsTreeEl).on('loaded.jstree', () => {
-                            if (this.selected !== null) {
-                                $(this.$refs.jsTreeEl).jstree('select_node', this.selected);
-        
-                                let node = $(this.$refs.jsTreeEl).jstree(true).get_node(this.selected);
-                                this.selectedValues.id = node.id;
-                                this.selectedValues.parent = node.parent;
-                                this.selectedValues.text = node.text;    
-                            }
+                            this.hasInit = true;
+                            this.setSelected();
                         });
 
                         $(this.$refs.jsTreeEl).on('changed.jstree', (e, data) => {
@@ -99,12 +103,17 @@
 
                             this.isExpanded = false;
 
-                            this.$emit('input', this.selectedValues.id);
+                            this.$emit('input', this.selectedValues.id, this.selectedValues.text);
                         });
                     });
             },
             toggleVisibility() {
                 this.isExpanded = !this.isExpanded;
+            }
+        },
+        watch: {
+            selected: function (newVal, oldVal) {
+                this.setSelected();
             }
         },
         computed: {
@@ -126,7 +135,8 @@
                     id: null,
                     text: null,
                     parent: null,
-                }
+                },
+                hasInit: false,
             }
         },
         mounted() {

--- a/webook/templates/arrangement/vue/js_tree_select_component.html
+++ b/webook/templates/arrangement/vue/js_tree_select_component.html
@@ -1,0 +1,143 @@
+{% include "arrangement/vue/popover_component.html" %}
+
+
+<template id="vuec-js-tree-select-template">
+    <label>
+        <i :class="icon"></i>&nbsp;
+        [[ label ]]
+    </label>
+    <div class="mb-2 border rounded-4 p-2 ps-4 pe-4">
+        
+        <div class="d-flex justify-content-between align-items-center w-100">
+
+            <label>
+                [[selectedText]]
+            </label>
+
+            <div>
+                <button class="btn wb-btn-secondary" @click="toggleVisibility()" type="button" ref="trigger">
+                    [[buttonLabel]]
+                </button>
+                <popover-component
+                    :is-visible="isExpanded"
+                    :excludes="[ this.$refs.trigger ]">
+
+                    <h5>[[label]]</h5>
+
+                    <input type="search" class="form-control mb-1" placeholder="Søk....">
+
+                    <div ref="jsTreeEl">
+                    </div>
+
+                </popover-component>
+            </div>
+        </div>
+    </div>
+
+</template>
+
+<script>
+    let TreeSelectComponent = {
+        components: {
+            PopoverComponent
+        },
+        props: {
+            isOpen: Boolean,
+            label: String,
+            buttonLabel: String,
+            icon: String,
+            jsonUrl: String,
+            selected: Number,
+        },
+        methods: {
+            async loadJson() {
+                let response = await fetch(this.jsonUrl);
+                let json = await response.json();
+                return json;
+            },
+            async initJsTree() {
+                await this.loadJson()
+                    .then(treeValidObj => {
+                        $(this.$refs.jsTreeEl).jstree({
+                            'checkbox': {
+                                "three_state": false,
+                                "cascade": "up+undetermined",
+                            },
+                            'plugins': [ 'checkbox',  'search',], 
+                            'core': {
+                                'data': treeValidObj,
+                                'multiple': false,
+                            }
+                        });
+
+                        $(this.$refs.jsTreeEl).on('loaded.jstree', () => {
+                            if (this.selected !== null) {
+                                $(this.$refs.jsTreeEl).jstree('select_node', this.selected);
+        
+                                let node = $(this.$refs.jsTreeEl).jstree(true).get_node(this.selected);
+                                this.selectedValues.id = node.id;
+                                this.selectedValues.parent = node.parent;
+                                this.selectedValues.text = node.text;    
+                            }
+                        });
+
+                        $(this.$refs.jsTreeEl).on('changed.jstree', (e, data) => {
+                            const selected = $(this.$refs.jsTreeEl).jstree("get_selected", true)[0];
+                            
+                            if (selected.parent !== "#")
+                            {
+                                let parentNode = $(this.$refs.jsTreeEl).jstree(true).get_node(selected.parent);
+                                this.selectedValues.parent = parentNode.text;
+                             }
+                            else 
+                            {
+                                this.selectedValues.parent = null;
+                            }
+
+                            this.selectedValues.id = selected.id;
+                            this.selectedValues.text = selected.text;
+
+                            this.isExpanded = false;
+
+                            this.$emit('input', this.selectedValues.id);
+                        });
+                    });
+            },
+            toggleVisibility() {
+                this.isExpanded = !this.isExpanded;
+            }
+        },
+        computed: {
+            selectedText() {
+                let text = this.selectedValues.text;
+
+                if (text === null)
+                    text = "Velg " + this.label.toLowerCase();
+                else if (this.selectedValues.parent)
+                    text = this.selectedValues.parent + " - " + text;
+
+                return text;
+            }
+        },
+        data() {
+            return {
+                isExpanded: false,
+                selectedValues: {
+                    id: null,
+                    text: null,
+                    parent: null,
+                }
+            }
+        },
+        mounted() {
+            this.isExpanded = this.isOpen || false;
+            this.selectedValues = this.selected || { id: null, text: null, parent: null };
+
+            this.$nextTick(() => {
+                this.initJsTree();
+            });
+        },
+        delimiters: ["[[", "]]"],
+        template: "#vuec-js-tree-select-template"
+    }
+</script>

--- a/webook/templates/arrangement/vue/popover_component.html
+++ b/webook/templates/arrangement/vue/popover_component.html
@@ -1,0 +1,64 @@
+<template id="vuec-popover-component">
+    <div :class="[ { active : internalIsVisible }, 'popover_wrapper', 'dialog-popover-left-fix' ]" ref="popover">
+        <div class="popover_content">
+            <slot></slot>
+        </div>
+    </div>
+</template>
+
+<script>
+    let PopoverComponent = {
+        props: {
+            isVisible: Boolean,
+            excludes: Array,
+        },
+        data() {
+            return {
+                internalIsVisible: false,
+            }
+        },
+        methods: {
+            initJsTree() {
+                      
+            },
+            toggleVisibility() {
+                this.internalIsVisible = !this.internalIsVisible;
+            }
+        },
+        watch: {
+            isVisible(newState, oldState) {
+                if (newState == false) {
+                    $(this.$refs.popover).hide("fade", {}, 400, () => {
+                        this.internalIsVisible = false;
+                    });
+                }
+                else {
+                    this.internalIsVisible = newState;
+                    $(this.$refs.popover).show("fade", {}, 400);
+                }
+            }
+        },
+        mounted() {
+            this.internalIsVisible = this.isVisible;
+
+            this.clickOutsideEvent = (e) => {
+                if (this.$el !== event.target && !this.$el.contains(event.target) && !event.target in this.excludes) {
+                    this.internalIsVisible = false;
+                }
+            };
+
+            document.addEventListener('click', this.clickOutsideEvent);
+            document.addEventListener('touchstart', this.clickOutsideEvent);
+
+            this.$nextTick(() => {
+                this.initJsTree();
+            });
+        },
+        unmounted() {
+            document.removeEventListener('click', this.clickOutsideEvent);
+            document.removeEventListener('touchstart', this.clickOutsideEvent);
+        },
+        delimiters: ["[[", "]]"],
+        template: "#vuec-popover-component"
+    }
+</script>


### PR DESCRIPTION
### Rewrite  create activity dialog to vue

This PR introduces a rewrite of the create activity dialog to vue. 

To make things work properly I have written two new components that I have taken in use for both Create Arrangement dialog and Create Activity dialog; Popover and JSTreeSelect. The latter was implemented in vanilla js, and used that way earlier, but now there is a Vue version. 

Using Vue I have also been able to simplify the way Create Arrangement -> Create Activity population works.