### PR TITLE
Reactivate model auditable functionality

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -178,7 +178,7 @@ MIDDLEWARE = [
     "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "webook.middleware.timezone_middleware.TimezoneMiddleware",
-    # "crum.CurrentRequestUserMiddleware",
+    "crum.CurrentRequestUserMiddleware",
 ]
 
 # STATIC

--- a/webook/arrangement/models.py
+++ b/webook/arrangement/models.py
@@ -8,14 +8,13 @@ from email.policy import default
 from enum import Enum
 from tabnanny import verbose
 from typing import Dict, List, Optional, Tuple
+from crum import get_current_user
 from django.utils.functional import cached_property
 from django.core.cache import cache
 
 import pytz
 from autoslug import AutoSlugField
 from colorfield.fields import ColorField
-
-# from crum import get_current_user
 
 from django.conf import settings
 from django.db import models
@@ -196,16 +195,16 @@ class ModelAuditableMixin(models.Model):
     )
 
     def save(self, *args, **kwargs):
-        # user = get_current_user()
-        # person = user.person
+        user = get_current_user()
+        person = user.person
 
-        # if person is None:
-        #     raise Exception("User has no person")
+        if person is None:
+            raise Exception("User has no person")
 
-        # if self._state.adding:
-        #     self.created_by = person
-        # else:
-        #     self.updated_by = person
+        if self._state.adding:
+            self.created_by = person
+        else:
+            self.updated_by = person
 
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
Reactivate ModelAuditableMixin functionality, add crum middleware back in.
Will allow for tracking who created, and who last updated, on models with the ModelAuditableMixin.