### PR TITLE
Fix set attributes on rigging events

### DIFF
--- a/webook/arrangement/management/commands/refresh_buffers.py
+++ b/webook/arrangement/management/commands/refresh_buffers.py
@@ -1,0 +1,21 @@
+"""refresh_buffers.py
+
+This module contains the refresh_buffers command. This command is used to force a refresh of all buffers in the application.
+Useful when changes have been made to how buffers are created, and want to also update retroactively.
+"""
+
+from django.core.management.base import BaseCommand
+
+from webook.arrangement.models import Event
+
+
+class Command(BaseCommand):
+    help = "Refreshes all buffers in the application"
+
+    def handle(self, *args, **options):
+        all_events = Event.objects.all()
+        for event in all_events:
+            self.stdout.write(f"Refreshing buffer for event {event}")
+            event.refresh_buffers()
+
+        self.stdout.write(self.style.SUCCESS("Successfully refreshed all buffers"))


### PR DESCRIPTION
Fix relevant attributes not being sent on the rigging event from the parent event. Lacking arrangement_type, status, responsible, etc.. would cause these rigging events to not  be shown on filtering, when it is wanted for them to appear along with the parent event.
I refactored the appropriate refresh_buffers method on Event model, and additionally added a new command that can be used to refresh buffers for all events  in the application, so that we can retroactively patch the rigging events with the desired state.