### PR TITLE
Optimize school booking associated endpoints

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ django-crum==0.7.9
 python-json-logger==2.0.7
 django-ninja==1.3.0
 inflect==7.2.1
-pandas==2.0.3
+pandas==2.2.3
 reportlab==4.2.2
 pyjwt==2.8.0
 

--- a/webook/api/paginate.py
+++ b/webook/api/paginate.py
@@ -27,7 +27,7 @@ class PaginatedData:
     num_pages: int
 
 
-async def paginate_queryset(
+def paginate_queryset(
     queryset, page, page_size: int = STANDARD_PAGE_SIZE
 ) -> PaginatedData:
     """Paginate a queryset and return the paginated queryset."""
@@ -37,7 +37,7 @@ async def paginate_queryset(
     if isinstance(queryset, QuerySet) and not queryset.ordered:
         queryset = queryset.order_by("id")
 
-    count = await queryset.acount()
+    count = queryset.count()
     qs = queryset[(page - 1) * page_size : min(page * page_size, count)]
 
     pd = PaginatedData(

--- a/webook/arrangement/api/routers/audience_router.py
+++ b/webook/arrangement/api/routers/audience_router.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from django.db.models import Q, Sum
 
+from webook.api.crud_router import Views
 from webook.api.schemas.base_schema import BaseSchema, ModelBaseSchema
 from webook.arrangement.api.validators import validate_tree_node_update
 from webook.arrangement.models import Arrangement, Event
@@ -52,7 +53,14 @@ def validate_save(
 
 
 class AudienceRouter(CrudRouter):
-    pass
+    def __init__(self, *args, **kwargs):
+        self.non_deferred_fields = ["parent"]
+        super().__init__(*args, **kwargs)
+
+    def get_queryset(self, view: Views = Views.GET) -> QuerySet:
+        qs = super().get_queryset(view)
+        qs = qs.select_related("parent")
+        return qs
 
 
 audience_router = AudienceRouter(

--- a/webook/arrangement/api/routers/event_serie_router.py
+++ b/webook/arrangement/api/routers/event_serie_router.py
@@ -308,19 +308,6 @@ def create_event_serie(request, data: PlanManifestCreateSchema):
 
     return form.save(form=form, user=request.user)
 
-
-@router.get("/testList", response=List[GetEventSerieSchema])
-@paginate(PageNumberPagination)
-async def test_list(
-    request, arrangement_id: Optional[int] = None
-) -> List[GetEventSerieSchema]:
-    qs = EventSerie.objects.select_related("serie_plan_manifest").select_related(
-        "arrangement"
-    )
-
-    return [x async for x in qs.iterator()]
-
-
 @router.put("/{id}", response=GetEventSerieSchema)
 def update_event_serie(request, id: int, data: PlanManifestSchema):
     event_serie = EventSerie.objects.get(id=id)

--- a/webook/onlinebooking/api/city_segment_router.py
+++ b/webook/onlinebooking/api/city_segment_router.py
@@ -1,4 +1,7 @@
 from typing import Optional
+
+from django.db.models.query import QuerySet as QuerySet
+from webook.api.crud_router import Views
 from webook import logger
 from webook.api.crud_router import CrudRouter, QueryFilter
 from webook.api.schemas.base_schema import BaseSchema, ModelBaseSchema
@@ -33,9 +36,16 @@ class CitySegmentRouter(CrudRouter):
             ),
         ]
 
+        self.non_deferred_fields = ["county"]
+
         super().__init__(*args, **kwargs)
 
         self.pre_update_hook = CitySegmentRouter.handle_school_move_on_county_edit
+
+    def get_queryset(self, view: Views = Views.GET) -> QuerySet:
+        qs = super().get_queryset(view)
+        qs = qs.select_related("county").prefetch_related("county__city_segments")
+        return qs
 
     def handle_school_move_on_county_edit(
         instance: CitySegment, payload: CitySegmentCreateSchema

--- a/webook/onlinebooking/api/county_router.py
+++ b/webook/onlinebooking/api/county_router.py
@@ -1,11 +1,21 @@
+from django.db.models.query import QuerySet as QuerySet
 from django.shortcuts import get_object_or_404
+from webook.api.crud_router import Views
 from webook.api.crud_router import CrudRouter
 from webook.api.schemas.base_schema import BaseSchema, ModelBaseSchema
 from webook.onlinebooking.api.schemas import CountyCreateSchema, CountyGetSchema
 from webook.onlinebooking.models import County
 
+
 class CountyRouter(CrudRouter):
-    pass
+    def __init__(self, *args, **kwargs):
+        self.non_deferred_fields = ["city_segments"]
+        super().__init__(*args, **kwargs)
+
+    def get_queryset(self, view: Views = Views.GET) -> QuerySet:
+        qs = super().get_queryset(view)
+        qs = qs.prefetch_related("city_segments")
+        return qs
 
 
 county_router = CountyRouter(


### PR DESCRIPTION
- Optimize school booking endpoint list gets (prefetch, and select_related in appropriate places)
- Remove async stuff, not possible to run async endpoints with atomic requests enabled. Unable to turn off atomic requests per endpoint with `@decorate_view` and `transaction.non_atomic`. Requires more study. Disabling atomicity project-wide is likely not an acceptable solution.