### PR TITLE
Adjust calendar month view date display

### DIFF
--- a/webook/static/css/nasj_style.css
+++ b/webook/static/css/nasj_style.css
@@ -89,3 +89,31 @@ div.dt-buttons.btn-group {
     box-shadow: none;
     margin-bottom: 0.4em;
 }
+
+.fc-daygrid-day-top {
+    flex-wrap: wrap!important;
+    flex-direction: unset!important;
+}
+
+.fc-daygrid-day:not(.fc-day-other) .fc-daygrid-day-number:not(:empty):hover {
+    background-color: var(--MAIN-COLOR);
+    color:white;
+}
+
+.fc-col-header-cell-cushion  {
+    color: black!important;
+}
+
+.fc-daygrid-week-number {
+    width: 100%;
+    color: black!important;
+    position: unset!important;
+}
+
+.fc-daygrid-day:not(.fc-day-other) .fc-daygrid-day-number:not(:empty) {
+    color: black;
+    /* border: solid 1px black; */
+    /* background-color: var(--fc-neutral-bg-color,rgba(208,208,208,.3)); */
+    background-color: #d6d6d6;
+    color:black;
+}

--- a/webook/static/modules/planner/commonLib.js
+++ b/webook/static/modules/planner/commonLib.js
@@ -566,8 +566,10 @@ export class FullCalendarBased {
             if (buttonElement.classList.contains("active") === false) {
                 buttonElement.classList.add("active");
             }
-
-            _this.getFcCalendar().changeView(event.detail.view);
+            
+            if (_this.getFcCalendar().view.type !== event.detail.view) {
+                _this.getFcCalendar().changeView(event.detail.view);
+            }
         })
     }
 

--- a/webook/static/modules/planner/locationCalendar.js
+++ b/webook/static/modules/planner/locationCalendar.js
@@ -268,7 +268,7 @@ export class LocationCalendar extends FullCalendarBased {
                     if (this.useOnclickEvents)
                         this._bindInspectorTrigger(arg.el);
                 },
-                navLinks: true,
+                navLinks: false,
                 locale: 'nb',
                 eventSources: [
                     {

--- a/webook/static/modules/planner/personCalendar.js
+++ b/webook/static/modules/planner/personCalendar.js
@@ -322,7 +322,7 @@ export class PersonCalendar extends FullCalendarBased {
                 eventRender: function (event, element, view) {
                     $(element).find(".fc-list-item-title").append("<div>" + event.resourceId + "</div>");
                 },
-                navLinks: true,
+                navLinks: false,
                 locale: 'nb',
                 eventSources: [
                     {

--- a/webook/static/modules/planner/plannerCalendar.js
+++ b/webook/static/modules/planner/plannerCalendar.js
@@ -426,6 +426,23 @@ export class PlannerCalendar extends FullCalendarBased {
                     }
                 },
                 datesSet: (dateInfo) => {
+                    if (dateInfo.view.type == "dayGridDay") {
+                        document.dispatchEvent(
+                            new CustomEvent(this._instanceUUID + "_callForFullCalendarViewRender", { "detail": { "view": "timeGridDay" } })
+                        );
+                    }
+                    if (dateInfo.view.type == "dayGridWeek") {
+                        $('.fc-daygrid-day-number, .fc-daygrid-week-number').hide();
+                        document.dispatchEvent(
+                            new CustomEvent(this._instanceUUID + "_callForFullCalendarViewRender", { "detail": { "view": "dayGridWeek" } })
+                        );
+                    }
+                    if (dateInfo.view.type == "dayGridMonth") {
+                        document.dispatchEvent(
+                            new CustomEvent(this._instanceUUID + "_callForFullCalendarViewRender", { "detail": { "view": "dayGridMonth" } })
+                        )
+                    }
+
                     $('#plannerCalendarHeader').text("");
                     $(".popover").popover('hide');
                     $('#plannerCalendarHeader').text(this._headerGenerator.generate(


### PR DESCRIPTION
Adjust how dates are shown in the cells on the month (dayGridMonth) view. Days will now be on the left of the cell, as opposed to the default right. The day number is encased by a background color. Added in some other design adjustments on the calendar as well.
Additionally revised how navigating via the FC navLinks works. Earlier you could "escape" the external buttons, and enter views not supported. Now when views are changed via navLinks the state will be reflected on the buttons, giving a more fluent and less disjointed experience. Additionally when going to view a specific day via navLink the user will be redirected to timeGridDay (fullcalendar wants to do dayGridDay) which is the only view for day we want to use.
Additionally I have deactivated navLinks on the location calendar and the person calendar, as this was not really well supported and felt off, additionally there doesn't seem like there is much of a point having this active in those contexts. May be changed in the future.